### PR TITLE
ci(benchmarks): skip regression check on PRs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -23,6 +23,11 @@ jobs:
   benchmark-regression:
     name: Benchmark Regression Check
     runs-on: ubuntu-latest
+    # Skip on pull_request — a full baseline save + compare run took
+    # ~98 minutes on #85 and was the long pole holding every merge.
+    # The job still runs on push to main/develop (to update the shared
+    # baseline) and on manual dispatch for ad-hoc regression checks.
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

- The Benchmark Regression Check job took **~98 minutes** on #85 (80m first bench run + 18m compare-pass that re-runs the whole suite).
- Gate the job on `github.event_name != 'pull_request'` so it no longer runs on every PR.
- Still runs on pushes to main/develop (keeps the shared baseline fresh) and on manual dispatch (ad-hoc regression checks).

## Test plan

- [ ] Opening this PR should NOT trigger the `Benchmark Regression Check` job.
- [ ] Merging to develop should trigger it (via the `push` event).
- [ ] The other three benchmark jobs (throughput / memory / async) still run on PRs — they're single-pass summaries, not the slow double-run.