### PR TITLE
feat(migrate): add ScyllaDB/CQL migration support via MigrationDialect trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4044,7 +4044,7 @@ dependencies = [
 
 [[package]]
 name = "prax-actix"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -4059,7 +4059,7 @@ dependencies = [
 
 [[package]]
 name = "prax-armature"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -4074,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "prax-axum"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "prax-codegen"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "convert_case 0.6.0",
  "prax-schema",
@@ -4108,7 +4108,7 @@ dependencies = [
 
 [[package]]
 name = "prax-duckdb"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4130,7 +4130,7 @@ dependencies = [
 
 [[package]]
 name = "prax-import"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "convert_case 0.6.0",
  "criterion 0.5.1",
@@ -4156,7 +4156,7 @@ dependencies = [
 
 [[package]]
 name = "prax-migrate"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4175,7 +4175,7 @@ dependencies = [
 
 [[package]]
 name = "prax-mongodb"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "bson",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "prax-mssql"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "bb8",
@@ -4222,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "prax-mysql"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4241,7 +4241,7 @@ dependencies = [
 
 [[package]]
 name = "prax-orm"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bson",
  "cargo-husky",
@@ -4277,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "prax-orm-cli"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -4304,7 +4304,7 @@ dependencies = [
 
 [[package]]
 name = "prax-pgvector"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "pgvector",
  "postgres-types",
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "prax-postgres"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "chrono",
  "deadpool-postgres",
@@ -4341,7 +4341,7 @@ dependencies = [
 
 [[package]]
 name = "prax-query"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "bson",
@@ -4369,7 +4369,7 @@ dependencies = [
 
 [[package]]
 name = "prax-schema"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "criterion 0.8.1",
  "indexmap",
@@ -4389,7 +4389,7 @@ dependencies = [
 
 [[package]]
 name = "prax-scylladb"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4412,7 +4412,7 @@ dependencies = [
 
 [[package]]
 name = "prax-sqlite"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4434,7 +4434,7 @@ dependencies = [
 
 [[package]]
 name = "prax-sqlx"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4454,7 +4454,7 @@ dependencies = [
 
 [[package]]
 name = "prax-typegen"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "clap",
  "convert_case 0.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Joseph Quinn <quinn.josephr@protonmail.com>"]
@@ -33,24 +33,24 @@ homepage = "https://github.com/quinnjr/prax"
 
 [workspace.dependencies]
 # Internal crates
-prax-schema = { path = "prax-schema", version = "0.7.1" }
-prax-codegen = { path = "prax-codegen", version = "0.7.1" }
-prax-query = { path = "prax-query", version = "0.7.1" }
-prax-postgres = { path = "prax-postgres", version = "0.7.1" }
-prax-mysql = { path = "prax-mysql", version = "0.7.1" }
-prax-sqlite = { path = "prax-sqlite", version = "0.7.1" }
-prax-mssql = { path = "prax-mssql", version = "0.7.1" }
-prax-mongodb = { path = "prax-mongodb", version = "0.7.1" }
-prax-duckdb = { path = "prax-duckdb", version = "0.7.1" }
-prax-scylladb = { path = "prax-scylladb", version = "0.7.1" }
-prax-migrate = { path = "prax-migrate", version = "0.7.1" }
-prax-orm-cli = { path = "prax-cli", version = "0.7.1" }
-prax-sqlx = { path = "prax-sqlx", version = "0.7.1" }
-prax-armature = { path = "prax-armature", version = "0.7.1" }
-prax-axum = { path = "prax-axum", version = "0.7.1" }
-prax-actix = { path = "prax-actix", version = "0.7.1" }
-prax-import = { path = "prax-import", version = "0.7.1" }
-prax-pgvector = { path = "prax-pgvector", version = "0.7.1" }
+prax-schema = { path = "prax-schema", version = "0.7.2" }
+prax-codegen = { path = "prax-codegen", version = "0.7.2" }
+prax-query = { path = "prax-query", version = "0.7.2" }
+prax-postgres = { path = "prax-postgres", version = "0.7.2" }
+prax-mysql = { path = "prax-mysql", version = "0.7.2" }
+prax-sqlite = { path = "prax-sqlite", version = "0.7.2" }
+prax-mssql = { path = "prax-mssql", version = "0.7.2" }
+prax-mongodb = { path = "prax-mongodb", version = "0.7.2" }
+prax-duckdb = { path = "prax-duckdb", version = "0.7.2" }
+prax-scylladb = { path = "prax-scylladb", version = "0.7.2" }
+prax-migrate = { path = "prax-migrate", version = "0.7.2" }
+prax-orm-cli = { path = "prax-cli", version = "0.7.2" }
+prax-sqlx = { path = "prax-sqlx", version = "0.7.2" }
+prax-armature = { path = "prax-armature", version = "0.7.2" }
+prax-axum = { path = "prax-axum", version = "0.7.2" }
+prax-actix = { path = "prax-actix", version = "0.7.2" }
+prax-import = { path = "prax-import", version = "0.7.2" }
+prax-pgvector = { path = "prax-pgvector", version = "0.7.2" }
 
 # Code generation (proc-macros)
 proc-macro2 = "1.0"

--- a/docs/superpowers/specs/2026-04-26-scylladb-migrations-design.md
+++ b/docs/superpowers/specs/2026-04-26-scylladb-migrations-design.md
@@ -1,0 +1,565 @@
+# ScyllaDB Migration Support Design
+
+**Date:** 2026-04-26  
+**Status:** Approved  
+**Type:** Architecture Refactor + Feature Addition
+
+## Overview
+
+Add ScyllaDB migration support to prax-migrate by introducing a `MigrationDialect` trait that abstracts the migration system over schema diff types, migration output types, and generators. The existing SQL migration path becomes one dialect (`SqlDialect`); ScyllaDB introduces a second (`CqlDialect`).
+
+This refactor enables future migration backends without further structural changes, while giving ScyllaDB its own schema diff model (`CqlSchemaDiff`) and migration output type (`MigrationCql`) — necessary because CQL differs fundamentally from SQL in its primary-key model, user-defined types, keyspaces, and ALTER semantics.
+
+## Goals
+
+1. **Introduce `MigrationDialect` trait** that abstracts migration operations over any database dialect
+2. **Preserve existing SQL behavior** — current consumers see minimal breaking changes (type alias for `SqlMigrationEngine`)
+3. **Native CQL schema diff** via `CqlSchemaDiff` — partition keys, clustering keys, UDTs, keyspaces, materialized views
+4. **Auto-create keyspaces** from schema config (replication strategy, factor)
+5. **UDT-based enum mapping** — Prax enums compile to CQL user-defined types
+6. **Safe ALTER generation** — generate valid CQL ALTER statements, warn loudly where drop-and-recreate is needed
+7. **Event sourcing integration** — reuse event model, new `_prax_cql_migrations` event log table stored in ScyllaDB keyspace
+
+## Non-Goals
+
+- SQL ↔ CQL cross-dialect migration (independent schemas)
+- Automatic migration of unsupported ALTER operations (e.g., partition key changes) — user must write manual migrations
+- Transactional guarantees — CQL migrations are not atomic across statements (inherent CQL limitation)
+- Real ScyllaDB instance in CI tests (unit/integration tests verify string generation only)
+
+## Background
+
+ScyllaDB is a Cassandra-compatible columnar database. It uses CQL (Cassandra Query Language), which is superficially similar to SQL but diverges in fundamental ways:
+
+- **No foreign keys** — denormalized schemas are required
+- **Primary key = partition key + clustering keys** — determines data layout and query patterns
+- **Keyspaces** replace databases/schemas and carry replication configuration
+- **User-Defined Types (UDTs)** replace enums and structs
+- **Materialized views** are a first-class schema object (auto-maintained denormalized views)
+- **Limited ALTER support** — no RENAME COLUMN in general, no type changes for incompatible types, no partition/clustering key changes
+- **Compaction strategies and TTL** are per-table schema concerns
+- **No transactions** — only lightweight transactions (LWT) on single partitions
+
+These differences make SQL-centric abstractions leaky if reused for CQL. The trait-based approach keeps each dialect's schema model and generation logic native to its database.
+
+## Architecture
+
+### MigrationDialect Trait
+
+```rust
+pub trait MigrationDialect {
+    /// The schema diff type for this dialect.
+    type Diff: Default + Send + Sync;
+    
+    /// The migration output type for this dialect.
+    type Migration: Send + Sync;
+    
+    /// Human-readable dialect name (e.g., "sql", "cql").
+    fn name() -> &'static str;
+    
+    /// Generate migration from schema diff.
+    fn generate(diff: &Self::Diff) -> Self::Migration;
+    
+    /// Event log table name for this dialect.
+    fn event_log_table() -> &'static str;
+}
+```
+
+Two implementations:
+
+**SqlDialect:**
+```rust
+pub struct SqlDialect;
+
+impl MigrationDialect for SqlDialect {
+    type Diff = SchemaDiff;
+    type Migration = MigrationSql;
+    
+    fn name() -> &'static str { "sql" }
+    fn generate(diff: &SchemaDiff) -> MigrationSql { /* uses existing generators */ }
+    fn event_log_table() -> &'static str { "_prax_migrations" }
+}
+```
+
+**CqlDialect:**
+```rust
+pub struct CqlDialect;
+
+impl MigrationDialect for CqlDialect {
+    type Diff = CqlSchemaDiff;
+    type Migration = MigrationCql;
+    
+    fn name() -> &'static str { "cql" }
+    fn generate(diff: &CqlSchemaDiff) -> MigrationCql {
+        CqlMigrationGenerator::new().generate(diff)
+    }
+    fn event_log_table() -> &'static str { "_prax_cql_migrations" }
+}
+```
+
+### Generic Migration Engine
+
+```rust
+pub struct MigrationEngine<D: MigrationDialect> {
+    config: MigrationConfig,
+    history: Arc<dyn MigrationHistoryRepository>,
+    event_store: Arc<dyn MigrationEventStore<D>>,
+    _dialect: PhantomData<D>,
+}
+
+pub type SqlMigrationEngine = MigrationEngine<SqlDialect>;
+pub type CqlMigrationEngine = MigrationEngine<CqlDialect>;
+```
+
+### New Files
+
+- `prax-migrate/src/dialect.rs` — `MigrationDialect` trait + `SqlDialect` impl
+- `prax-migrate/src/cql/mod.rs` — CQL module entry + `CqlDialect` impl
+- `prax-migrate/src/cql/diff.rs` — `CqlSchemaDiff` and related types
+- `prax-migrate/src/cql/generator.rs` — `CqlMigrationGenerator`
+- `prax-migrate/src/cql/migration.rs` — `MigrationCql`
+- `prax-migrate/tests/cql_migration.rs` — integration tests
+- `prax-migrate/examples/cql_migration.rs` — runnable example
+
+### Modified Files
+
+- `prax-migrate/src/lib.rs` — export dialect trait, CqlDialect, CqlSchemaDiff, etc.
+- `prax-migrate/src/engine.rs` — make `MigrationEngine` generic over dialect
+- `prax-migrate/src/event_store.rs` — make trait generic over dialect
+
+## Components
+
+### CqlSchemaDiff
+
+```rust
+#[derive(Debug, Default, Clone)]
+pub struct CqlSchemaDiff {
+    /// Keyspace to create (generated first, runs once).
+    pub create_keyspace: Option<KeyspaceConfig>,
+    /// Keyspace to drop (generated last in up, or avoided entirely).
+    pub drop_keyspace: Option<String>,
+    
+    /// User-Defined Types (created before tables that reference them).
+    pub create_udts: Vec<UdtDiff>,
+    pub drop_udts: Vec<String>,
+    pub alter_udts: Vec<UdtAlterDiff>,
+    
+    /// Tables.
+    pub create_tables: Vec<CqlTableDiff>,
+    pub drop_tables: Vec<String>,
+    pub alter_tables: Vec<CqlTableAlterDiff>,
+    
+    /// Materialized views (reference a base table).
+    pub create_materialized_views: Vec<MaterializedViewDiff>,
+    pub drop_materialized_views: Vec<String>,
+    
+    /// Secondary indexes.
+    pub create_indexes: Vec<CqlIndexDiff>,
+    pub drop_indexes: Vec<String>,
+}
+
+pub struct KeyspaceConfig {
+    pub name: String,
+    pub replication: ReplicationStrategy,
+    pub durable_writes: bool,
+}
+
+pub enum ReplicationStrategy {
+    Simple { factor: u32 },
+    NetworkTopology { dc_factors: Vec<(String, u32)> },
+}
+
+pub struct UdtDiff {
+    pub name: String,
+    pub fields: Vec<UdtField>,
+}
+
+pub struct UdtField {
+    pub name: String,
+    pub cql_type: String,
+}
+
+pub struct UdtAlterDiff {
+    pub name: String,
+    pub add_fields: Vec<UdtField>,
+    pub rename_fields: Vec<(String, String)>,
+}
+
+pub struct CqlTableDiff {
+    pub name: String,
+    pub fields: Vec<CqlFieldDiff>,
+    pub partition_keys: Vec<String>,       // at least one required
+    pub clustering_keys: Vec<ClusteringKey>,
+    pub compaction: Option<CompactionStrategy>,
+    pub default_ttl: Option<u32>,
+}
+
+pub struct CqlFieldDiff {
+    pub name: String,
+    pub cql_type: String,  // e.g., "text", "uuid", "frozen<order_status>"
+    pub is_static: bool,
+}
+
+pub struct ClusteringKey {
+    pub name: String,
+    pub order: ClusteringOrder,
+}
+
+pub enum ClusteringOrder {
+    Asc,
+    Desc,
+}
+
+pub enum CompactionStrategy {
+    SizeTiered,
+    Leveled,
+    TimeWindow { window_unit: String, window_size: u32 },
+}
+
+pub struct CqlTableAlterDiff {
+    pub name: String,
+    pub add_fields: Vec<CqlFieldDiff>,
+    pub drop_fields: Vec<String>,
+    pub alter_fields: Vec<CqlFieldAlterDiff>,
+}
+
+pub struct CqlFieldAlterDiff {
+    pub name: String,
+    pub old_type: Option<String>,
+    pub new_type: Option<String>,
+}
+
+pub struct MaterializedViewDiff {
+    pub name: String,
+    pub base_table: String,
+    pub select_columns: Vec<String>,
+    pub where_clause: String,
+    pub partition_keys: Vec<String>,
+    pub clustering_keys: Vec<ClusteringKey>,
+}
+
+pub struct CqlIndexDiff {
+    pub name: String,
+    pub table_name: String,
+    pub column: String,
+    pub index_type: CqlIndexType,
+}
+
+pub enum CqlIndexType {
+    Secondary,
+    SasiPrefixed,  // SASI index (Cassandra-specific)
+    Custom(String),
+}
+```
+
+### MigrationCql
+
+```rust
+pub struct MigrationCql {
+    pub up: String,
+    pub down: String,
+    pub warnings: Vec<String>,
+}
+
+impl MigrationCql {
+    pub fn is_empty(&self) -> bool {
+        self.up.trim().is_empty() && self.down.trim().is_empty()
+    }
+}
+```
+
+### CqlMigrationGenerator
+
+Generates CQL statements in dependency order:
+
+**Up script order:**
+1. `CREATE KEYSPACE` (if present)
+2. `CREATE TYPE` for UDTs
+3. `CREATE TABLE` (with partition/clustering keys, compaction, TTL)
+4. `ALTER TABLE` for existing table changes
+5. `CREATE INDEX` for secondary indexes
+6. `CREATE MATERIALIZED VIEW` (depends on tables)
+
+**Down script order (reverse):**
+1. `DROP MATERIALIZED VIEW`
+2. `DROP INDEX`
+3. `DROP TABLE`
+4. `DROP TYPE`
+5. `DROP KEYSPACE` (if it was created by up)
+
+### CQL Output Examples
+
+**Keyspace creation:**
+```cql
+CREATE KEYSPACE IF NOT EXISTS "myapp"
+WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}
+AND durable_writes = true;
+```
+
+**NetworkTopologyStrategy:**
+```cql
+CREATE KEYSPACE IF NOT EXISTS "myapp"
+WITH replication = {'class': 'NetworkTopologyStrategy', 'us-east': 3, 'us-west': 2}
+AND durable_writes = true;
+```
+
+**UDT for enum:**
+```cql
+CREATE TYPE "myapp"."order_status" (
+    value text
+);
+```
+
+Used in table: `status frozen<"order_status">`
+
+**Table with compound partition key + clustering:**
+```cql
+CREATE TABLE "myapp"."events" (
+    tenant_id uuid,
+    event_time timestamp,
+    event_id uuid,
+    payload text,
+    status frozen<"order_status">,
+    PRIMARY KEY ((tenant_id), event_time, event_id)
+) WITH CLUSTERING ORDER BY (event_time DESC, event_id ASC)
+  AND compaction = {'class': 'TimeWindowCompactionStrategy', 'compaction_window_unit': 'DAYS', 'compaction_window_size': 1}
+  AND default_time_to_live = 2592000;
+```
+
+**Materialized view:**
+```cql
+CREATE MATERIALIZED VIEW "myapp"."events_by_status" AS
+    SELECT * FROM "myapp"."events"
+    WHERE status IS NOT NULL AND tenant_id IS NOT NULL AND event_time IS NOT NULL AND event_id IS NOT NULL
+    PRIMARY KEY ((status), tenant_id, event_time, event_id)
+    WITH CLUSTERING ORDER BY (tenant_id ASC, event_time DESC, event_id ASC);
+```
+
+**Secondary index:**
+```cql
+CREATE INDEX IF NOT EXISTS "events_status_idx" ON "myapp"."events" (status);
+```
+
+## ALTER Semantics
+
+Per design decisions (Q4 → option A):
+
+| Operation | Support | Behavior |
+|-----------|---------|----------|
+| `ALTER TABLE ADD column` | ✅ | Safe, no warning |
+| `ALTER TABLE DROP column` | ✅ | Generates statement, warns: data lost |
+| `ALTER TABLE ALTER column TYPE` | ⚠️ | Only for compatible types (text↔varchar, int→bigint); warn otherwise |
+| `ALTER TABLE RENAME column` | ⚠️ | Only for partition/clustering keys in CQL; warn for regular columns |
+| Partition key change | ❌ | Not generated; requires manual drop/recreate migration |
+| Clustering key change | ❌ | Not generated; requires manual drop/recreate migration |
+| UDT add field | ✅ | Safe, no warning |
+| UDT rename field | ✅ | CQL supports this for UDTs |
+| UDT drop field | ❌ | Cassandra doesn't support dropping UDT fields; warn |
+| Materialized view alter | ❌ | CQL requires DROP + CREATE; generator produces both with warning |
+
+## Data-Loss Warnings
+
+```
+Dropping keyspace '<name>' — ALL data in ALL tables in the keyspace will be permanently lost
+Dropping table '<keyspace>.<name>' — all rows will be lost
+Dropping column '<name>' from '<keyspace>.<table>' — data in this column will be lost
+Dropping UDT '<name>' — requires no referencing tables; ensure safety manually
+Dropping materialized view '<name>' — the view data will be lost, but the base table is unaffected
+Partition key change detected for '<table>' — not supported in-place; requires manual DROP/CREATE migration
+Clustering key change detected for '<table>' — not supported in-place; requires manual DROP/CREATE migration
+Type change from '<old>' to '<new>' for column '<name>' — CQL may reject this if data is incompatible
+CQL migrations are not atomic across statements; partial failures require manual remediation
+```
+
+## Event Sourcing Integration
+
+### Event Log Table
+
+Created automatically on engine initialization in the user's keyspace:
+
+```cql
+CREATE TABLE IF NOT EXISTS "<user_keyspace>"."_prax_cql_migrations" (
+    migration_id text,
+    event_time timeuuid,
+    event_type text,
+    event_data text,
+    created_at timestamp,
+    PRIMARY KEY (migration_id, event_time)
+) WITH CLUSTERING ORDER BY (event_time DESC);
+```
+
+- **Partition by `migration_id`** — all events for a migration are colocated for efficient replay
+- **Clustering by `event_time`** (TIMEUUID) — events ordered chronologically per migration
+- **`event_data` stored as JSON text** — CQL doesn't have JSONB; text is fine for event payloads
+
+### Event Model
+
+Reuses the existing `MigrationEvent` structure (event types: `Applied`, `RolledBack`, `Failed`, `Resolved`). Serialization to CQL uses JSON for `event_data`.
+
+### MigrationEventStore trait
+
+Becomes generic over dialect:
+
+```rust
+#[async_trait]
+pub trait MigrationEventStore<D: MigrationDialect>: Send + Sync {
+    async fn append_event(&self, event: MigrationEvent) -> Result<(), MigrationError>;
+    async fn get_events(&self, migration_id: &str) -> Result<Vec<MigrationEvent>, MigrationError>;
+    async fn get_all_events(&self) -> Result<Vec<MigrationEvent>, MigrationError>;
+    async fn initialize(&self) -> Result<(), MigrationError>;
+    async fn is_initialized(&self) -> Result<bool, MigrationError>;
+    async fn get_latest_event(&self, migration_id: &str) -> Result<Option<MigrationEvent>, MigrationError>;
+    async fn count_events(&self) -> Result<usize, MigrationError>;
+}
+```
+
+An `InMemoryEventStore<D>` is provided for testing any dialect. Production usage expects dialect-specific implementations backed by the target database.
+
+## Migration Path for Existing Users
+
+**Breaking changes:**
+- `MigrationEngine` becomes `MigrationEngine<SqlDialect>`. Type alias `SqlMigrationEngine` provided.
+- `MigrationEventStore` trait becomes `MigrationEventStore<SqlDialect>`. Type alias `SqlMigrationEventStore` provided.
+
+**Non-breaking:**
+- `SchemaDiff`, `MigrationSql`, all SQL generators (PostgresSqlGenerator etc.) unchanged.
+- Existing migration files and event log tables continue to work.
+
+**Upgrade steps:**
+1. Update any `MigrationEngine::new(...)` to use `SqlMigrationEngine::new(...)` — or rely on type inference.
+2. Update any explicit `Arc<dyn MigrationEventStore>` to `Arc<dyn SqlMigrationEventStore>`.
+
+## Testing Strategy
+
+### Unit Tests
+
+Location: `prax-migrate/src/cql/generator.rs` (inline)
+
+**Coverage:**
+- Keyspace creation (SimpleStrategy and NetworkTopologyStrategy)
+- UDT creation, alter (add field, rename field), drop warnings
+- Table creation with all partition/clustering/compaction/TTL combinations
+- ALTER TABLE add/drop column with warnings
+- Type change warnings
+- Materialized view creation and drop-recreate for alter
+- Secondary index creation
+- Down-script ordering (reverse of up)
+
+### Integration Tests
+
+Location: `prax-migrate/tests/cql_migration.rs`
+
+**Coverage:**
+- Full workflow: diff → generate → verify output
+- Keyspace + UDT + table + index + materialized view in correct order
+- Drop operations produce correct warnings
+- Partition key change produces no ALTER + loud warning
+
+### Property-Based Tests
+
+- Random `CqlSchemaDiff` → generator output respects dependency order
+- Any diff with drops → at least one warning
+- Down script drops in reverse order of up creates
+
+### Trait Refactor Verification
+
+- Snapshot tests: existing SQL generator output is unchanged after introducing `SqlDialect`
+- Compile-time check: `MigrationEngine<CqlDialect>` compiles and accepts `CqlSchemaDiff`
+- `event_log_table()` returns distinct strings per dialect
+
+## Example Output
+
+**Input CqlSchemaDiff:**
+```rust
+CqlSchemaDiff {
+    create_keyspace: Some(KeyspaceConfig {
+        name: "myapp".into(),
+        replication: ReplicationStrategy::Simple { factor: 3 },
+        durable_writes: true,
+    }),
+    create_udts: vec![UdtDiff {
+        name: "order_status".into(),
+        fields: vec![UdtField { name: "value".into(), cql_type: "text".into() }],
+    }],
+    create_tables: vec![CqlTableDiff {
+        name: "events".into(),
+        fields: vec![
+            CqlFieldDiff { name: "tenant_id".into(), cql_type: "uuid".into(), is_static: false },
+            CqlFieldDiff { name: "event_time".into(), cql_type: "timestamp".into(), is_static: false },
+            CqlFieldDiff { name: "payload".into(), cql_type: "text".into(), is_static: false },
+        ],
+        partition_keys: vec!["tenant_id".into()],
+        clustering_keys: vec![ClusteringKey {
+            name: "event_time".into(),
+            order: ClusteringOrder::Desc,
+        }],
+        compaction: None,
+        default_ttl: None,
+    }],
+    ..Default::default()
+}
+```
+
+**Generated up.cql:**
+```cql
+CREATE KEYSPACE IF NOT EXISTS "myapp"
+WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}
+AND durable_writes = true;
+
+CREATE TYPE "myapp"."order_status" (
+    value text
+);
+
+CREATE TABLE "myapp"."events" (
+    tenant_id uuid,
+    event_time timestamp,
+    payload text,
+    PRIMARY KEY ((tenant_id), event_time)
+) WITH CLUSTERING ORDER BY (event_time DESC);
+```
+
+**Generated down.cql:**
+```cql
+DROP TABLE IF EXISTS "myapp"."events";
+
+DROP TYPE IF EXISTS "myapp"."order_status";
+
+DROP KEYSPACE IF EXISTS "myapp";
+```
+
+**Warnings:**
+```
+(none for pure creation)
+```
+
+## Success Criteria
+
+**Functional:**
+- `MigrationDialect` trait abstracts migration over SQL and CQL dialects
+- `CqlMigrationGenerator` produces valid CQL for all supported operations
+- Keyspaces, UDTs, tables, materialized views, indexes all generate correctly
+- Data-loss warnings emit for all destructive operations
+- ALTER warnings for unsupported operations (partition/clustering key changes)
+
+**Backward compatibility:**
+- All existing `prax-migrate` tests still pass (SQL generation unchanged)
+- Existing consumers compile with at most a type alias substitution
+
+**Testing:**
+- Unit tests for CQL generator
+- Integration tests for full CQL migration workflow
+- Snapshot tests verify SQL output identical to pre-refactor
+- Property tests verify invariants
+
+**Documentation:**
+- CqlMigrationGenerator has doc comments
+- Example in `examples/cql_migration.rs`
+- Module doc updated in `lib.rs`
+
+## Future Work
+
+- Live ScyllaDB integration tests (behind feature flag)
+- SASI index creation (currently returns plain secondary index)
+- User-defined functions (UDFs) and aggregates (UDAs)
+- Automatic partition key change via shadow table + data copy (complex, manual today)
+- CQL-backed `CqlEventStore` implementation using scylla driver

--- a/prax-cli/tests/cli_tests.rs
+++ b/prax-cli/tests/cli_tests.rs
@@ -32,7 +32,7 @@ fn test_version_command() {
         .assert()
         .success()
         .stdout(predicate::str::contains("Version"))
-        .stdout(predicate::str::contains("0.7.1"));
+        .stdout(predicate::str::contains("0.7.2"));
 }
 
 #[test]
@@ -252,5 +252,5 @@ fn test_global_options() {
         .arg("--version")
         .assert()
         .success()
-        .stdout(predicate::str::contains("0.7.1"));
+        .stdout(predicate::str::contains("0.7.2"));
 }

--- a/prax-migrate/examples/cql_migration.rs
+++ b/prax-migrate/examples/cql_migration.rs
@@ -25,10 +25,7 @@ fn main() {
     diff.create_keyspace = Some(KeyspaceConfig {
         name: "myapp".into(),
         replication: ReplicationStrategy::NetworkTopology {
-            dc_factors: vec![
-                ("us-east".into(), 3),
-                ("us-west".into(), 2),
-            ],
+            dc_factors: vec![("us-east".into(), 3), ("us-west".into(), 2)],
         },
         durable_writes: true,
     });

--- a/prax-migrate/examples/cql_migration.rs
+++ b/prax-migrate/examples/cql_migration.rs
@@ -1,0 +1,115 @@
+//! Example: generate CQL migration scripts for a ScyllaDB schema.
+//!
+//! Run with: cargo run --example cql_migration -p prax-migrate
+
+use prax_migrate::{
+    ClusteringKey, ClusteringOrder, CompactionStrategy, CqlFieldDiff, CqlIndexDiff, CqlIndexType,
+    CqlMigrationGenerator, CqlSchemaDiff, CqlTableDiff, KeyspaceConfig, MaterializedViewDiff,
+    ReplicationStrategy, UdtDiff, UdtField,
+};
+
+fn field(name: &str, cql_type: &str) -> CqlFieldDiff {
+    CqlFieldDiff {
+        name: name.into(),
+        cql_type: cql_type.into(),
+        is_static: false,
+    }
+}
+
+fn main() {
+    let mut diff = CqlSchemaDiff {
+        keyspace_context: Some("myapp".into()),
+        ..Default::default()
+    };
+
+    diff.create_keyspace = Some(KeyspaceConfig {
+        name: "myapp".into(),
+        replication: ReplicationStrategy::NetworkTopology {
+            dc_factors: vec![
+                ("us-east".into(), 3),
+                ("us-west".into(), 2),
+            ],
+        },
+        durable_writes: true,
+    });
+
+    diff.create_udts.push(UdtDiff {
+        name: "order_status".into(),
+        fields: vec![UdtField {
+            name: "value".into(),
+            cql_type: "text".into(),
+        }],
+    });
+
+    diff.create_tables.push(CqlTableDiff {
+        name: "events".into(),
+        fields: vec![
+            field("tenant_id", "uuid"),
+            field("event_time", "timestamp"),
+            field("event_id", "uuid"),
+            field("payload", "text"),
+            field("status", "frozen<\"order_status\">"),
+        ],
+        partition_keys: vec!["tenant_id".into()],
+        clustering_keys: vec![
+            ClusteringKey {
+                name: "event_time".into(),
+                order: ClusteringOrder::Desc,
+            },
+            ClusteringKey {
+                name: "event_id".into(),
+                order: ClusteringOrder::Asc,
+            },
+        ],
+        compaction: Some(CompactionStrategy::TimeWindow {
+            window_unit: "DAYS".into(),
+            window_size: 1,
+        }),
+        default_ttl: Some(2_592_000),
+    });
+
+    diff.create_indexes.push(CqlIndexDiff {
+        name: "events_status_idx".into(),
+        table_name: "events".into(),
+        column: "status".into(),
+        index_type: CqlIndexType::Secondary,
+    });
+
+    diff.create_materialized_views.push(MaterializedViewDiff {
+        name: "events_by_status".into(),
+        base_table: "events".into(),
+        select_columns: vec!["*".into()],
+        where_clause: "status IS NOT NULL AND tenant_id IS NOT NULL AND event_time IS NOT NULL AND event_id IS NOT NULL".into(),
+        partition_keys: vec!["status".into()],
+        clustering_keys: vec![
+            ClusteringKey {
+                name: "tenant_id".into(),
+                order: ClusteringOrder::Asc,
+            },
+            ClusteringKey {
+                name: "event_time".into(),
+                order: ClusteringOrder::Desc,
+            },
+            ClusteringKey {
+                name: "event_id".into(),
+                order: ClusteringOrder::Asc,
+            },
+        ],
+    });
+
+    let migration = CqlMigrationGenerator::new().generate(&diff);
+
+    println!("=== up.cql ===");
+    println!("{}", migration.up);
+    println!();
+    println!("=== down.cql ===");
+    println!("{}", migration.down);
+
+    if !migration.warnings.is_empty() {
+        println!();
+        println!("=== warnings ===");
+        for w in &migration.warnings {
+            println!("- {}", w);
+        }
+    }
+}

--- a/prax-migrate/src/cql/diff.rs
+++ b/prax-migrate/src/cql/diff.rs
@@ -1,0 +1,203 @@
+//! CQL schema diff types.
+
+/// A diff describing CQL schema changes to apply.
+#[derive(Debug, Default, Clone)]
+pub struct CqlSchemaDiff {
+    /// Keyspace to create (runs first in up).
+    pub create_keyspace: Option<KeyspaceConfig>,
+    /// Keyspace to drop (runs last in up).
+    pub drop_keyspace: Option<String>,
+
+    /// User-Defined Types to create (before tables that reference them).
+    pub create_udts: Vec<UdtDiff>,
+    /// UDT names to drop.
+    pub drop_udts: Vec<String>,
+    /// UDT alterations.
+    pub alter_udts: Vec<UdtAlterDiff>,
+
+    /// Tables to create.
+    pub create_tables: Vec<CqlTableDiff>,
+    /// Table names to drop.
+    pub drop_tables: Vec<String>,
+    /// Table alterations.
+    pub alter_tables: Vec<CqlTableAlterDiff>,
+
+    /// Materialized views to create.
+    pub create_materialized_views: Vec<MaterializedViewDiff>,
+    /// Materialized view names to drop.
+    pub drop_materialized_views: Vec<String>,
+
+    /// Secondary indexes to create.
+    pub create_indexes: Vec<CqlIndexDiff>,
+    /// Index names to drop.
+    pub drop_indexes: Vec<String>,
+
+    /// Keyspace to use when qualifying object names. If None, generator emits
+    /// unqualified names (useful for testing).
+    pub keyspace_context: Option<String>,
+}
+
+/// Keyspace configuration for CREATE KEYSPACE.
+#[derive(Debug, Clone)]
+pub struct KeyspaceConfig {
+    pub name: String,
+    pub replication: ReplicationStrategy,
+    pub durable_writes: bool,
+}
+
+/// Replication strategy for a keyspace.
+#[derive(Debug, Clone)]
+pub enum ReplicationStrategy {
+    Simple { factor: u32 },
+    NetworkTopology { dc_factors: Vec<(String, u32)> },
+}
+
+/// User-Defined Type diff (creation).
+#[derive(Debug, Clone)]
+pub struct UdtDiff {
+    pub name: String,
+    pub fields: Vec<UdtField>,
+}
+
+/// A field inside a UDT.
+#[derive(Debug, Clone)]
+pub struct UdtField {
+    pub name: String,
+    pub cql_type: String,
+}
+
+/// UDT alteration (add fields, rename fields).
+#[derive(Debug, Clone)]
+pub struct UdtAlterDiff {
+    pub name: String,
+    pub add_fields: Vec<UdtField>,
+    pub rename_fields: Vec<(String, String)>,
+}
+
+/// Table creation diff.
+#[derive(Debug, Clone)]
+pub struct CqlTableDiff {
+    pub name: String,
+    pub fields: Vec<CqlFieldDiff>,
+    pub partition_keys: Vec<String>,
+    pub clustering_keys: Vec<ClusteringKey>,
+    pub compaction: Option<CompactionStrategy>,
+    pub default_ttl: Option<u32>,
+}
+
+/// A column in a CQL table.
+#[derive(Debug, Clone)]
+pub struct CqlFieldDiff {
+    pub name: String,
+    pub cql_type: String,
+    pub is_static: bool,
+}
+
+/// A clustering key with explicit ordering.
+#[derive(Debug, Clone)]
+pub struct ClusteringKey {
+    pub name: String,
+    pub order: ClusteringOrder,
+}
+
+/// Clustering order direction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClusteringOrder {
+    Asc,
+    Desc,
+}
+
+/// Compaction strategy for a table.
+#[derive(Debug, Clone)]
+pub enum CompactionStrategy {
+    SizeTiered,
+    Leveled,
+    TimeWindow { window_unit: String, window_size: u32 },
+}
+
+/// Table alteration (add/drop/alter columns).
+#[derive(Debug, Clone, Default)]
+pub struct CqlTableAlterDiff {
+    pub name: String,
+    pub add_fields: Vec<CqlFieldDiff>,
+    pub drop_fields: Vec<String>,
+    pub alter_fields: Vec<CqlFieldAlterDiff>,
+    /// Partition key change detected (generates warning, no SQL).
+    pub partition_key_changed: bool,
+    /// Clustering key change detected (generates warning, no SQL).
+    pub clustering_key_changed: bool,
+}
+
+/// Column alteration within a table.
+#[derive(Debug, Clone)]
+pub struct CqlFieldAlterDiff {
+    pub name: String,
+    pub old_type: Option<String>,
+    pub new_type: Option<String>,
+}
+
+/// Materialized view diff.
+#[derive(Debug, Clone)]
+pub struct MaterializedViewDiff {
+    pub name: String,
+    pub base_table: String,
+    pub select_columns: Vec<String>,
+    pub where_clause: String,
+    pub partition_keys: Vec<String>,
+    pub clustering_keys: Vec<ClusteringKey>,
+}
+
+/// Secondary index diff.
+#[derive(Debug, Clone)]
+pub struct CqlIndexDiff {
+    pub name: String,
+    pub table_name: String,
+    pub column: String,
+    pub index_type: CqlIndexType,
+}
+
+/// Secondary index type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CqlIndexType {
+    Secondary,
+    SasiPrefixed,
+    Custom(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cql_schema_diff_default_is_empty() {
+        let diff = CqlSchemaDiff::default();
+        assert!(diff.create_keyspace.is_none());
+        assert!(diff.create_tables.is_empty());
+        assert!(diff.create_udts.is_empty());
+        assert!(diff.keyspace_context.is_none());
+    }
+
+    #[test]
+    fn test_replication_strategy_variants() {
+        let simple = ReplicationStrategy::Simple { factor: 3 };
+        let nt = ReplicationStrategy::NetworkTopology {
+            dc_factors: vec![("us-east".to_string(), 3), ("us-west".to_string(), 2)],
+        };
+        match simple {
+            ReplicationStrategy::Simple { factor } => assert_eq!(factor, 3),
+            _ => panic!("wrong variant"),
+        }
+        match nt {
+            ReplicationStrategy::NetworkTopology { dc_factors } => {
+                assert_eq!(dc_factors.len(), 2);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn test_clustering_order_equality() {
+        assert_eq!(ClusteringOrder::Asc, ClusteringOrder::Asc);
+        assert_ne!(ClusteringOrder::Asc, ClusteringOrder::Desc);
+    }
+}

--- a/prax-migrate/src/cql/diff.rs
+++ b/prax-migrate/src/cql/diff.rs
@@ -112,7 +112,10 @@ pub enum ClusteringOrder {
 pub enum CompactionStrategy {
     SizeTiered,
     Leveled,
-    TimeWindow { window_unit: String, window_size: u32 },
+    TimeWindow {
+        window_unit: String,
+        window_size: u32,
+    },
 }
 
 /// Table alteration (add/drop/alter columns).

--- a/prax-migrate/src/cql/generator.rs
+++ b/prax-migrate/src/cql/generator.rs
@@ -1,8 +1,9 @@
 //! CQL migration SQL generator for ScyllaDB.
 
 use crate::cql::diff::{
-    ClusteringKey, ClusteringOrder, CompactionStrategy, CqlFieldDiff, CqlSchemaDiff,
-    CqlTableAlterDiff, CqlTableDiff, KeyspaceConfig, ReplicationStrategy, UdtAlterDiff, UdtDiff,
+    ClusteringKey, ClusteringOrder, CompactionStrategy, CqlFieldDiff, CqlIndexDiff, CqlIndexType,
+    CqlSchemaDiff, CqlTableAlterDiff, CqlTableDiff, KeyspaceConfig, ReplicationStrategy,
+    UdtAlterDiff, UdtDiff,
 };
 use crate::cql::migration::MigrationCql;
 
@@ -76,6 +77,15 @@ impl CqlMigrationGenerator {
             }
 
             up.extend(self.alter_table_statements(alter, ks_context));
+        }
+
+        for index in &diff.create_indexes {
+            up.push(self.create_index_statement(index, ks_context));
+            down.push(self.drop_index_statement(&index.name, ks_context));
+        }
+
+        for name in &diff.drop_indexes {
+            up.push(self.drop_index_statement(name, ks_context));
         }
 
         for name in &diff.drop_tables {
@@ -318,6 +328,30 @@ impl CqlMigrationGenerator {
 
         stmts
     }
+
+    fn create_index_statement(&self, index: &CqlIndexDiff, keyspace_context: Option<&str>) -> String {
+        let qualified_index = self.qualify(&index.name, keyspace_context);
+        let qualified_table = self.qualify(&index.table_name, keyspace_context);
+
+        match &index.index_type {
+            CqlIndexType::Secondary => format!(
+                "CREATE INDEX IF NOT EXISTS {} ON {} ({});",
+                qualified_index, qualified_table, index.column
+            ),
+            CqlIndexType::SasiPrefixed => format!(
+                "CREATE CUSTOM INDEX IF NOT EXISTS {} ON {} ({}) USING 'org.apache.cassandra.index.sasi.SASIIndex';",
+                qualified_index, qualified_table, index.column
+            ),
+            CqlIndexType::Custom(class) => format!(
+                "CREATE CUSTOM INDEX IF NOT EXISTS {} ON {} ({}) USING '{}';",
+                qualified_index, qualified_table, index.column, class
+            ),
+        }
+    }
+
+    fn drop_index_statement(&self, name: &str, keyspace_context: Option<&str>) -> String {
+        format!("DROP INDEX IF EXISTS {};", self.qualify(name, keyspace_context))
+    }
 }
 
 impl Default for CqlMigrationGenerator {
@@ -331,8 +365,8 @@ mod tests {
     use super::*;
     use crate::cql::diff::{
         ClusteringKey, ClusteringOrder, CompactionStrategy, CqlFieldAlterDiff, CqlFieldDiff,
-        CqlTableAlterDiff, CqlTableDiff, KeyspaceConfig, ReplicationStrategy, UdtAlterDiff,
-        UdtDiff, UdtField,
+        CqlIndexDiff, CqlIndexType, CqlTableAlterDiff, CqlTableDiff, KeyspaceConfig,
+        ReplicationStrategy, UdtAlterDiff, UdtDiff, UdtField,
     };
 
     fn simple_field(name: &str, cql_type: &str) -> CqlFieldDiff {
@@ -707,5 +741,62 @@ mod tests {
             migration.warnings.iter().any(|w| w.contains("Clustering key") && w.contains("events")),
             "expected clustering-key-change warning"
         );
+    }
+
+    #[test]
+    fn test_create_secondary_index() {
+        let generator = CqlMigrationGenerator::new();
+        let mut diff = CqlSchemaDiff::default();
+        diff.create_indexes.push(CqlIndexDiff {
+            name: "users_email_idx".into(),
+            table_name: "users".into(),
+            column: "email".into(),
+            index_type: CqlIndexType::Secondary,
+        });
+
+        let migration = generator.generate(&diff);
+        assert!(migration.up.contains("CREATE INDEX IF NOT EXISTS \"users_email_idx\""));
+        assert!(migration.up.contains("ON \"users\" (email)"));
+        assert!(migration.down.contains("DROP INDEX IF EXISTS \"users_email_idx\""));
+    }
+
+    #[test]
+    fn test_create_sasi_index() {
+        let generator = CqlMigrationGenerator::new();
+        let mut diff = CqlSchemaDiff::default();
+        diff.create_indexes.push(CqlIndexDiff {
+            name: "users_name_sasi".into(),
+            table_name: "users".into(),
+            column: "name".into(),
+            index_type: CqlIndexType::SasiPrefixed,
+        });
+
+        let migration = generator.generate(&diff);
+        assert!(migration.up.contains("USING 'org.apache.cassandra.index.sasi.SASIIndex'"));
+    }
+
+    #[test]
+    fn test_create_custom_index() {
+        let generator = CqlMigrationGenerator::new();
+        let mut diff = CqlSchemaDiff::default();
+        diff.create_indexes.push(CqlIndexDiff {
+            name: "custom_idx".into(),
+            table_name: "users".into(),
+            column: "data".into(),
+            index_type: CqlIndexType::Custom("my.custom.IndexClass".into()),
+        });
+
+        let migration = generator.generate(&diff);
+        assert!(migration.up.contains("USING 'my.custom.IndexClass'"));
+    }
+
+    #[test]
+    fn test_drop_index() {
+        let generator = CqlMigrationGenerator::new();
+        let mut diff = CqlSchemaDiff::default();
+        diff.drop_indexes.push("old_idx".into());
+
+        let migration = generator.generate(&diff);
+        assert!(migration.up.contains("DROP INDEX IF EXISTS \"old_idx\""));
     }
 }

--- a/prax-migrate/src/cql/generator.rs
+++ b/prax-migrate/src/cql/generator.rs
@@ -1,6 +1,6 @@
 //! CQL migration SQL generator for ScyllaDB.
 
-use crate::cql::diff::CqlSchemaDiff;
+use crate::cql::diff::{CqlSchemaDiff, KeyspaceConfig, ReplicationStrategy};
 use crate::cql::migration::MigrationCql;
 
 /// Generates CQL migration scripts from a CqlSchemaDiff.
@@ -13,8 +13,61 @@ impl CqlMigrationGenerator {
     }
 
     /// Generate a CQL migration from a schema diff.
-    pub fn generate(&self, _diff: &CqlSchemaDiff) -> MigrationCql {
-        MigrationCql::default()
+    pub fn generate(&self, diff: &CqlSchemaDiff) -> MigrationCql {
+        let mut up: Vec<String> = Vec::new();
+        let mut down: Vec<String> = Vec::new();
+        let mut warnings: Vec<String> = Vec::new();
+
+        if let Some(keyspace) = &diff.create_keyspace {
+            up.push(self.create_keyspace_statement(keyspace));
+            down.push(self.drop_keyspace_statement(&keyspace.name));
+        }
+
+        if let Some(name) = &diff.drop_keyspace {
+            up.push(self.drop_keyspace_statement(name));
+            warnings.push(format!(
+                "Dropping keyspace '{}' - ALL data in ALL tables in the keyspace will be permanently lost",
+                name
+            ));
+        }
+
+        down.reverse();
+
+        MigrationCql {
+            up: up.join("\n\n"),
+            down: down.join("\n\n"),
+            warnings,
+        }
+    }
+
+    fn create_keyspace_statement(&self, cfg: &KeyspaceConfig) -> String {
+        let replication = self.format_replication(&cfg.replication);
+        format!(
+            "CREATE KEYSPACE IF NOT EXISTS \"{}\"\nWITH replication = {}\nAND durable_writes = {};",
+            cfg.name, replication, cfg.durable_writes
+        )
+    }
+
+    fn drop_keyspace_statement(&self, name: &str) -> String {
+        format!("DROP KEYSPACE IF EXISTS \"{}\";", name)
+    }
+
+    fn format_replication(&self, strategy: &ReplicationStrategy) -> String {
+        match strategy {
+            ReplicationStrategy::Simple { factor } => {
+                format!(
+                    "{{'class': 'SimpleStrategy', 'replication_factor': {}}}",
+                    factor
+                )
+            }
+            ReplicationStrategy::NetworkTopology { dc_factors } => {
+                let mut parts = vec!["'class': 'NetworkTopologyStrategy'".to_string()];
+                for (dc, factor) in dc_factors {
+                    parts.push(format!("'{}': {}", dc, factor));
+                }
+                format!("{{{}}}", parts.join(", "))
+            }
+        }
     }
 }
 
@@ -27,6 +80,7 @@ impl Default for CqlMigrationGenerator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cql::diff::{KeyspaceConfig, ReplicationStrategy};
 
     #[test]
     fn test_empty_diff_produces_empty_migration() {
@@ -35,5 +89,56 @@ mod tests {
         let migration = generator.generate(&diff);
         assert!(migration.is_empty());
         assert!(migration.warnings.is_empty());
+    }
+
+    #[test]
+    fn test_create_keyspace_simple_strategy() {
+        let generator = CqlMigrationGenerator::new();
+        let mut diff = CqlSchemaDiff::default();
+        diff.create_keyspace = Some(KeyspaceConfig {
+            name: "myapp".into(),
+            replication: ReplicationStrategy::Simple { factor: 3 },
+            durable_writes: true,
+        });
+
+        let migration = generator.generate(&diff);
+        assert!(migration.up.contains("CREATE KEYSPACE IF NOT EXISTS \"myapp\""));
+        assert!(migration.up.contains("'class': 'SimpleStrategy'"));
+        assert!(migration.up.contains("'replication_factor': 3"));
+        assert!(migration.up.contains("durable_writes = true"));
+        assert!(migration.down.contains("DROP KEYSPACE IF EXISTS \"myapp\""));
+    }
+
+    #[test]
+    fn test_create_keyspace_network_topology() {
+        let generator = CqlMigrationGenerator::new();
+        let mut diff = CqlSchemaDiff::default();
+        diff.create_keyspace = Some(KeyspaceConfig {
+            name: "myapp".into(),
+            replication: ReplicationStrategy::NetworkTopology {
+                dc_factors: vec![("us-east".into(), 3), ("us-west".into(), 2)],
+            },
+            durable_writes: false,
+        });
+
+        let migration = generator.generate(&diff);
+        assert!(migration.up.contains("'class': 'NetworkTopologyStrategy'"));
+        assert!(migration.up.contains("'us-east': 3"));
+        assert!(migration.up.contains("'us-west': 2"));
+        assert!(migration.up.contains("durable_writes = false"));
+    }
+
+    #[test]
+    fn test_drop_keyspace_generates_warning() {
+        let generator = CqlMigrationGenerator::new();
+        let mut diff = CqlSchemaDiff::default();
+        diff.drop_keyspace = Some("legacy".into());
+
+        let migration = generator.generate(&diff);
+        assert!(migration.up.contains("DROP KEYSPACE IF EXISTS \"legacy\""));
+        assert!(
+            migration.warnings.iter().any(|w| w.contains("legacy") && w.contains("ALL data")),
+            "expected drop-keyspace warning"
+        );
     }
 }

--- a/prax-migrate/src/cql/generator.rs
+++ b/prax-migrate/src/cql/generator.rs
@@ -2,8 +2,8 @@
 
 use crate::cql::diff::{
     ClusteringKey, ClusteringOrder, CompactionStrategy, CqlFieldDiff, CqlIndexDiff, CqlIndexType,
-    CqlSchemaDiff, CqlTableAlterDiff, CqlTableDiff, KeyspaceConfig, ReplicationStrategy,
-    UdtAlterDiff, UdtDiff,
+    CqlSchemaDiff, CqlTableAlterDiff, CqlTableDiff, KeyspaceConfig, MaterializedViewDiff,
+    ReplicationStrategy, UdtAlterDiff, UdtDiff,
 };
 use crate::cql::migration::MigrationCql;
 
@@ -86,6 +86,15 @@ impl CqlMigrationGenerator {
 
         for name in &diff.drop_indexes {
             up.push(self.drop_index_statement(name, ks_context));
+        }
+
+        for view in &diff.create_materialized_views {
+            up.push(self.create_materialized_view_statement(view, ks_context));
+            down.push(self.drop_materialized_view_statement(&view.name, ks_context));
+        }
+
+        for name in &diff.drop_materialized_views {
+            up.push(self.drop_materialized_view_statement(name, ks_context));
         }
 
         for name in &diff.drop_tables {
@@ -352,6 +361,43 @@ impl CqlMigrationGenerator {
     fn drop_index_statement(&self, name: &str, keyspace_context: Option<&str>) -> String {
         format!("DROP INDEX IF EXISTS {};", self.qualify(name, keyspace_context))
     }
+
+    fn create_materialized_view_statement(
+        &self,
+        view: &MaterializedViewDiff,
+        keyspace_context: Option<&str>,
+    ) -> String {
+        let qualified_view = self.qualify(&view.name, keyspace_context);
+        let qualified_base = self.qualify(&view.base_table, keyspace_context);
+        let columns = view.select_columns.join(", ");
+        let pk = self.format_primary_key(&view.partition_keys, &view.clustering_keys);
+
+        let mut stmt = format!(
+            "CREATE MATERIALIZED VIEW {} AS\nSELECT {} FROM {}\nWHERE {}\n{}",
+            qualified_view, columns, qualified_base, view.where_clause, pk
+        );
+
+        if !view.clustering_keys.is_empty() {
+            stmt.push_str(&format!(
+                " WITH {}",
+                self.format_clustering_order(&view.clustering_keys)
+            ));
+        }
+
+        stmt.push(';');
+        stmt
+    }
+
+    fn drop_materialized_view_statement(
+        &self,
+        name: &str,
+        keyspace_context: Option<&str>,
+    ) -> String {
+        format!(
+            "DROP MATERIALIZED VIEW IF EXISTS {};",
+            self.qualify(name, keyspace_context)
+        )
+    }
 }
 
 impl Default for CqlMigrationGenerator {
@@ -366,7 +412,7 @@ mod tests {
     use crate::cql::diff::{
         ClusteringKey, ClusteringOrder, CompactionStrategy, CqlFieldAlterDiff, CqlFieldDiff,
         CqlIndexDiff, CqlIndexType, CqlTableAlterDiff, CqlTableDiff, KeyspaceConfig,
-        ReplicationStrategy, UdtAlterDiff, UdtDiff, UdtField,
+        MaterializedViewDiff, ReplicationStrategy, UdtAlterDiff, UdtDiff, UdtField,
     };
 
     fn simple_field(name: &str, cql_type: &str) -> CqlFieldDiff {
@@ -798,5 +844,46 @@ mod tests {
 
         let migration = generator.generate(&diff);
         assert!(migration.up.contains("DROP INDEX IF EXISTS \"old_idx\""));
+    }
+
+    #[test]
+    fn test_create_materialized_view() {
+        let generator = CqlMigrationGenerator::new();
+        let mut diff = CqlSchemaDiff::default();
+        diff.create_materialized_views.push(MaterializedViewDiff {
+            name: "events_by_status".into(),
+            base_table: "events".into(),
+            select_columns: vec!["*".into()],
+            where_clause: "status IS NOT NULL AND tenant_id IS NOT NULL AND event_time IS NOT NULL".into(),
+            partition_keys: vec!["status".into()],
+            clustering_keys: vec![
+                ClusteringKey {
+                    name: "tenant_id".into(),
+                    order: ClusteringOrder::Asc,
+                },
+                ClusteringKey {
+                    name: "event_time".into(),
+                    order: ClusteringOrder::Desc,
+                },
+            ],
+        });
+
+        let migration = generator.generate(&diff);
+        assert!(migration.up.contains("CREATE MATERIALIZED VIEW \"events_by_status\""));
+        assert!(migration.up.contains("FROM \"events\""));
+        assert!(migration.up.contains("WHERE status IS NOT NULL"));
+        assert!(migration.up.contains("PRIMARY KEY ((status), tenant_id, event_time)"));
+        assert!(migration.up.contains("CLUSTERING ORDER BY (tenant_id ASC, event_time DESC)"));
+        assert!(migration.down.contains("DROP MATERIALIZED VIEW IF EXISTS \"events_by_status\""));
+    }
+
+    #[test]
+    fn test_drop_materialized_view() {
+        let generator = CqlMigrationGenerator::new();
+        let mut diff = CqlSchemaDiff::default();
+        diff.drop_materialized_views.push("old_view".into());
+
+        let migration = generator.generate(&diff);
+        assert!(migration.up.contains("DROP MATERIALIZED VIEW IF EXISTS \"old_view\""));
     }
 }

--- a/prax-migrate/src/cql/generator.rs
+++ b/prax-migrate/src/cql/generator.rs
@@ -1,8 +1,8 @@
 //! CQL migration SQL generator for ScyllaDB.
 
 use crate::cql::diff::{
-    ClusteringKey, ClusteringOrder, CompactionStrategy, CqlFieldDiff, CqlSchemaDiff, CqlTableDiff,
-    KeyspaceConfig, ReplicationStrategy, UdtAlterDiff, UdtDiff,
+    ClusteringKey, ClusteringOrder, CompactionStrategy, CqlFieldDiff, CqlSchemaDiff,
+    CqlTableAlterDiff, CqlTableDiff, KeyspaceConfig, ReplicationStrategy, UdtAlterDiff, UdtDiff,
 };
 use crate::cql::migration::MigrationCql;
 
@@ -40,6 +40,42 @@ impl CqlMigrationGenerator {
         for table in &diff.create_tables {
             up.push(self.create_table_statement(table, ks_context));
             down.push(self.drop_table_statement(&table.name, ks_context));
+        }
+
+        for alter in &diff.alter_tables {
+            if alter.partition_key_changed {
+                warnings.push(format!(
+                    "Partition key change detected for table '{}' - not supported in-place; requires manual DROP/CREATE migration",
+                    alter.name
+                ));
+            }
+            if alter.clustering_key_changed {
+                warnings.push(format!(
+                    "Clustering key change detected for table '{}' - not supported in-place; requires manual DROP/CREATE migration",
+                    alter.name
+                ));
+            }
+
+            for field_name in &alter.drop_fields {
+                warnings.push(format!(
+                    "Dropping column '{}' from table '{}' - data in this column will be lost",
+                    field_name, alter.name
+                ));
+            }
+
+            for field in &alter.alter_fields {
+                if field.new_type.is_some() && field.old_type.is_some() {
+                    warnings.push(format!(
+                        "Type change from '{}' to '{}' for column '{}' on table '{}' - CQL may reject this if data is incompatible",
+                        field.old_type.as_deref().unwrap_or(""),
+                        field.new_type.as_deref().unwrap_or(""),
+                        field.name,
+                        alter.name
+                    ));
+                }
+            }
+
+            up.extend(self.alter_table_statements(alter, ks_context));
         }
 
         for name in &diff.drop_tables {
@@ -251,6 +287,37 @@ impl CqlMigrationGenerator {
             ),
         }
     }
+
+    fn alter_table_statements(
+        &self,
+        alter: &CqlTableAlterDiff,
+        keyspace_context: Option<&str>,
+    ) -> Vec<String> {
+        let qualified = self.qualify(&alter.name, keyspace_context);
+        let mut stmts = Vec::new();
+
+        for field in &alter.add_fields {
+            stmts.push(format!(
+                "ALTER TABLE {} ADD {} {};",
+                qualified, field.name, field.cql_type
+            ));
+        }
+
+        for field_name in &alter.drop_fields {
+            stmts.push(format!("ALTER TABLE {} DROP {};", qualified, field_name));
+        }
+
+        for field in &alter.alter_fields {
+            if let Some(new_type) = &field.new_type {
+                stmts.push(format!(
+                    "ALTER TABLE {} ALTER {} TYPE {};",
+                    qualified, field.name, new_type
+                ));
+            }
+        }
+
+        stmts
+    }
 }
 
 impl Default for CqlMigrationGenerator {
@@ -263,8 +330,9 @@ impl Default for CqlMigrationGenerator {
 mod tests {
     use super::*;
     use crate::cql::diff::{
-        ClusteringKey, ClusteringOrder, CompactionStrategy, CqlFieldDiff, CqlTableDiff,
-        KeyspaceConfig, ReplicationStrategy, UdtAlterDiff, UdtDiff, UdtField,
+        ClusteringKey, ClusteringOrder, CompactionStrategy, CqlFieldAlterDiff, CqlFieldDiff,
+        CqlTableAlterDiff, CqlTableDiff, KeyspaceConfig, ReplicationStrategy, UdtAlterDiff,
+        UdtDiff, UdtField,
     };
 
     fn simple_field(name: &str, cql_type: &str) -> CqlFieldDiff {
@@ -531,6 +599,113 @@ mod tests {
         assert!(
             migration.warnings.iter().any(|w| w.contains("legacy_table") && w.contains("all rows")),
             "expected drop-table warning"
+        );
+    }
+
+    #[test]
+    fn test_alter_table_add_column() {
+        let generator = CqlMigrationGenerator::new();
+        let mut diff = CqlSchemaDiff::default();
+        diff.alter_tables.push(CqlTableAlterDiff {
+            name: "users".into(),
+            add_fields: vec![simple_field("email", "text")],
+            drop_fields: vec![],
+            alter_fields: vec![],
+            partition_key_changed: false,
+            clustering_key_changed: false,
+        });
+
+        let migration = generator.generate(&diff);
+        assert!(migration.up.contains("ALTER TABLE \"users\" ADD email text"));
+    }
+
+    #[test]
+    fn test_alter_table_drop_column_generates_warning() {
+        let generator = CqlMigrationGenerator::new();
+        let mut diff = CqlSchemaDiff::default();
+        diff.alter_tables.push(CqlTableAlterDiff {
+            name: "users".into(),
+            add_fields: vec![],
+            drop_fields: vec!["legacy_field".into()],
+            alter_fields: vec![],
+            partition_key_changed: false,
+            clustering_key_changed: false,
+        });
+
+        let migration = generator.generate(&diff);
+        assert!(migration.up.contains("ALTER TABLE \"users\" DROP legacy_field"));
+        assert!(
+            migration.warnings.iter().any(|w| w.contains("legacy_field") && w.contains("users")),
+            "expected drop-column warning"
+        );
+    }
+
+    #[test]
+    fn test_alter_table_type_change_generates_warning() {
+        let generator = CqlMigrationGenerator::new();
+        let mut diff = CqlSchemaDiff::default();
+        diff.alter_tables.push(CqlTableAlterDiff {
+            name: "users".into(),
+            add_fields: vec![],
+            drop_fields: vec![],
+            alter_fields: vec![CqlFieldAlterDiff {
+                name: "age".into(),
+                old_type: Some("int".into()),
+                new_type: Some("bigint".into()),
+            }],
+            partition_key_changed: false,
+            clustering_key_changed: false,
+        });
+
+        let migration = generator.generate(&diff);
+        assert!(migration.up.contains("ALTER TABLE \"users\" ALTER age TYPE bigint"));
+        assert!(
+            migration.warnings.iter().any(|w| w.contains("age") && w.contains("data is incompatible")),
+            "expected type-change warning"
+        );
+    }
+
+    #[test]
+    fn test_partition_key_change_warns_without_alter() {
+        let generator = CqlMigrationGenerator::new();
+        let mut diff = CqlSchemaDiff::default();
+        diff.alter_tables.push(CqlTableAlterDiff {
+            name: "users".into(),
+            add_fields: vec![],
+            drop_fields: vec![],
+            alter_fields: vec![],
+            partition_key_changed: true,
+            clustering_key_changed: false,
+        });
+
+        let migration = generator.generate(&diff);
+        assert!(
+            migration.warnings.iter().any(|w| w.contains("Partition key") && w.contains("users")),
+            "expected partition-key-change warning"
+        );
+        assert!(
+            !migration.up.contains("ALTER TABLE"),
+            "partition key change should not emit ALTER TABLE"
+        );
+    }
+
+    #[test]
+    fn test_clustering_key_change_warns_without_alter() {
+        let generator = CqlMigrationGenerator::new();
+        let mut diff = CqlSchemaDiff::default();
+        diff.alter_tables.push(CqlTableAlterDiff {
+            name: "events".into(),
+            add_fields: vec![],
+            drop_fields: vec![],
+            alter_fields: vec![],
+            partition_key_changed: false,
+            clustering_key_changed: true,
+        });
+
+        let migration = generator.generate(&diff);
+        assert!(
+            migration.warnings.iter().any(|w| w.contains("Clustering key") && w.contains("events")),
+            "expected clustering-key-change warning"
         );
     }
 }

--- a/prax-migrate/src/cql/generator.rs
+++ b/prax-migrate/src/cql/generator.rs
@@ -1,6 +1,8 @@
 //! CQL migration SQL generator for ScyllaDB.
 
-use crate::cql::diff::{CqlSchemaDiff, KeyspaceConfig, ReplicationStrategy};
+use crate::cql::diff::{
+    CqlSchemaDiff, KeyspaceConfig, ReplicationStrategy, UdtAlterDiff, UdtDiff,
+};
 use crate::cql::migration::MigrationCql;
 
 /// Generates CQL migration scripts from a CqlSchemaDiff.
@@ -21,6 +23,25 @@ impl CqlMigrationGenerator {
         if let Some(keyspace) = &diff.create_keyspace {
             up.push(self.create_keyspace_statement(keyspace));
             down.push(self.drop_keyspace_statement(&keyspace.name));
+        }
+
+        let ks_context = diff.keyspace_context.as_deref();
+
+        for udt in &diff.create_udts {
+            up.push(self.create_udt_statement(udt, ks_context));
+            down.push(self.drop_udt_statement(&udt.name, ks_context));
+        }
+
+        for alter in &diff.alter_udts {
+            up.extend(self.alter_udt_statements(alter, ks_context));
+        }
+
+        for name in &diff.drop_udts {
+            up.push(self.drop_udt_statement(name, ks_context));
+            warnings.push(format!(
+                "Dropping UDT '{}' - ensure no tables reference this type",
+                name
+            ));
         }
 
         if let Some(name) = &diff.drop_keyspace {
@@ -69,6 +90,50 @@ impl CqlMigrationGenerator {
             }
         }
     }
+
+    fn qualify(&self, name: &str, keyspace_context: Option<&str>) -> String {
+        match keyspace_context {
+            Some(ks) => format!("\"{}\".\"{}\"", ks, name),
+            None => format!("\"{}\"", name),
+        }
+    }
+
+    fn create_udt_statement(&self, udt: &UdtDiff, keyspace_context: Option<&str>) -> String {
+        let qualified = self.qualify(&udt.name, keyspace_context);
+        let fields = udt
+            .fields
+            .iter()
+            .map(|f| format!("    {} {}", f.name, f.cql_type))
+            .collect::<Vec<_>>()
+            .join(",\n");
+        format!("CREATE TYPE {} (\n{}\n);", qualified, fields)
+    }
+
+    fn drop_udt_statement(&self, name: &str, keyspace_context: Option<&str>) -> String {
+        format!("DROP TYPE IF EXISTS {};", self.qualify(name, keyspace_context))
+    }
+
+    fn alter_udt_statements(
+        &self,
+        alter: &UdtAlterDiff,
+        keyspace_context: Option<&str>,
+    ) -> Vec<String> {
+        let qualified = self.qualify(&alter.name, keyspace_context);
+        let mut stmts = Vec::new();
+        for field in &alter.add_fields {
+            stmts.push(format!(
+                "ALTER TYPE {} ADD {} {};",
+                qualified, field.name, field.cql_type
+            ));
+        }
+        for (old, new) in &alter.rename_fields {
+            stmts.push(format!(
+                "ALTER TYPE {} RENAME {} TO {};",
+                qualified, old, new
+            ));
+        }
+        stmts
+    }
 }
 
 impl Default for CqlMigrationGenerator {
@@ -80,7 +145,7 @@ impl Default for CqlMigrationGenerator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cql::diff::{KeyspaceConfig, ReplicationStrategy};
+    use crate::cql::diff::{KeyspaceConfig, ReplicationStrategy, UdtAlterDiff, UdtDiff, UdtField};
 
     #[test]
     fn test_empty_diff_produces_empty_migration() {
@@ -140,5 +205,84 @@ mod tests {
             migration.warnings.iter().any(|w| w.contains("legacy") && w.contains("ALL data")),
             "expected drop-keyspace warning"
         );
+    }
+
+    #[test]
+    fn test_create_udt_without_keyspace_context() {
+        let generator = CqlMigrationGenerator::new();
+        let mut diff = CqlSchemaDiff::default();
+        diff.create_udts.push(UdtDiff {
+            name: "order_status".into(),
+            fields: vec![UdtField {
+                name: "value".into(),
+                cql_type: "text".into(),
+            }],
+        });
+
+        let migration = generator.generate(&diff);
+        assert!(migration.up.contains("CREATE TYPE \"order_status\" ("));
+        assert!(migration.up.contains("value text"));
+        assert!(migration.down.contains("DROP TYPE IF EXISTS \"order_status\""));
+    }
+
+    #[test]
+    fn test_create_udt_with_keyspace_context() {
+        let generator = CqlMigrationGenerator::new();
+        let mut diff = CqlSchemaDiff {
+            keyspace_context: Some("myapp".into()),
+            ..Default::default()
+        };
+        diff.create_udts.push(UdtDiff {
+            name: "order_status".into(),
+            fields: vec![UdtField {
+                name: "value".into(),
+                cql_type: "text".into(),
+            }],
+        });
+
+        let migration = generator.generate(&diff);
+        assert!(migration.up.contains("CREATE TYPE \"myapp\".\"order_status\" ("));
+    }
+
+    #[test]
+    fn test_alter_udt_add_field() {
+        let generator = CqlMigrationGenerator::new();
+        let mut diff = CqlSchemaDiff::default();
+        diff.alter_udts.push(UdtAlterDiff {
+            name: "order_status".into(),
+            add_fields: vec![UdtField {
+                name: "description".into(),
+                cql_type: "text".into(),
+            }],
+            rename_fields: vec![],
+        });
+
+        let migration = generator.generate(&diff);
+        assert!(migration.up.contains("ALTER TYPE \"order_status\" ADD description text"));
+    }
+
+    #[test]
+    fn test_alter_udt_rename_field() {
+        let generator = CqlMigrationGenerator::new();
+        let mut diff = CqlSchemaDiff::default();
+        diff.alter_udts.push(UdtAlterDiff {
+            name: "order_status".into(),
+            add_fields: vec![],
+            rename_fields: vec![("old_name".into(), "new_name".into())],
+        });
+
+        let migration = generator.generate(&diff);
+        assert!(migration.up.contains("ALTER TYPE \"order_status\" RENAME old_name TO new_name"));
+    }
+
+    #[test]
+    fn test_drop_udt_generates_warning() {
+        let generator = CqlMigrationGenerator::new();
+        let mut diff = CqlSchemaDiff::default();
+        diff.drop_udts.push("legacy_type".into());
+
+        let migration = generator.generate(&diff);
+        assert!(migration.up.contains("DROP TYPE IF EXISTS \"legacy_type\""));
+        assert!(migration.warnings.iter().any(|w| w.contains("legacy_type")));
     }
 }

--- a/prax-migrate/src/cql/generator.rs
+++ b/prax-migrate/src/cql/generator.rs
@@ -99,10 +99,7 @@ impl CqlMigrationGenerator {
 
         for name in &diff.drop_tables {
             up.push(self.drop_table_statement(name, ks_context));
-            warnings.push(format!(
-                "Dropping table '{}' - all rows will be lost",
-                name
-            ));
+            warnings.push(format!("Dropping table '{}' - all rows will be lost", name));
         }
 
         for name in &diff.drop_udts {
@@ -179,7 +176,10 @@ impl CqlMigrationGenerator {
     }
 
     fn drop_udt_statement(&self, name: &str, keyspace_context: Option<&str>) -> String {
-        format!("DROP TYPE IF EXISTS {};", self.qualify(name, keyspace_context))
+        format!(
+            "DROP TYPE IF EXISTS {};",
+            self.qualify(name, keyspace_context)
+        )
     }
 
     fn alter_udt_statements(
@@ -204,7 +204,11 @@ impl CqlMigrationGenerator {
         stmts
     }
 
-    fn create_table_statement(&self, table: &CqlTableDiff, keyspace_context: Option<&str>) -> String {
+    fn create_table_statement(
+        &self,
+        table: &CqlTableDiff,
+        keyspace_context: Option<&str>,
+    ) -> String {
         let qualified = self.qualify(&table.name, keyspace_context);
         let columns = table
             .fields
@@ -224,7 +228,10 @@ impl CqlMigrationGenerator {
             options.push(self.format_clustering_order(&table.clustering_keys));
         }
         if let Some(compaction) = &table.compaction {
-            options.push(format!("compaction = {}", self.format_compaction(compaction)));
+            options.push(format!(
+                "compaction = {}",
+                self.format_compaction(compaction)
+            ));
         }
         if let Some(ttl) = table.default_ttl {
             options.push(format!("default_time_to_live = {}", ttl));
@@ -240,7 +247,10 @@ impl CqlMigrationGenerator {
     }
 
     fn drop_table_statement(&self, name: &str, keyspace_context: Option<&str>) -> String {
-        format!("DROP TABLE IF EXISTS {};", self.qualify(name, keyspace_context))
+        format!(
+            "DROP TABLE IF EXISTS {};",
+            self.qualify(name, keyspace_context)
+        )
     }
 
     fn format_column(&self, field: &CqlFieldDiff) -> String {
@@ -294,9 +304,7 @@ impl CqlMigrationGenerator {
             CompactionStrategy::SizeTiered => {
                 "{'class': 'SizeTieredCompactionStrategy'}".to_string()
             }
-            CompactionStrategy::Leveled => {
-                "{'class': 'LeveledCompactionStrategy'}".to_string()
-            }
+            CompactionStrategy::Leveled => "{'class': 'LeveledCompactionStrategy'}".to_string(),
             CompactionStrategy::TimeWindow {
                 window_unit,
                 window_size,
@@ -338,7 +346,11 @@ impl CqlMigrationGenerator {
         stmts
     }
 
-    fn create_index_statement(&self, index: &CqlIndexDiff, keyspace_context: Option<&str>) -> String {
+    fn create_index_statement(
+        &self,
+        index: &CqlIndexDiff,
+        keyspace_context: Option<&str>,
+    ) -> String {
         let qualified_index = self.qualify(&index.name, keyspace_context);
         let qualified_table = self.qualify(&index.table_name, keyspace_context);
 
@@ -359,7 +371,10 @@ impl CqlMigrationGenerator {
     }
 
     fn drop_index_statement(&self, name: &str, keyspace_context: Option<&str>) -> String {
-        format!("DROP INDEX IF EXISTS {};", self.qualify(name, keyspace_context))
+        format!(
+            "DROP INDEX IF EXISTS {};",
+            self.qualify(name, keyspace_context)
+        )
     }
 
     fn create_materialized_view_statement(
@@ -443,7 +458,11 @@ mod tests {
         });
 
         let migration = generator.generate(&diff);
-        assert!(migration.up.contains("CREATE KEYSPACE IF NOT EXISTS \"myapp\""));
+        assert!(
+            migration
+                .up
+                .contains("CREATE KEYSPACE IF NOT EXISTS \"myapp\"")
+        );
         assert!(migration.up.contains("'class': 'SimpleStrategy'"));
         assert!(migration.up.contains("'replication_factor': 3"));
         assert!(migration.up.contains("durable_writes = true"));
@@ -478,7 +497,10 @@ mod tests {
         let migration = generator.generate(&diff);
         assert!(migration.up.contains("DROP KEYSPACE IF EXISTS \"legacy\""));
         assert!(
-            migration.warnings.iter().any(|w| w.contains("legacy") && w.contains("ALL data")),
+            migration
+                .warnings
+                .iter()
+                .any(|w| w.contains("legacy") && w.contains("ALL data")),
             "expected drop-keyspace warning"
         );
     }
@@ -498,7 +520,11 @@ mod tests {
         let migration = generator.generate(&diff);
         assert!(migration.up.contains("CREATE TYPE \"order_status\" ("));
         assert!(migration.up.contains("value text"));
-        assert!(migration.down.contains("DROP TYPE IF EXISTS \"order_status\""));
+        assert!(
+            migration
+                .down
+                .contains("DROP TYPE IF EXISTS \"order_status\"")
+        );
     }
 
     #[test]
@@ -517,7 +543,11 @@ mod tests {
         });
 
         let migration = generator.generate(&diff);
-        assert!(migration.up.contains("CREATE TYPE \"myapp\".\"order_status\" ("));
+        assert!(
+            migration
+                .up
+                .contains("CREATE TYPE \"myapp\".\"order_status\" (")
+        );
     }
 
     #[test]
@@ -534,7 +564,11 @@ mod tests {
         });
 
         let migration = generator.generate(&diff);
-        assert!(migration.up.contains("ALTER TYPE \"order_status\" ADD description text"));
+        assert!(
+            migration
+                .up
+                .contains("ALTER TYPE \"order_status\" ADD description text")
+        );
     }
 
     #[test]
@@ -548,7 +582,11 @@ mod tests {
         });
 
         let migration = generator.generate(&diff);
-        assert!(migration.up.contains("ALTER TYPE \"order_status\" RENAME old_name TO new_name"));
+        assert!(
+            migration
+                .up
+                .contains("ALTER TYPE \"order_status\" RENAME old_name TO new_name")
+        );
     }
 
     #[test]
@@ -568,10 +606,7 @@ mod tests {
         let mut diff = CqlSchemaDiff::default();
         diff.create_tables.push(CqlTableDiff {
             name: "users".into(),
-            fields: vec![
-                simple_field("id", "uuid"),
-                simple_field("name", "text"),
-            ],
+            fields: vec![simple_field("id", "uuid"), simple_field("name", "text")],
             partition_keys: vec!["id".into()],
             clustering_keys: vec![],
             compaction: None,
@@ -615,8 +650,16 @@ mod tests {
         });
 
         let migration = generator.generate(&diff);
-        assert!(migration.up.contains("PRIMARY KEY ((tenant_id, region), event_time, event_id)"));
-        assert!(migration.up.contains("CLUSTERING ORDER BY (event_time DESC, event_id ASC)"));
+        assert!(
+            migration
+                .up
+                .contains("PRIMARY KEY ((tenant_id, region), event_time, event_id)")
+        );
+        assert!(
+            migration
+                .up
+                .contains("CLUSTERING ORDER BY (event_time DESC, event_id ASC)")
+        );
     }
 
     #[test]
@@ -636,7 +679,11 @@ mod tests {
         });
 
         let migration = generator.generate(&diff);
-        assert!(migration.up.contains("'class': 'TimeWindowCompactionStrategy'"));
+        assert!(
+            migration
+                .up
+                .contains("'class': 'TimeWindowCompactionStrategy'")
+        );
         assert!(migration.up.contains("'compaction_window_unit': 'DAYS'"));
         assert!(migration.up.contains("'compaction_window_size': 1"));
         assert!(migration.up.contains("default_time_to_live = 2592000"));
@@ -675,9 +722,16 @@ mod tests {
         diff.drop_tables.push("legacy_table".into());
 
         let migration = generator.generate(&diff);
-        assert!(migration.up.contains("DROP TABLE IF EXISTS \"legacy_table\""));
         assert!(
-            migration.warnings.iter().any(|w| w.contains("legacy_table") && w.contains("all rows")),
+            migration
+                .up
+                .contains("DROP TABLE IF EXISTS \"legacy_table\"")
+        );
+        assert!(
+            migration
+                .warnings
+                .iter()
+                .any(|w| w.contains("legacy_table") && w.contains("all rows")),
             "expected drop-table warning"
         );
     }
@@ -696,7 +750,11 @@ mod tests {
         });
 
         let migration = generator.generate(&diff);
-        assert!(migration.up.contains("ALTER TABLE \"users\" ADD email text"));
+        assert!(
+            migration
+                .up
+                .contains("ALTER TABLE \"users\" ADD email text")
+        );
     }
 
     #[test]
@@ -713,9 +771,16 @@ mod tests {
         });
 
         let migration = generator.generate(&diff);
-        assert!(migration.up.contains("ALTER TABLE \"users\" DROP legacy_field"));
         assert!(
-            migration.warnings.iter().any(|w| w.contains("legacy_field") && w.contains("users")),
+            migration
+                .up
+                .contains("ALTER TABLE \"users\" DROP legacy_field")
+        );
+        assert!(
+            migration
+                .warnings
+                .iter()
+                .any(|w| w.contains("legacy_field") && w.contains("users")),
             "expected drop-column warning"
         );
     }
@@ -738,9 +803,16 @@ mod tests {
         });
 
         let migration = generator.generate(&diff);
-        assert!(migration.up.contains("ALTER TABLE \"users\" ALTER age TYPE bigint"));
         assert!(
-            migration.warnings.iter().any(|w| w.contains("age") && w.contains("data is incompatible")),
+            migration
+                .up
+                .contains("ALTER TABLE \"users\" ALTER age TYPE bigint")
+        );
+        assert!(
+            migration
+                .warnings
+                .iter()
+                .any(|w| w.contains("age") && w.contains("data is incompatible")),
             "expected type-change warning"
         );
     }
@@ -760,7 +832,10 @@ mod tests {
 
         let migration = generator.generate(&diff);
         assert!(
-            migration.warnings.iter().any(|w| w.contains("Partition key") && w.contains("users")),
+            migration
+                .warnings
+                .iter()
+                .any(|w| w.contains("Partition key") && w.contains("users")),
             "expected partition-key-change warning"
         );
         assert!(
@@ -784,7 +859,10 @@ mod tests {
 
         let migration = generator.generate(&diff);
         assert!(
-            migration.warnings.iter().any(|w| w.contains("Clustering key") && w.contains("events")),
+            migration
+                .warnings
+                .iter()
+                .any(|w| w.contains("Clustering key") && w.contains("events")),
             "expected clustering-key-change warning"
         );
     }
@@ -801,9 +879,17 @@ mod tests {
         });
 
         let migration = generator.generate(&diff);
-        assert!(migration.up.contains("CREATE INDEX IF NOT EXISTS \"users_email_idx\""));
+        assert!(
+            migration
+                .up
+                .contains("CREATE INDEX IF NOT EXISTS \"users_email_idx\"")
+        );
         assert!(migration.up.contains("ON \"users\" (email)"));
-        assert!(migration.down.contains("DROP INDEX IF EXISTS \"users_email_idx\""));
+        assert!(
+            migration
+                .down
+                .contains("DROP INDEX IF EXISTS \"users_email_idx\"")
+        );
     }
 
     #[test]
@@ -818,7 +904,11 @@ mod tests {
         });
 
         let migration = generator.generate(&diff);
-        assert!(migration.up.contains("USING 'org.apache.cassandra.index.sasi.SASIIndex'"));
+        assert!(
+            migration
+                .up
+                .contains("USING 'org.apache.cassandra.index.sasi.SASIIndex'")
+        );
     }
 
     #[test]
@@ -854,7 +944,8 @@ mod tests {
             name: "events_by_status".into(),
             base_table: "events".into(),
             select_columns: vec!["*".into()],
-            where_clause: "status IS NOT NULL AND tenant_id IS NOT NULL AND event_time IS NOT NULL".into(),
+            where_clause: "status IS NOT NULL AND tenant_id IS NOT NULL AND event_time IS NOT NULL"
+                .into(),
             partition_keys: vec!["status".into()],
             clustering_keys: vec![
                 ClusteringKey {
@@ -869,12 +960,28 @@ mod tests {
         });
 
         let migration = generator.generate(&diff);
-        assert!(migration.up.contains("CREATE MATERIALIZED VIEW \"events_by_status\""));
+        assert!(
+            migration
+                .up
+                .contains("CREATE MATERIALIZED VIEW \"events_by_status\"")
+        );
         assert!(migration.up.contains("FROM \"events\""));
         assert!(migration.up.contains("WHERE status IS NOT NULL"));
-        assert!(migration.up.contains("PRIMARY KEY ((status), tenant_id, event_time)"));
-        assert!(migration.up.contains("CLUSTERING ORDER BY (tenant_id ASC, event_time DESC)"));
-        assert!(migration.down.contains("DROP MATERIALIZED VIEW IF EXISTS \"events_by_status\""));
+        assert!(
+            migration
+                .up
+                .contains("PRIMARY KEY ((status), tenant_id, event_time)")
+        );
+        assert!(
+            migration
+                .up
+                .contains("CLUSTERING ORDER BY (tenant_id ASC, event_time DESC)")
+        );
+        assert!(
+            migration
+                .down
+                .contains("DROP MATERIALIZED VIEW IF EXISTS \"events_by_status\"")
+        );
     }
 
     #[test]
@@ -884,6 +991,10 @@ mod tests {
         diff.drop_materialized_views.push("old_view".into());
 
         let migration = generator.generate(&diff);
-        assert!(migration.up.contains("DROP MATERIALIZED VIEW IF EXISTS \"old_view\""));
+        assert!(
+            migration
+                .up
+                .contains("DROP MATERIALIZED VIEW IF EXISTS \"old_view\"")
+        );
     }
 }

--- a/prax-migrate/src/cql/generator.rs
+++ b/prax-migrate/src/cql/generator.rs
@@ -1,0 +1,39 @@
+//! CQL migration SQL generator for ScyllaDB.
+
+use crate::cql::diff::CqlSchemaDiff;
+use crate::cql::migration::MigrationCql;
+
+/// Generates CQL migration scripts from a CqlSchemaDiff.
+pub struct CqlMigrationGenerator;
+
+impl CqlMigrationGenerator {
+    /// Create a new generator.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Generate a CQL migration from a schema diff.
+    pub fn generate(&self, _diff: &CqlSchemaDiff) -> MigrationCql {
+        MigrationCql::default()
+    }
+}
+
+impl Default for CqlMigrationGenerator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_diff_produces_empty_migration() {
+        let generator = CqlMigrationGenerator::new();
+        let diff = CqlSchemaDiff::default();
+        let migration = generator.generate(&diff);
+        assert!(migration.is_empty());
+        assert!(migration.warnings.is_empty());
+    }
+}

--- a/prax-migrate/src/cql/generator.rs
+++ b/prax-migrate/src/cql/generator.rs
@@ -1,7 +1,8 @@
 //! CQL migration SQL generator for ScyllaDB.
 
 use crate::cql::diff::{
-    CqlSchemaDiff, KeyspaceConfig, ReplicationStrategy, UdtAlterDiff, UdtDiff,
+    ClusteringKey, ClusteringOrder, CompactionStrategy, CqlFieldDiff, CqlSchemaDiff, CqlTableDiff,
+    KeyspaceConfig, ReplicationStrategy, UdtAlterDiff, UdtDiff,
 };
 use crate::cql::migration::MigrationCql;
 
@@ -34,6 +35,19 @@ impl CqlMigrationGenerator {
 
         for alter in &diff.alter_udts {
             up.extend(self.alter_udt_statements(alter, ks_context));
+        }
+
+        for table in &diff.create_tables {
+            up.push(self.create_table_statement(table, ks_context));
+            down.push(self.drop_table_statement(&table.name, ks_context));
+        }
+
+        for name in &diff.drop_tables {
+            up.push(self.drop_table_statement(name, ks_context));
+            warnings.push(format!(
+                "Dropping table '{}' - all rows will be lost",
+                name
+            ));
         }
 
         for name in &diff.drop_udts {
@@ -134,6 +148,109 @@ impl CqlMigrationGenerator {
         }
         stmts
     }
+
+    fn create_table_statement(&self, table: &CqlTableDiff, keyspace_context: Option<&str>) -> String {
+        let qualified = self.qualify(&table.name, keyspace_context);
+        let columns = table
+            .fields
+            .iter()
+            .map(|f| self.format_column(f))
+            .collect::<Vec<_>>()
+            .join(",\n    ");
+        let pk = self.format_primary_key(&table.partition_keys, &table.clustering_keys);
+
+        let mut stmt = format!(
+            "CREATE TABLE {} (\n    {},\n    {}\n)",
+            qualified, columns, pk
+        );
+
+        let mut options: Vec<String> = Vec::new();
+        if !table.clustering_keys.is_empty() {
+            options.push(self.format_clustering_order(&table.clustering_keys));
+        }
+        if let Some(compaction) = &table.compaction {
+            options.push(format!("compaction = {}", self.format_compaction(compaction)));
+        }
+        if let Some(ttl) = table.default_ttl {
+            options.push(format!("default_time_to_live = {}", ttl));
+        }
+
+        if !options.is_empty() {
+            stmt.push_str(" WITH ");
+            stmt.push_str(&options.join("\n  AND "));
+        }
+
+        stmt.push(';');
+        stmt
+    }
+
+    fn drop_table_statement(&self, name: &str, keyspace_context: Option<&str>) -> String {
+        format!("DROP TABLE IF EXISTS {};", self.qualify(name, keyspace_context))
+    }
+
+    fn format_column(&self, field: &CqlFieldDiff) -> String {
+        let mut col = format!("{} {}", field.name, field.cql_type);
+        if field.is_static {
+            col.push_str(" STATIC");
+        }
+        col
+    }
+
+    fn format_primary_key(
+        &self,
+        partition_keys: &[String],
+        clustering_keys: &[ClusteringKey],
+    ) -> String {
+        let partition = if partition_keys.len() == 1 {
+            format!("({})", partition_keys[0])
+        } else {
+            format!("({})", partition_keys.join(", "))
+        };
+
+        if clustering_keys.is_empty() {
+            format!("PRIMARY KEY ({})", partition)
+        } else {
+            let clustering = clustering_keys
+                .iter()
+                .map(|ck| ck.name.clone())
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("PRIMARY KEY ({}, {})", partition, clustering)
+        }
+    }
+
+    fn format_clustering_order(&self, clustering_keys: &[ClusteringKey]) -> String {
+        let order = clustering_keys
+            .iter()
+            .map(|ck| {
+                let dir = match ck.order {
+                    ClusteringOrder::Asc => "ASC",
+                    ClusteringOrder::Desc => "DESC",
+                };
+                format!("{} {}", ck.name, dir)
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("CLUSTERING ORDER BY ({})", order)
+    }
+
+    fn format_compaction(&self, strategy: &CompactionStrategy) -> String {
+        match strategy {
+            CompactionStrategy::SizeTiered => {
+                "{'class': 'SizeTieredCompactionStrategy'}".to_string()
+            }
+            CompactionStrategy::Leveled => {
+                "{'class': 'LeveledCompactionStrategy'}".to_string()
+            }
+            CompactionStrategy::TimeWindow {
+                window_unit,
+                window_size,
+            } => format!(
+                "{{'class': 'TimeWindowCompactionStrategy', 'compaction_window_unit': '{}', 'compaction_window_size': {}}}",
+                window_unit, window_size
+            ),
+        }
+    }
 }
 
 impl Default for CqlMigrationGenerator {
@@ -145,7 +262,18 @@ impl Default for CqlMigrationGenerator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cql::diff::{KeyspaceConfig, ReplicationStrategy, UdtAlterDiff, UdtDiff, UdtField};
+    use crate::cql::diff::{
+        ClusteringKey, ClusteringOrder, CompactionStrategy, CqlFieldDiff, CqlTableDiff,
+        KeyspaceConfig, ReplicationStrategy, UdtAlterDiff, UdtDiff, UdtField,
+    };
+
+    fn simple_field(name: &str, cql_type: &str) -> CqlFieldDiff {
+        CqlFieldDiff {
+            name: name.into(),
+            cql_type: cql_type.into(),
+            is_static: false,
+        }
+    }
 
     #[test]
     fn test_empty_diff_produces_empty_migration() {
@@ -284,5 +412,125 @@ mod tests {
         let migration = generator.generate(&diff);
         assert!(migration.up.contains("DROP TYPE IF EXISTS \"legacy_type\""));
         assert!(migration.warnings.iter().any(|w| w.contains("legacy_type")));
+    }
+
+    #[test]
+    fn test_create_table_with_simple_partition_key() {
+        let generator = CqlMigrationGenerator::new();
+        let mut diff = CqlSchemaDiff::default();
+        diff.create_tables.push(CqlTableDiff {
+            name: "users".into(),
+            fields: vec![
+                simple_field("id", "uuid"),
+                simple_field("name", "text"),
+            ],
+            partition_keys: vec!["id".into()],
+            clustering_keys: vec![],
+            compaction: None,
+            default_ttl: None,
+        });
+
+        let migration = generator.generate(&diff);
+        assert!(migration.up.contains("CREATE TABLE \"users\" ("));
+        assert!(migration.up.contains("id uuid"));
+        assert!(migration.up.contains("name text"));
+        assert!(migration.up.contains("PRIMARY KEY ((id))"));
+        assert!(migration.down.contains("DROP TABLE IF EXISTS \"users\""));
+    }
+
+    #[test]
+    fn test_create_table_with_compound_partition_and_clustering() {
+        let generator = CqlMigrationGenerator::new();
+        let mut diff = CqlSchemaDiff::default();
+        diff.create_tables.push(CqlTableDiff {
+            name: "events".into(),
+            fields: vec![
+                simple_field("tenant_id", "uuid"),
+                simple_field("region", "text"),
+                simple_field("event_time", "timestamp"),
+                simple_field("event_id", "uuid"),
+                simple_field("payload", "text"),
+            ],
+            partition_keys: vec!["tenant_id".into(), "region".into()],
+            clustering_keys: vec![
+                ClusteringKey {
+                    name: "event_time".into(),
+                    order: ClusteringOrder::Desc,
+                },
+                ClusteringKey {
+                    name: "event_id".into(),
+                    order: ClusteringOrder::Asc,
+                },
+            ],
+            compaction: None,
+            default_ttl: None,
+        });
+
+        let migration = generator.generate(&diff);
+        assert!(migration.up.contains("PRIMARY KEY ((tenant_id, region), event_time, event_id)"));
+        assert!(migration.up.contains("CLUSTERING ORDER BY (event_time DESC, event_id ASC)"));
+    }
+
+    #[test]
+    fn test_create_table_with_compaction_and_ttl() {
+        let generator = CqlMigrationGenerator::new();
+        let mut diff = CqlSchemaDiff::default();
+        diff.create_tables.push(CqlTableDiff {
+            name: "metrics".into(),
+            fields: vec![simple_field("id", "uuid"), simple_field("value", "double")],
+            partition_keys: vec!["id".into()],
+            clustering_keys: vec![],
+            compaction: Some(CompactionStrategy::TimeWindow {
+                window_unit: "DAYS".into(),
+                window_size: 1,
+            }),
+            default_ttl: Some(2592000),
+        });
+
+        let migration = generator.generate(&diff);
+        assert!(migration.up.contains("'class': 'TimeWindowCompactionStrategy'"));
+        assert!(migration.up.contains("'compaction_window_unit': 'DAYS'"));
+        assert!(migration.up.contains("'compaction_window_size': 1"));
+        assert!(migration.up.contains("default_time_to_live = 2592000"));
+    }
+
+    #[test]
+    fn test_create_table_with_static_column() {
+        let generator = CqlMigrationGenerator::new();
+        let mut diff = CqlSchemaDiff::default();
+        let mut static_field = simple_field("tenant_name", "text");
+        static_field.is_static = true;
+        diff.create_tables.push(CqlTableDiff {
+            name: "tenant_data".into(),
+            fields: vec![
+                simple_field("tenant_id", "uuid"),
+                simple_field("event_id", "uuid"),
+                static_field,
+            ],
+            partition_keys: vec!["tenant_id".into()],
+            clustering_keys: vec![ClusteringKey {
+                name: "event_id".into(),
+                order: ClusteringOrder::Asc,
+            }],
+            compaction: None,
+            default_ttl: None,
+        });
+
+        let migration = generator.generate(&diff);
+        assert!(migration.up.contains("tenant_name text STATIC"));
+    }
+
+    #[test]
+    fn test_drop_table_generates_warning() {
+        let generator = CqlMigrationGenerator::new();
+        let mut diff = CqlSchemaDiff::default();
+        diff.drop_tables.push("legacy_table".into());
+
+        let migration = generator.generate(&diff);
+        assert!(migration.up.contains("DROP TABLE IF EXISTS \"legacy_table\""));
+        assert!(
+            migration.warnings.iter().any(|w| w.contains("legacy_table") && w.contains("all rows")),
+            "expected drop-table warning"
+        );
     }
 }

--- a/prax-migrate/src/cql/migration.rs
+++ b/prax-migrate/src/cql/migration.rs
@@ -1,0 +1,50 @@
+//! CQL migration output type.
+
+/// A CQL migration: up script, down script, and warnings.
+#[derive(Debug, Clone, Default)]
+pub struct MigrationCql {
+    /// CQL statements to apply the migration (forward direction).
+    pub up: String,
+    /// CQL statements to roll back the migration (reverse direction).
+    pub down: String,
+    /// Warnings about potential data loss or manual steps required.
+    pub warnings: Vec<String>,
+}
+
+impl MigrationCql {
+    /// Returns true if both up and down are empty.
+    pub fn is_empty(&self) -> bool {
+        self.up.trim().is_empty() && self.down.trim().is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_migration_cql_default_is_empty() {
+        let migration = MigrationCql::default();
+        assert!(migration.is_empty());
+        assert!(migration.warnings.is_empty());
+    }
+
+    #[test]
+    fn test_migration_cql_with_up_is_not_empty() {
+        let migration = MigrationCql {
+            up: "CREATE TABLE foo (id uuid PRIMARY KEY);".to_string(),
+            ..Default::default()
+        };
+        assert!(!migration.is_empty());
+    }
+
+    #[test]
+    fn test_migration_cql_whitespace_only_is_empty() {
+        let migration = MigrationCql {
+            up: "   \n\t  ".to_string(),
+            down: "   ".to_string(),
+            warnings: vec![],
+        };
+        assert!(migration.is_empty());
+    }
+}

--- a/prax-migrate/src/cql/mod.rs
+++ b/prax-migrate/src/cql/mod.rs
@@ -1,5 +1,11 @@
 //! CQL (Cassandra Query Language) migration support for ScyllaDB.
 
+pub mod diff;
 pub mod migration;
 
+pub use diff::{
+    ClusteringKey, ClusteringOrder, CompactionStrategy, CqlFieldAlterDiff, CqlFieldDiff,
+    CqlIndexDiff, CqlIndexType, CqlSchemaDiff, CqlTableAlterDiff, CqlTableDiff, KeyspaceConfig,
+    MaterializedViewDiff, ReplicationStrategy, UdtAlterDiff, UdtDiff, UdtField,
+};
 pub use migration::MigrationCql;

--- a/prax-migrate/src/cql/mod.rs
+++ b/prax-migrate/src/cql/mod.rs
@@ -1,8 +1,30 @@
 //! CQL (Cassandra Query Language) migration support for ScyllaDB.
 
+use crate::dialect::MigrationDialect;
+
 pub mod diff;
 pub mod generator;
 pub mod migration;
+
+/// The CQL dialect for ScyllaDB.
+pub struct CqlDialect;
+
+impl MigrationDialect for CqlDialect {
+    type Diff = CqlSchemaDiff;
+    type Migration = MigrationCql;
+
+    fn name() -> &'static str {
+        "cql"
+    }
+
+    fn generate(diff: &CqlSchemaDiff) -> MigrationCql {
+        CqlMigrationGenerator::new().generate(diff)
+    }
+
+    fn event_log_table() -> &'static str {
+        "_prax_cql_migrations"
+    }
+}
 
 pub use diff::{
     ClusteringKey, ClusteringOrder, CompactionStrategy, CqlFieldAlterDiff, CqlFieldDiff,

--- a/prax-migrate/src/cql/mod.rs
+++ b/prax-migrate/src/cql/mod.rs
@@ -1,6 +1,7 @@
 //! CQL (Cassandra Query Language) migration support for ScyllaDB.
 
 pub mod diff;
+pub mod generator;
 pub mod migration;
 
 pub use diff::{
@@ -8,4 +9,5 @@ pub use diff::{
     CqlIndexDiff, CqlIndexType, CqlSchemaDiff, CqlTableAlterDiff, CqlTableDiff, KeyspaceConfig,
     MaterializedViewDiff, ReplicationStrategy, UdtAlterDiff, UdtDiff, UdtField,
 };
+pub use generator::CqlMigrationGenerator;
 pub use migration::MigrationCql;

--- a/prax-migrate/src/cql/mod.rs
+++ b/prax-migrate/src/cql/mod.rs
@@ -1,0 +1,5 @@
+//! CQL (Cassandra Query Language) migration support for ScyllaDB.
+
+pub mod migration;
+
+pub use migration::MigrationCql;

--- a/prax-migrate/src/dialect.rs
+++ b/prax-migrate/src/dialect.rs
@@ -62,4 +62,24 @@ mod tests {
         let migration = SqlDialect::generate(&diff);
         assert!(migration.is_empty());
     }
+
+    #[test]
+    fn test_cql_dialect_name() {
+        use crate::cql::CqlDialect;
+        assert_eq!(CqlDialect::name(), "cql");
+    }
+
+    #[test]
+    fn test_cql_dialect_event_log_table() {
+        use crate::cql::CqlDialect;
+        assert_eq!(CqlDialect::event_log_table(), "_prax_cql_migrations");
+    }
+
+    #[test]
+    fn test_cql_dialect_generates_empty_migration_from_empty_diff() {
+        use crate::cql::{CqlDialect, CqlSchemaDiff};
+        let diff = CqlSchemaDiff::default();
+        let migration = CqlDialect::generate(&diff);
+        assert!(migration.is_empty());
+    }
 }

--- a/prax-migrate/src/dialect.rs
+++ b/prax-migrate/src/dialect.rs
@@ -82,4 +82,36 @@ mod tests {
         let migration = CqlDialect::generate(&diff);
         assert!(migration.is_empty());
     }
+
+    #[test]
+    fn test_sql_dialect_matches_postgres_generator_directly() {
+        use crate::diff::{FieldDiff, ModelDiff};
+
+        let mut diff = SchemaDiff::default();
+        diff.create_models.push(ModelDiff {
+            name: "User".to_string(),
+            table_name: "users".to_string(),
+            fields: vec![FieldDiff {
+                name: "id".to_string(),
+                column_name: "id".to_string(),
+                sql_type: "BIGINT".to_string(),
+                nullable: false,
+                default: None,
+                is_primary_key: true,
+                is_auto_increment: true,
+                is_unique: false,
+            }],
+            primary_key: vec!["id".to_string()],
+            indexes: Vec::new(),
+            unique_constraints: Vec::new(),
+            foreign_keys: Vec::new(),
+        });
+
+        let via_trait = SqlDialect::generate(&diff);
+        let via_direct = PostgresSqlGenerator.generate(&diff);
+
+        assert_eq!(via_trait.up, via_direct.up);
+        assert_eq!(via_trait.down, via_direct.down);
+        assert_eq!(via_trait.warnings, via_direct.warnings);
+    }
 }

--- a/prax-migrate/src/dialect.rs
+++ b/prax-migrate/src/dialect.rs
@@ -1,0 +1,65 @@
+//! Migration dialect trait for abstracting over SQL and CQL backends.
+
+use crate::diff::SchemaDiff;
+use crate::sql::{MigrationSql, PostgresSqlGenerator};
+
+/// A migration dialect abstracts the schema diff type, migration output type,
+/// and generator for a specific database backend.
+pub trait MigrationDialect {
+    /// The schema diff type for this dialect.
+    type Diff: Default + Send + Sync;
+
+    /// The migration output type for this dialect.
+    type Migration: Send + Sync;
+
+    /// Human-readable dialect name (e.g., "sql", "cql").
+    fn name() -> &'static str;
+
+    /// Generate a migration from a schema diff.
+    fn generate(diff: &Self::Diff) -> Self::Migration;
+
+    /// Event log table name used by this dialect.
+    fn event_log_table() -> &'static str;
+}
+
+/// The SQL dialect (PostgreSQL, MySQL, SQLite, MSSQL, DuckDB share this).
+pub struct SqlDialect;
+
+impl MigrationDialect for SqlDialect {
+    type Diff = SchemaDiff;
+    type Migration = MigrationSql;
+
+    fn name() -> &'static str {
+        "sql"
+    }
+
+    fn generate(diff: &SchemaDiff) -> MigrationSql {
+        PostgresSqlGenerator.generate(diff)
+    }
+
+    fn event_log_table() -> &'static str {
+        "_prax_migrations"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sql_dialect_name() {
+        assert_eq!(SqlDialect::name(), "sql");
+    }
+
+    #[test]
+    fn test_sql_dialect_event_log_table() {
+        assert_eq!(SqlDialect::event_log_table(), "_prax_migrations");
+    }
+
+    #[test]
+    fn test_sql_dialect_generates_empty_migration_from_empty_diff() {
+        let diff = SchemaDiff::default();
+        let migration = SqlDialect::generate(&diff);
+        assert!(migration.is_empty());
+    }
+}

--- a/prax-migrate/src/lib.rs
+++ b/prax-migrate/src/lib.rs
@@ -168,10 +168,10 @@ pub mod state;
 // Re-exports
 pub use bootstrap::Bootstrap;
 pub use cql::{
-    ClusteringKey, ClusteringOrder, CompactionStrategy, CqlFieldAlterDiff, CqlFieldDiff,
-    CqlIndexDiff, CqlIndexType, CqlMigrationGenerator, CqlSchemaDiff, CqlTableAlterDiff,
-    CqlTableDiff, KeyspaceConfig, MaterializedViewDiff, MigrationCql, ReplicationStrategy,
-    UdtAlterDiff, UdtDiff, UdtField,
+    ClusteringKey, ClusteringOrder, CompactionStrategy, CqlDialect, CqlFieldAlterDiff,
+    CqlFieldDiff, CqlIndexDiff, CqlIndexType, CqlMigrationGenerator, CqlSchemaDiff,
+    CqlTableAlterDiff, CqlTableDiff, KeyspaceConfig, MaterializedViewDiff, MigrationCql,
+    ReplicationStrategy, UdtAlterDiff, UdtDiff, UdtField,
 };
 pub use dialect::{MigrationDialect, SqlDialect};
 pub use diff::{

--- a/prax-migrate/src/lib.rs
+++ b/prax-migrate/src/lib.rs
@@ -167,7 +167,11 @@ pub mod state;
 
 // Re-exports
 pub use bootstrap::Bootstrap;
-pub use cql::MigrationCql;
+pub use cql::{
+    ClusteringKey, ClusteringOrder, CompactionStrategy, CqlFieldAlterDiff, CqlFieldDiff,
+    CqlIndexDiff, CqlIndexType, CqlSchemaDiff, CqlTableAlterDiff, CqlTableDiff, KeyspaceConfig,
+    MaterializedViewDiff, MigrationCql, ReplicationStrategy, UdtAlterDiff, UdtDiff, UdtField,
+};
 pub use dialect::{MigrationDialect, SqlDialect};
 pub use diff::{
     EnumAlterDiff, EnumDiff, ExtensionDiff, FieldAlterDiff, FieldDiff, ForeignKeyDiff, IndexDiff,

--- a/prax-migrate/src/lib.rs
+++ b/prax-migrate/src/lib.rs
@@ -5,6 +5,7 @@
 //! This crate provides functionality for:
 //! - Schema diffing between Prax schema definitions and database state
 //! - SQL migration generation for PostgreSQL, MySQL, SQLite, MSSQL, and DuckDB
+//! - CQL migration generation for ScyllaDB (via MigrationDialect trait)
 //! - Migration file management on the filesystem
 //! - **Event sourcing** for complete migration audit trails
 //! - Migration history tracking with immutable event log

--- a/prax-migrate/src/lib.rs
+++ b/prax-migrate/src/lib.rs
@@ -149,6 +149,7 @@
 //! ```
 
 pub mod bootstrap;
+pub mod cql;
 pub mod dialect;
 pub mod diff;
 pub mod engine;
@@ -166,6 +167,7 @@ pub mod state;
 
 // Re-exports
 pub use bootstrap::Bootstrap;
+pub use cql::MigrationCql;
 pub use dialect::{MigrationDialect, SqlDialect};
 pub use diff::{
     EnumAlterDiff, EnumDiff, ExtensionDiff, FieldAlterDiff, FieldDiff, ForeignKeyDiff, IndexDiff,

--- a/prax-migrate/src/lib.rs
+++ b/prax-migrate/src/lib.rs
@@ -169,8 +169,9 @@ pub mod state;
 pub use bootstrap::Bootstrap;
 pub use cql::{
     ClusteringKey, ClusteringOrder, CompactionStrategy, CqlFieldAlterDiff, CqlFieldDiff,
-    CqlIndexDiff, CqlIndexType, CqlSchemaDiff, CqlTableAlterDiff, CqlTableDiff, KeyspaceConfig,
-    MaterializedViewDiff, MigrationCql, ReplicationStrategy, UdtAlterDiff, UdtDiff, UdtField,
+    CqlIndexDiff, CqlIndexType, CqlMigrationGenerator, CqlSchemaDiff, CqlTableAlterDiff,
+    CqlTableDiff, KeyspaceConfig, MaterializedViewDiff, MigrationCql, ReplicationStrategy,
+    UdtAlterDiff, UdtDiff, UdtField,
 };
 pub use dialect::{MigrationDialect, SqlDialect};
 pub use diff::{

--- a/prax-migrate/src/lib.rs
+++ b/prax-migrate/src/lib.rs
@@ -149,6 +149,7 @@
 //! ```
 
 pub mod bootstrap;
+pub mod dialect;
 pub mod diff;
 pub mod engine;
 pub mod error;
@@ -165,6 +166,7 @@ pub mod state;
 
 // Re-exports
 pub use bootstrap::Bootstrap;
+pub use dialect::{MigrationDialect, SqlDialect};
 pub use diff::{
     EnumAlterDiff, EnumDiff, ExtensionDiff, FieldAlterDiff, FieldDiff, ForeignKeyDiff, IndexDiff,
     ModelAlterDiff, ModelDiff, SchemaDiff, SchemaDiffer, UniqueConstraint, ViewDiff,

--- a/prax-migrate/tests/cql_migration.rs
+++ b/prax-migrate/tests/cql_migration.rs
@@ -1,0 +1,189 @@
+//! Integration tests for CQL migration support.
+
+use prax_migrate::{
+    ClusteringKey, ClusteringOrder, CompactionStrategy, CqlDialect, CqlFieldDiff, CqlIndexDiff,
+    CqlIndexType, CqlMigrationGenerator, CqlSchemaDiff, CqlTableDiff, KeyspaceConfig,
+    MaterializedViewDiff, MigrationDialect, ReplicationStrategy, UdtDiff, UdtField,
+};
+
+fn field(name: &str, cql_type: &str) -> CqlFieldDiff {
+    CqlFieldDiff {
+        name: name.into(),
+        cql_type: cql_type.into(),
+        is_static: false,
+    }
+}
+
+#[test]
+fn test_cql_full_workflow_keyspace_udt_table_index_view() {
+    let mut diff = CqlSchemaDiff {
+        keyspace_context: Some("myapp".into()),
+        ..Default::default()
+    };
+
+    diff.create_keyspace = Some(KeyspaceConfig {
+        name: "myapp".into(),
+        replication: ReplicationStrategy::Simple { factor: 3 },
+        durable_writes: true,
+    });
+
+    diff.create_udts.push(UdtDiff {
+        name: "order_status".into(),
+        fields: vec![UdtField {
+            name: "value".into(),
+            cql_type: "text".into(),
+        }],
+    });
+
+    diff.create_tables.push(CqlTableDiff {
+        name: "events".into(),
+        fields: vec![
+            field("tenant_id", "uuid"),
+            field("event_time", "timestamp"),
+            field("event_id", "uuid"),
+            field("payload", "text"),
+            field("status", "frozen<\"order_status\">"),
+        ],
+        partition_keys: vec!["tenant_id".into()],
+        clustering_keys: vec![
+            ClusteringKey {
+                name: "event_time".into(),
+                order: ClusteringOrder::Desc,
+            },
+            ClusteringKey {
+                name: "event_id".into(),
+                order: ClusteringOrder::Asc,
+            },
+        ],
+        compaction: Some(CompactionStrategy::TimeWindow {
+            window_unit: "DAYS".into(),
+            window_size: 1,
+        }),
+        default_ttl: Some(2592000),
+    });
+
+    diff.create_indexes.push(CqlIndexDiff {
+        name: "events_status_idx".into(),
+        table_name: "events".into(),
+        column: "status".into(),
+        index_type: CqlIndexType::Secondary,
+    });
+
+    diff.create_materialized_views.push(MaterializedViewDiff {
+        name: "events_by_status".into(),
+        base_table: "events".into(),
+        select_columns: vec!["*".into()],
+        where_clause: "status IS NOT NULL AND tenant_id IS NOT NULL AND event_time IS NOT NULL AND event_id IS NOT NULL".into(),
+        partition_keys: vec!["status".into()],
+        clustering_keys: vec![
+            ClusteringKey {
+                name: "tenant_id".into(),
+                order: ClusteringOrder::Asc,
+            },
+            ClusteringKey {
+                name: "event_time".into(),
+                order: ClusteringOrder::Desc,
+            },
+            ClusteringKey {
+                name: "event_id".into(),
+                order: ClusteringOrder::Asc,
+            },
+        ],
+    });
+
+    let migration = CqlMigrationGenerator::new().generate(&diff);
+
+    // Ordering check: keyspace first, then UDT, then table, then index, then view
+    let ks_pos = migration.up.find("CREATE KEYSPACE").expect("keyspace missing");
+    let udt_pos = migration.up.find("CREATE TYPE").expect("UDT missing");
+    let tbl_pos = migration.up.find("CREATE TABLE").expect("table missing");
+    let idx_pos = migration.up.find("CREATE INDEX").expect("index missing");
+    let mv_pos = migration
+        .up
+        .find("CREATE MATERIALIZED VIEW")
+        .expect("MV missing");
+
+    assert!(ks_pos < udt_pos);
+    assert!(udt_pos < tbl_pos);
+    assert!(tbl_pos < idx_pos);
+    assert!(idx_pos < mv_pos);
+
+    // Keyspace context applied to names
+    assert!(migration.up.contains("CREATE TABLE \"myapp\".\"events\""));
+    assert!(migration.up.contains("CREATE TYPE \"myapp\".\"order_status\""));
+
+    // No warnings for pure creation
+    assert!(migration.warnings.is_empty());
+}
+
+#[test]
+fn test_cql_down_reverses_dependency_order() {
+    let mut diff = CqlSchemaDiff::default();
+    diff.create_keyspace = Some(KeyspaceConfig {
+        name: "myapp".into(),
+        replication: ReplicationStrategy::Simple { factor: 1 },
+        durable_writes: true,
+    });
+    diff.create_udts.push(UdtDiff {
+        name: "my_type".into(),
+        fields: vec![UdtField {
+            name: "v".into(),
+            cql_type: "int".into(),
+        }],
+    });
+    diff.create_tables.push(CqlTableDiff {
+        name: "t".into(),
+        fields: vec![field("id", "uuid")],
+        partition_keys: vec!["id".into()],
+        clustering_keys: vec![],
+        compaction: None,
+        default_ttl: None,
+    });
+
+    let migration = CqlMigrationGenerator::new().generate(&diff);
+
+    // Down order should be: DROP TABLE, DROP TYPE, DROP KEYSPACE
+    let drop_tbl = migration.down.find("DROP TABLE").expect("DROP TABLE missing");
+    let drop_type = migration.down.find("DROP TYPE").expect("DROP TYPE missing");
+    let drop_ks = migration
+        .down
+        .find("DROP KEYSPACE")
+        .expect("DROP KEYSPACE missing");
+    assert!(drop_tbl < drop_type);
+    assert!(drop_type < drop_ks);
+}
+
+#[test]
+fn test_cql_dialect_trait_produces_same_output_as_generator() {
+    let mut diff = CqlSchemaDiff::default();
+    diff.create_tables.push(CqlTableDiff {
+        name: "t".into(),
+        fields: vec![field("id", "uuid")],
+        partition_keys: vec!["id".into()],
+        clustering_keys: vec![],
+        compaction: None,
+        default_ttl: None,
+    });
+
+    let via_trait = CqlDialect::generate(&diff);
+    let via_direct = CqlMigrationGenerator::new().generate(&diff);
+
+    assert_eq!(via_trait.up, via_direct.up);
+    assert_eq!(via_trait.down, via_direct.down);
+    assert_eq!(via_trait.warnings, via_direct.warnings);
+}
+
+#[test]
+fn test_cql_destructive_operations_generate_warnings() {
+    let mut diff = CqlSchemaDiff::default();
+    diff.drop_tables.push("legacy".into());
+    diff.drop_udts.push("old_type".into());
+    diff.drop_keyspace = Some("old_app".into());
+
+    let migration = CqlMigrationGenerator::new().generate(&diff);
+
+    assert_eq!(migration.warnings.len(), 3);
+    assert!(migration.warnings.iter().any(|w| w.contains("legacy")));
+    assert!(migration.warnings.iter().any(|w| w.contains("old_type")));
+    assert!(migration.warnings.iter().any(|w| w.contains("old_app")));
+}

--- a/prax-migrate/tests/cql_migration.rs
+++ b/prax-migrate/tests/cql_migration.rs
@@ -94,7 +94,10 @@ fn test_cql_full_workflow_keyspace_udt_table_index_view() {
     let migration = CqlMigrationGenerator::new().generate(&diff);
 
     // Ordering check: keyspace first, then UDT, then table, then index, then view
-    let ks_pos = migration.up.find("CREATE KEYSPACE").expect("keyspace missing");
+    let ks_pos = migration
+        .up
+        .find("CREATE KEYSPACE")
+        .expect("keyspace missing");
     let udt_pos = migration.up.find("CREATE TYPE").expect("UDT missing");
     let tbl_pos = migration.up.find("CREATE TABLE").expect("table missing");
     let idx_pos = migration.up.find("CREATE INDEX").expect("index missing");
@@ -110,7 +113,11 @@ fn test_cql_full_workflow_keyspace_udt_table_index_view() {
 
     // Keyspace context applied to names
     assert!(migration.up.contains("CREATE TABLE \"myapp\".\"events\""));
-    assert!(migration.up.contains("CREATE TYPE \"myapp\".\"order_status\""));
+    assert!(
+        migration
+            .up
+            .contains("CREATE TYPE \"myapp\".\"order_status\"")
+    );
 
     // No warnings for pure creation
     assert!(migration.warnings.is_empty());
@@ -143,7 +150,10 @@ fn test_cql_down_reverses_dependency_order() {
     let migration = CqlMigrationGenerator::new().generate(&diff);
 
     // Down order should be: DROP TABLE, DROP TYPE, DROP KEYSPACE
-    let drop_tbl = migration.down.find("DROP TABLE").expect("DROP TABLE missing");
+    let drop_tbl = migration
+        .down
+        .find("DROP TABLE")
+        .expect("DROP TABLE missing");
     let drop_type = migration.down.find("DROP TYPE").expect("DROP TYPE missing");
     let drop_ks = migration
         .down


### PR DESCRIPTION
## Summary

Adds ScyllaDB/CQL migration support to prax-migrate via a new `MigrationDialect` trait that abstracts the migration output over database dialects.

- **MigrationDialect trait** with `SqlDialect` (existing PostgreSQL/MySQL/SQLite/MSSQL/DuckDB behavior) and `CqlDialect` (new ScyllaDB path)
- **CqlSchemaDiff** with keyspaces, UDTs, tables with partition/clustering keys, materialized views, secondary indexes, and compaction/TTL
- **CqlMigrationGenerator** with full CQL statement generation — CREATE KEYSPACE (SimpleStrategy / NetworkTopology), CREATE TYPE, CREATE TABLE (with static columns + compound keys + compaction + TTL), ALTER TABLE (ADD/DROP/TYPE), CREATE INDEX (Secondary/SASI/Custom), CREATE MATERIALIZED VIEW
- **Keyspace-aware qualified naming** via `keyspace_context` field
- **Loud warnings** for unsupported in-place changes (partition key changes, clustering key changes, UDT field drops) and data-loss operations

## Changes

**16 commits across 6 phases:**

1. **Trait foundation** (Tasks 1-5): `MigrationDialect` trait, `SqlDialect`, `CqlDialect`, `CqlSchemaDiff`, `MigrationCql`, generator skeleton
2. **Keyspace + UDT** (Tasks 6-7): CREATE/DROP KEYSPACE, UDT create/drop/alter
3. **Tables** (Tasks 8-9): CREATE TABLE with full options, ALTER TABLE with warnings
4. **Schema objects** (Tasks 10-11): Secondary indexes, materialized views
5. **Testing + example** (Tasks 12-14): Snapshot test for SqlDialect parity, integration tests, runnable example
6. **Polish** (Tasks 15-16): Module docs, version bump to 0.7.2

## Test plan

- [x] 25 unit tests pass for CqlMigrationGenerator
- [x] 4 integration tests pass (ordering, down reversal, trait equivalence, warnings)
- [x] 7 dialect tests (3 SQL + 3 CQL + 1 snapshot parity test)
- [x] 181 existing prax-migrate tests unchanged (baseline preserved)
- [x] 17 CLI tests pass with v0.7.2 assertions
- [x] `cargo build --workspace` clean
- [x] `cargo run --example cql_migration -p prax-migrate` produces valid CQL
- [ ] CI passes

## Architectural note

This PR introduces `MigrationDialect` as a foundation but does NOT generalize `MigrationEngine<D>` or `MigrationEventStore<D>`. That refactor is scoped to a follow-up PR. The current `MigrationDialect::event_log_table()` method is forward-positioned to support that work (`_prax_migrations` for SQL, `_prax_cql_migrations` for CQL).

## Spec

Design doc: `docs/superpowers/specs/2026-04-26-scylladb-migrations-design.md`
Implementation plan: `docs/superpowers/plans/2026-04-26-scylladb-migrations.md`