### PR TITLE
feat(cli): wire prax generate output to the runtime (FromRow + ModelWithPk + Client<E>)

### DIFF
--- a/prax-cli/src/commands/generate.rs
+++ b/prax-cli/src/commands/generate.rs
@@ -275,15 +275,12 @@ fn generate_client_module(
         let snake_name = to_snake_case(model.name());
         code.push_str(&format!("    /// Access {} operations\n", model.name()));
         code.push_str(&format!(
-            "    pub fn {}(&self) -> {}::{}Operations<E> {{\n",
-            snake_name,
-            snake_name,
-            model.name()
+            "    pub fn {}(&self) -> {}::Client<E> {{\n",
+            snake_name, snake_name,
         ));
         code.push_str(&format!(
-            "        {}::{}Operations::new(self.engine.clone())\n",
+            "        {}::Client::new(self.engine.clone())\n",
             snake_name,
-            model.name()
         ));
         code.push_str("    }\n\n");
     }
@@ -389,80 +386,166 @@ fn generate_model_module(
     ));
     code.push_str("}\n\n");
 
-    // Operations struct (owned engine, no lifetime)
-    code.push_str("#[allow(dead_code)]\n");
-    code.push_str(&format!("/// Operations for the {} model\n", model.name()));
+    // FromRow — required to decode rows back into the model when an
+    // operation is run. Mirrors the emission in
+    // `prax-codegen/src/generators/derive_from_row.rs`: scalar fields
+    // decode via `FromColumn`; relation fields default-init and are
+    // filled later by the relation executor on the `.include` path.
     code.push_str(&format!(
-        "pub struct {}Operations<E: prax_query::QueryEngine> {{\n",
+        "impl prax_query::row::FromRow for {} {{\n",
         model.name()
     ));
+    code.push_str(
+        "    fn from_row(row: &impl prax_query::row::RowRef)\n        -> Result<Self, prax_query::row::RowError>\n    {\n",
+    );
+    code.push_str("        Ok(Self {\n");
+    for field in model.fields.values() {
+        let field_name = to_snake_case(field.name());
+        let rust_type = field_type_to_rust_with_boxing(
+            &field.field_type,
+            field.modifier,
+            model.name(),
+            relation_graph,
+        );
+        if field.is_relation() {
+            code.push_str(&format!(
+                "            {}: ::core::default::Default::default(),\n",
+                field_name
+            ));
+        } else {
+            let column = field
+                .get_attribute("map")
+                .and_then(|a| a.first_arg())
+                .and_then(|v| v.as_string())
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| field_name.clone());
+            code.push_str(&format!(
+                "            {}: <{} as prax_query::row::FromColumn>::from_column(row, \"{}\")?,\n",
+                field_name, rust_type, column
+            ));
+        }
+    }
+    code.push_str("        })\n");
+    code.push_str("    }\n");
+    code.push_str("}\n\n");
+
+    // ModelWithPk — required by composite-key handling and by operations
+    // that need to extract the primary key from a model instance (e.g.
+    // upsert, nested writes). Mirrors
+    // `prax-codegen/src/generators/derive_model_with_pk.rs`.
+    code.push_str(&format!(
+        "impl prax_query::traits::ModelWithPk for {} {{\n",
+        model.name()
+    ));
+    code.push_str("    fn pk_value(&self) -> prax_query::filter::FilterValue {\n");
+    let id_field_objs: Vec<_> = model.id_fields();
+    if id_field_objs.len() == 1 {
+        let f = id_field_objs[0];
+        code.push_str(&format!(
+            "        <{} as prax_query::filter::ToFilterValue>::to_filter_value(&self.{})\n",
+            field_type_to_rust_with_boxing(&f.field_type, f.modifier, model.name(), relation_graph),
+            to_snake_case(f.name())
+        ));
+    } else if id_field_objs.is_empty() {
+        code.push_str("        prax_query::filter::FilterValue::Null\n");
+    } else {
+        code.push_str("        prax_query::filter::FilterValue::List(vec![\n");
+        for f in &id_field_objs {
+            code.push_str(&format!(
+                "            <{} as prax_query::filter::ToFilterValue>::to_filter_value(&self.{}),\n",
+                field_type_to_rust_with_boxing(&f.field_type, f.modifier, model.name(), relation_graph),
+                to_snake_case(f.name())
+            ));
+        }
+        code.push_str("        ])\n");
+    }
+    code.push_str("    }\n\n");
+
+    code.push_str(
+        "    fn get_column_value(&self, column: &str)\n        -> ::core::option::Option<prax_query::filter::FilterValue>\n    {\n",
+    );
+    code.push_str("        match column {\n");
+    for field in model.scalar_fields() {
+        let field_name = to_snake_case(field.name());
+        let column = field
+            .get_attribute("map")
+            .and_then(|a| a.first_arg())
+            .and_then(|v| v.as_string())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| field_name.clone());
+        let rust_type = field_type_to_rust_with_boxing(
+            &field.field_type,
+            field.modifier,
+            model.name(),
+            relation_graph,
+        );
+        code.push_str(&format!(
+            "            \"{}\" => ::core::option::Option::Some(\n                <{} as prax_query::filter::ToFilterValue>::to_filter_value(&self.{})\n            ),\n",
+            column, rust_type, field_name
+        ));
+    }
+    code.push_str("            _ => ::core::option::Option::None,\n");
+    code.push_str("        }\n");
+    code.push_str("    }\n");
+    code.push_str("}\n\n");
+
+    // Per-model `Client<E>` (named `Client`, not `{Model}Operations`, so
+    // `prax::client!(Foo, Bar, ...)` can find `foo::Client::new(...)`
+    // and `bar::Client::new(...)` by snake-cased module path — matching
+    // the shape emitted by `#[derive(Model)]`).
+    code.push_str("#[allow(dead_code)]\n");
+    code.push_str(&format!("/// Operations for the {} model\n", model.name()));
+    code.push_str("pub struct Client<E: prax_query::QueryEngine> {\n");
     code.push_str("    engine: E,\n");
     code.push_str("}\n\n");
 
-    code.push_str(&format!(
-        "impl<E: prax_query::QueryEngine> {}Operations<E> {{\n",
-        model.name()
-    ));
+    code.push_str("impl<E: prax_query::QueryEngine> Client<E> {\n");
     code.push_str("    pub fn new(engine: E) -> Self {\n");
     code.push_str("        Self { engine }\n");
     code.push_str("    }\n\n");
 
-    // CRUD methods (1-arg constructors, no lifetime on return types)
-    code.push_str("    /// Find many records\n");
-    code.push_str(&format!(
-        "    pub fn find_many(&self) -> prax_query::FindManyOperation<E, {}> {{\n",
-        model.name()
-    ));
-    code.push_str("        prax_query::FindManyOperation::new(self.engine.clone())\n");
-    code.push_str("    }\n\n");
-
-    code.push_str("    /// Find a unique record\n");
-    code.push_str(&format!(
-        "    pub fn find_unique(&self) -> prax_query::FindUniqueOperation<E, {}> {{\n",
-        model.name()
-    ));
-    code.push_str("        prax_query::FindUniqueOperation::new(self.engine.clone())\n");
-    code.push_str("    }\n\n");
-
-    code.push_str("    /// Find the first matching record\n");
-    code.push_str(&format!(
-        "    pub fn find_first(&self) -> prax_query::FindFirstOperation<E, {}> {{\n",
-        model.name()
-    ));
-    code.push_str("        prax_query::FindFirstOperation::new(self.engine.clone())\n");
-    code.push_str("    }\n\n");
-
-    code.push_str("    /// Create a new record\n");
-    code.push_str(&format!(
-        "    pub fn create(&self) -> prax_query::CreateOperation<E, {}> {{\n",
-        model.name()
-    ));
-    code.push_str("        prax_query::CreateOperation::new(self.engine.clone())\n");
-    code.push_str("    }\n\n");
-
-    code.push_str("    /// Update a record\n");
-    code.push_str(&format!(
-        "    pub fn update(&self) -> prax_query::UpdateOperation<E, {}> {{\n",
-        model.name()
-    ));
-    code.push_str("        prax_query::UpdateOperation::new(self.engine.clone())\n");
-    code.push_str("    }\n\n");
-
-    code.push_str("    /// Delete a record\n");
-    code.push_str(&format!(
-        "    pub fn delete(&self) -> prax_query::DeleteOperation<E, {}> {{\n",
-        model.name()
-    ));
-    code.push_str("        prax_query::DeleteOperation::new(self.engine.clone())\n");
-    code.push_str("    }\n\n");
-
-    code.push_str("    /// Count records\n");
-    code.push_str(&format!(
-        "    pub fn count(&self) -> prax_query::CountOperation<E, {}> {{\n",
-        model.name()
-    ));
-    code.push_str("        prax_query::CountOperation::new(self.engine.clone())\n");
-    code.push_str("    }\n");
+    let model_ty = model.name();
+    let crud_methods: &[(&str, &str, &str)] = &[
+        ("find_many", "FindManyOperation", "Find many records"),
+        ("find_unique", "FindUniqueOperation", "Find a unique record"),
+        (
+            "find_first",
+            "FindFirstOperation",
+            "Find the first matching record",
+        ),
+        ("create", "CreateOperation", "Create a new record"),
+        (
+            "create_many",
+            "CreateManyOperation",
+            "Create many records in one operation",
+        ),
+        ("update", "UpdateOperation", "Update a record"),
+        (
+            "update_many",
+            "UpdateManyOperation",
+            "Update many records matching a filter",
+        ),
+        ("upsert", "UpsertOperation", "Insert or update a record"),
+        ("delete", "DeleteOperation", "Delete a record"),
+        (
+            "delete_many",
+            "DeleteManyOperation",
+            "Delete many records matching a filter",
+        ),
+        ("count", "CountOperation", "Count records"),
+    ];
+    for (method, op_ty, doc) in crud_methods {
+        code.push_str(&format!("    /// {}\n", doc));
+        code.push_str(&format!(
+            "    pub fn {}(&self) -> prax_query::operations::{}<E, {}> {{\n",
+            method, op_ty, model_ty,
+        ));
+        code.push_str(&format!(
+            "        prax_query::operations::{}::new(self.engine.clone())\n",
+            op_ty,
+        ));
+        code.push_str("    }\n\n");
+    }
 
     code.push_str("}\n");
 

--- a/prax-cli/src/commands/generate.rs
+++ b/prax-cli/src/commands/generate.rs
@@ -779,28 +779,23 @@ fn field_type_to_rust_with_boxing(
 ) -> String {
     use prax_schema::ast::{FieldType, TypeModifier};
 
-    // For model references (non-list), check if boxing is needed to break cycles
+    // For model references (non-list), check if boxing is needed to break cycles.
+    // Non-list relations are always emitted as `Option<T>` regardless of the
+    // schema's required/optional modifier: the relation is "not loaded" until
+    // `.include` populates it, so the Rust struct must allow representing the
+    // un-included state. This also gives the field a `Default::default()`
+    // (== `None`), which `FromRow` relies on to construct a row that hasn't
+    // been join-decoded yet. The schema-level required-ness is a database
+    // constraint enforced by FK + NOT NULL, not a Rust struct invariant.
     if let FieldType::Model(target) = field_type
         && !matches!(modifier, TypeModifier::List)
     {
         let should_box = needs_boxing(source_model, target, relation_graph);
         let base = target.to_string();
-        return match modifier {
-            TypeModifier::Optional | TypeModifier::OptionalList => {
-                if should_box {
-                    format!("Option<Box<{}>>", base)
-                } else {
-                    format!("Option<{}>", base)
-                }
-            }
-            TypeModifier::Required => {
-                if should_box {
-                    format!("Box<{}>", base)
-                } else {
-                    base
-                }
-            }
-            TypeModifier::List => unreachable!(),
+        return if should_box {
+            format!("Option<Box<{}>>", base)
+        } else {
+            format!("Option<{}>", base)
         };
     }
 

--- a/prax-cli/tests/cli_tests.rs
+++ b/prax-cli/tests/cli_tests.rs
@@ -254,3 +254,86 @@ fn test_global_options() {
         .success()
         .stdout(predicate::str::contains("0.8.0"));
 }
+
+/// `prax generate` must emit the trait impls the runtime needs to round-trip
+/// rows back into model structs (`FromRow`) and to extract primary key /
+/// column values from a model instance (`ModelWithPk`). The per-model
+/// operations struct must also be named `Client<E>` so the
+/// `prax::client!(...)` macro can find `<snake_name>::Client<E>` by path
+/// — same convention as the `#[derive(Model)]` path. Without these the
+/// generated code compiles but cannot decode rows or be wired into the
+/// `client!` macro, which is the gap this test guards.
+#[test]
+fn test_generate_emits_runtime_trait_impls_and_client_struct() {
+    let temp_dir = TempDir::new().unwrap();
+    let schema_path = temp_dir.path().join("schema.prax");
+    let schema_content = r#"
+datasource db {
+  provider = "postgresql"
+  url = "postgres://localhost/test"
+}
+
+model User {
+  id    Int    @id @auto
+  email String @unique
+  name  String
+}
+"#;
+    fs::write(&schema_path, schema_content).unwrap();
+
+    let output_dir = temp_dir.path().join("out");
+    prax_cmd()
+        .args([
+            "generate",
+            "--schema",
+            schema_path.to_str().unwrap(),
+            "--output",
+            output_dir.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let user_module = fs::read_to_string(output_dir.join("user.rs")).expect("user.rs not emitted");
+
+    // FromRow impl present and uses FromColumn to decode each scalar field.
+    assert!(
+        user_module.contains("impl prax_query::row::FromRow for User"),
+        "user.rs missing FromRow impl:\n{user_module}"
+    );
+    assert!(
+        user_module.contains("FromColumn>::from_column(row, \"email\")"),
+        "user.rs FromRow does not decode email column:\n{user_module}"
+    );
+
+    // ModelWithPk impl present with pk_value and get_column_value.
+    assert!(
+        user_module.contains("impl prax_query::traits::ModelWithPk for User"),
+        "user.rs missing ModelWithPk impl:\n{user_module}"
+    );
+    assert!(
+        user_module.contains("fn pk_value(&self)"),
+        "user.rs ModelWithPk missing pk_value:\n{user_module}"
+    );
+    assert!(
+        user_module.contains("fn get_column_value(&self, column: &str)"),
+        "user.rs ModelWithPk missing get_column_value:\n{user_module}"
+    );
+
+    // Operations struct is named `Client<E>` (not `UserOperations<E>`) so
+    // `prax::client!` can dispatch via `user::Client::new(...)`.
+    assert!(
+        user_module.contains("pub struct Client<E: prax_query::QueryEngine>"),
+        "user.rs missing per-model Client<E> struct:\n{user_module}"
+    );
+    assert!(
+        !user_module.contains("UserOperations"),
+        "user.rs still emits the legacy UserOperations<E> name:\n{user_module}"
+    );
+
+    // The top-level client accessor must call `user::Client::new(...)`.
+    let mod_rs = fs::read_to_string(output_dir.join("mod.rs")).expect("mod.rs not emitted");
+    assert!(
+        mod_rs.contains("user::Client::new(self.engine.clone())"),
+        "mod.rs accessor not routed through user::Client:\n{mod_rs}"
+    );
+}


### PR DESCRIPTION
## Summary

The schema-first `prax generate` CLI emitted only `Model` trait impls and a per-model `{Name}Operations<E>` struct. Generated code typechecked, but couldn't actually run a query: the operation builders need `FromRow` to decode rows back into the model, `ModelWithPk` to extract primary-key / column values for updates and nested writes, and the operations struct has to be named `Client<E>` so `prax::client!(User, Post, …)` can resolve `<snake_name>::Client<E>` by path the same way it does for the `#[derive(Model)]` path.

This PR mirrors the proc-macro generators directly:

- **`FromRow`** — decodes each scalar field via `FromColumn::from_column(row, "<column>")?` and default-initializes relation fields. Mirrors `prax-codegen/src/generators/derive_from_row.rs`.
- **`ModelWithPk`** — routes single id fields through `ToFilterValue` and collapses composite ids into `FilterValue::List`; `get_column_value` dispatches by `@map`-aware column name. Mirrors `prax-codegen/src/generators/derive_model_with_pk.rs`.
- **`Client<E>`** — per-model struct renamed from `{Name}Operations<E>` to `Client<E>`, gains the operation builders that were missing (`create_many`, `update_many`, `upsert`, `delete_many`) so the generated client matches the surface emitted by the derive path.
- **Top-level accessor** — `PraxClient<E>::user(&self) -> user::Client<E>` now calls `user::Client::new(self.engine.clone())`.

> Note: this PR currently shows the in-flight `bugfix/sql-generator-fk-ordering` commits as well. They drop out of the diff automatically once #89 lands — base will narrow to just the codegen commit.

## Test plan

- [x] New integration test `test_generate_emits_runtime_trait_impls_and_client_struct` in `prax-cli/tests/cli_tests.rs` — runs `prax generate` against a small schema, reads the emitted module, asserts the FromRow impl, the ModelWithPk impl, the `Client<E>` struct, and that the parent module routes its accessor through `user::Client::new`. Without this guard the regression is silent — generated code still compiles but cannot round-trip rows.
- [x] Full `cargo test -p prax-orm-cli` suite passes (18 tests).
- [x] husky pre-push gate (full build + workspace tests + doctests + docs) passed before push.
- [ ] CI green (will fire when this PR lands).