### PR TITLE
feat(query): typed input traits + capability gates (phase 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4812,6 +4812,7 @@ name = "prax-query"
 version = "0.9.7"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "bson",
  "bumpalo",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,9 @@ scylla = "0.14"
 # Apache Cassandra driver (pure Rust)
 cdrs-tokio = "9.0"
 
+# Base64 encoding/decoding
+base64 = "0.22"
+
 # Decimal type
 rust_decimal = { version = "1.37", features = ["serde"] }
 

--- a/docs/superpowers/plans/2026-05-18-typed-inputs-runtime-traits.md
+++ b/docs/superpowers/plans/2026-05-18-typed-inputs-runtime-traits.md
@@ -1937,7 +1937,7 @@ wire."
 - Create: `prax-query/tests/inputs_relation.rs`
 
 `ListRelationFilter<W>` and `SingleRelationFilter<W>` lower to
-`Filter::ScalarSubquery` via a per-relation `RelationMeta` adapter that
+`Filter::ScalarSubquery` via a per-relation `RelationFilterMeta` adapter that
 phase 2's codegen will supply. Phase 1 introduces the wrappers and a
 hand-built adapter trait used in tests.
 
@@ -1948,7 +1948,7 @@ Create `prax-query/tests/inputs_relation.rs`:
 ```rust
 use prax_query::filter::{Filter, FilterValue};
 use prax_query::inputs::{
-    relation::{LowerRelationFilter, RelationMeta, ListRelationFilter, SingleRelationFilter},
+    relation::{LowerRelationFilter, RelationFilterMeta, ListRelationFilter, SingleRelationFilter},
     StringFilter, WhereInput,
 };
 use prax_query::traits::Model;
@@ -1978,7 +1978,7 @@ impl WhereInput for PostWhereInput {
 
 // Hand-built relation meta for `User.posts` so we don't need the codegen.
 struct UserPostsMeta;
-impl RelationMeta for UserPostsMeta {
+impl RelationFilterMeta for UserPostsMeta {
     const PARENT_TABLE: &'static str = "users";
     const PARENT_PK: &'static str = "id";
     const CHILD_TABLE: &'static str = "posts";
@@ -2072,17 +2072,20 @@ Create `prax-query/src/inputs/relation.rs`:
 //! `ListRelationFilter<W>` and `SingleRelationFilter<W>` carry the
 //! Prisma operator shape (`some`/`every`/`none` for to-many;
 //! `is`/`is_not` for to-one). They lower to [`Filter::ScalarSubquery`]
-//! fragments via a per-relation [`RelationMeta`] adapter that codegen
+//! fragments via a per-relation [`RelationFilterMeta`] adapter that codegen
 //! emits (phase 2) but tests / hand-built users can supply directly.
 
 use crate::filter::{Filter, FilterValue};
 use crate::inputs::traits::WhereInput;
 
-/// Static metadata for one parent→child relation.
+/// Static metadata for one parent→child relation, used when lowering
+/// relation filters to EXISTS / NOT EXISTS subqueries.
 ///
 /// Phase 2 codegen emits one impl per relation declared in the schema.
 /// Hand-rolled callers can implement this trait themselves.
-pub trait RelationMeta {
+///
+/// Distinct from `crate::relations::RelationMeta`, which carries runtime-loader metadata.
+pub trait RelationFilterMeta {
     /// Parent SQL table name.
     const PARENT_TABLE: &'static str;
     /// Parent primary-key column name.
@@ -2116,14 +2119,14 @@ pub struct SingleRelationFilter<W> {
 }
 
 /// Lowering helper: produces `Filter::ScalarSubquery` from a relation
-/// filter + `RelationMeta`.
+/// filter + [`RelationFilterMeta`].
 ///
 /// Implemented blanket-style for any `W: WhereInput` so neither the
 /// codegen nor the macro layer needs to manually thread metadata.
 pub trait LowerRelationFilter {
     /// Lower this relation filter to a runtime [`Filter`] using the
     /// supplied metadata.
-    fn lower<M: RelationMeta>(self) -> Filter;
+    fn lower<M: RelationFilterMeta>(self) -> Filter;
 }
 
 fn render_inline_filter(
@@ -2250,7 +2253,7 @@ fn render_inline_filter(
 }
 
 impl<W: WhereInput> LowerRelationFilter for ListRelationFilter<W> {
-    fn lower<M: RelationMeta>(self) -> Filter {
+    fn lower<M: RelationFilterMeta>(self) -> Filter {
         let mut clauses: Vec<Filter> = Vec::new();
         if let Some(w) = self.some {
             let inner = w.into_ir();
@@ -2294,7 +2297,7 @@ impl<W: WhereInput> LowerRelationFilter for ListRelationFilter<W> {
 }
 
 impl<W: WhereInput> LowerRelationFilter for SingleRelationFilter<W> {
-    fn lower<M: RelationMeta>(self) -> Filter {
+    fn lower<M: RelationFilterMeta>(self) -> Filter {
         let mut clauses: Vec<Filter> = Vec::new();
         if let Some(w) = self.is {
             let inner = w.into_ir();
@@ -2340,9 +2343,9 @@ git commit -m "feat(query): add relation filter wrappers + EXISTS/NOT EXISTS low
 
 ListRelationFilter (some/every/none) and SingleRelationFilter
 (is/is_not) lower to Filter::ScalarSubquery via a per-relation
-RelationMeta adapter. Phase 1 supplies a hand-rolled inline filter
+RelationFilterMeta adapter. Phase 1 supplies a hand-rolled inline filter
 renderer scoped to the operators the scalar filters emit;
-phase 2 codegen supplies RelationMeta impls per relation."
+phase 2 codegen supplies RelationFilterMeta impls per relation."
 ```
 
 ---
@@ -3730,7 +3733,7 @@ pub use crate::inputs::{
     IntFieldUpdate, IntNullableFieldUpdate, JsonFieldUpdate, JsonNullableFieldUpdate,
     StringFieldUpdate, StringNullableFieldUpdate, UuidFieldUpdate, UuidNullableFieldUpdate,
     // Relation filters + meta.
-    relation::{ListRelationFilter, LowerRelationFilter, RelationMeta, SingleRelationFilter},
+    relation::{ListRelationFilter, LowerRelationFilter, RelationFilterMeta, SingleRelationFilter},
     // Traits.
     AggregateInput, CountSelect, CreateInput, GroupByInput, IncludeInput, OrderByInput,
     PaginationInput, SelectInput, UpdateInput, WhereInput, WhereUniqueInput,
@@ -3803,7 +3806,7 @@ The branch is ready for PR. Phase 2 (codegen of per-model input types in `prax-c
 - [ ] `prax-query/src/capabilities.rs` exposes 9 marker traits with `#[diagnostic::on_unimplemented]` messages.
 - [ ] `prax-query/src/inputs/` is structured into `traits.rs`, `scalar.rs`, `scalar_update.rs`, `relation.rs`, `args.rs`, `mod.rs`.
 - [ ] Every scalar type listed in the spec has a non-nullable + nullable filter wrapper with `into_filter(column)` lowering.
-- [ ] `ListRelationFilter` and `SingleRelationFilter` lower to `Filter::ScalarSubquery` EXISTS / NOT EXISTS fragments via `RelationMeta`.
+- [ ] `ListRelationFilter` and `SingleRelationFilter` lower to `Filter::ScalarSubquery` EXISTS / NOT EXISTS fragments via `RelationFilterMeta`.
 - [ ] Every scalar type has a `*FieldUpdate` wrapper with `From<scalar>` shortcut.
 - [ ] 13 `*Args` containers exist with the field shape promised by section 3 of the spec.
 - [ ] Every read/write/count/aggregate operation has `with_*_input` extension methods that consume the typed inputs, AND-composing where appropriate.
@@ -3816,7 +3819,7 @@ The branch is ready for PR. Phase 2 (codegen of per-model input types in `prax-c
 
 - **Spec coverage.** Phase 1 of section 8 in the spec maps to tasks 2 (Filter variant), 3 (in_transaction), 4 (capabilities), 5–11 (input types), 12–14 (ext methods), 15 (re-exports). Computed/virtual fields (spec §9), codegen (§3), macros (§4-5), and docs (§10) are out of scope for this plan and live in phase 2+.
 - **Placeholders.** Every step has either runnable commands or complete Rust source. No "TBD", no "fill in", no "similar to Task N." The `_field` skips on operations where a field doesn't yet exist are explicit, not placeholders.
-- **Type consistency.** `WhereInput::into_ir(self) -> Filter` is used uniformly across tasks 5, 6, 7, 8, 9, 12, 13, 14. `IncludeInput::into_ir(self) -> Include` is used consistently. `RelationMeta` constants are named identically across tasks 9, 10, 12. The `Args` field name `r#where` is consistent across tasks 11, 12, 13.
+- **Type consistency.** `WhereInput::into_ir(self) -> Filter` is used uniformly across tasks 5, 6, 7, 8, 9, 12, 13, 14. `IncludeInput::into_ir(self) -> Include` is used consistently. `RelationFilterMeta` constants are named identically across tasks 9, 10, 12. The `Args` field name `r#where` is consistent across tasks 11, 12, 13.
 - **YAGNI.** No phase-2+ work is preemptively wired up. The `mode: QueryMode` field is parsed but ignored at the IR level (phase 2 dialect layer consumes it). Computed/virtual field SQL emission relies on `Filter::ScalarSubquery` but the variant has no producers in this plan.
 - **TDD.** Every code-emitting task follows write-test → confirm-fail → implement → confirm-pass → commit.
 

--- a/docs/superpowers/plans/2026-05-18-typed-inputs-runtime-traits.md
+++ b/docs/superpowers/plans/2026-05-18-typed-inputs-runtime-traits.md
@@ -1,0 +1,3822 @@
+# Typed Input Traits — Runtime Foundation (Phase 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the runtime trait spine and hand-buildable input types that codegen and macros (phases 2–7) will lower onto. All new symbols live in `prax-query`; nothing else is touched. Existing fluent-builder API stays byte-for-byte unchanged.
+
+**Architecture:**
+- New module `prax-query/src/inputs/` holds the 10 input traits, every shared scalar/relation/update filter wrapper, and the per-operation `*Args` containers. Each trait has one method (`into_ir`) that lowers the input to existing runtime IR (`Filter` / `IncludeSpec` / `OrderBy` / `CreateData::Data` / `UpdateData::Data`).
+- New module `prax-query/src/capabilities.rs` holds the empty marker traits engine crates will implement later (`SupportsRelationFilter`, `SupportsNestedWrites`, etc.).
+- `Filter` gains one additive variant — `Filter::ScalarSubquery { sql, params }` — plus `#[non_exhaustive]`, so phase 5.5 (computed/virtual fields) and phase 5 (nested writes) can splice SQL fragments without further IR changes. The variant is dormant in phase 1: nothing in the workspace constructs it.
+- Each existing `*Operation` in `prax-query/src/operations/` gains additive `with_*_input` extension methods. Old fluent setters (`r#where`, `.include(...)`, ...) remain. Both styles AND-compose for `where`.
+- `QueryEngine` gains a default `in_transaction(&self) -> bool` so the nested-write executor can detect a wrapping transaction.
+
+**Tech Stack:** Rust 2024, `serde` (the input types derive `Serialize`/`Deserialize` so option 4 from the brainstorm — typed-structs-with-serde — is also satisfied for free), `chrono`, `uuid`, `rust_decimal`, `serde_json` (already direct deps of `prax-query`).
+
+---
+
+## File Structure
+
+### New files (all in `prax-query/`)
+
+- `prax-query/src/inputs/mod.rs` — module root, re-exports
+- `prax-query/src/inputs/traits.rs` — the 10 input traits
+- `prax-query/src/inputs/scalar.rs` — `QueryMode` + `StringFilter`, `IntFilter`, etc. and their nullable variants
+- `prax-query/src/inputs/scalar_update.rs` — `StringFieldUpdate`, `IntFieldUpdate`, etc. and nullable variants
+- `prax-query/src/inputs/relation.rs` — `ListRelationFilter<W>`, `SingleRelationFilter<W>`
+- `prax-query/src/inputs/args.rs` — `FindManyArgs`, `FindUniqueArgs`, `FindFirstArgs`, `CreateArgs`, `CreateManyArgs`, `UpdateArgs`, `UpdateManyArgs`, `DeleteArgs`, `DeleteManyArgs`, `UpsertArgs`, `CountArgs`, `AggregateArgs`, `GroupByArgs`
+- `prax-query/src/capabilities.rs` — marker traits
+- `prax-query/tests/inputs_scalar.rs` — unit tests for scalar filter lowering
+- `prax-query/tests/inputs_relation.rs` — unit tests for relation filter lowering
+- `prax-query/tests/inputs_update.rs` — unit tests for scalar update wrappers
+- `prax-query/tests/inputs_args.rs` — unit tests for `*Args` construction + lowering
+- `prax-query/tests/operation_ext_methods.rs` — unit tests for `with_*_input` on each operation
+
+### Modified files
+
+- `prax-query/src/lib.rs:14` — add `pub mod capabilities;` and `pub mod inputs;`; re-export the input traits/types in the same shape as the existing `Filter`/`FilterValue` re-exports
+- `prax-query/src/filter.rs:551-602` — add `#[non_exhaustive]` to `Filter` and the `ScalarSubquery { sql: Cow<'static, str>, params: Vec<FilterValue> }` variant
+- `prax-query/src/filter.rs:965-1115` — extend `to_sql_with_params` to lower `ScalarSubquery` (inline the sql with `{N}` → dialect placeholder substitution, append params)
+- `prax-query/src/filter.rs` (after existing impls) — wildcard arm for `#[non_exhaustive]` in any internal `match` that currently is exhaustive
+- `prax-query/src/traits.rs:108-264` — add `fn in_transaction(&self) -> bool { false }` to `QueryEngine`
+- `prax-query/src/operations/find_many.rs` — `with_where_input`, `with_include_input`, `with_select_input`, `with_order_by_input`, `with_cursor_input`
+- `prax-query/src/operations/find_unique.rs` — `with_where_input` (unique), `with_include_input`, `with_select_input`
+- `prax-query/src/operations/find_first.rs` — `with_where_input`, `with_include_input`, `with_select_input`, `with_order_by_input`, `with_cursor_input`
+- `prax-query/src/operations/create.rs` — `with_data_input`, `with_include_input`, `with_select_input`
+- `prax-query/src/operations/update.rs` — `with_where_input` (unique), `with_data_input`, `with_include_input`, `with_select_input`
+- `prax-query/src/operations/delete.rs` — `with_where_input` (unique), `with_include_input`, `with_select_input`
+- `prax-query/src/operations/upsert.rs` — `with_where_input` (unique), `with_create_input`, `with_update_input`, `with_include_input`, `with_select_input`
+- `prax-query/src/operations/count.rs` — `with_where_input`, `with_order_by_input`, `with_cursor_input`
+- `prax-query/src/operations/aggregate.rs` — `with_where_input`, `with_order_by_input`, `with_aggregate_input`, `with_group_by_input`
+
+### Deleted
+
+- None.
+
+---
+
+## Task 1: Verify clean baseline
+
+**Files:**
+- None (verification only)
+
+- [ ] **Step 1: Confirm worktree and branch**
+
+Run: `git -C /home/joseph/Projects/prax/.worktrees/typed-inputs-runtime-traits rev-parse --abbrev-ref HEAD`
+Expected: `feature/typed-inputs-runtime-traits`
+
+- [ ] **Step 2: Workspace check**
+
+Run: `cargo check --workspace --all-features` (from the worktree root)
+Expected: zero compile errors. Any pre-existing failure must be fixed before continuing.
+
+- [ ] **Step 3: prax-query unit tests**
+
+Run: `cargo test -p prax-query --lib`
+Expected: every test passes.
+
+- [ ] **Step 4: No commit — verification only**
+
+---
+
+## Task 2: Add `Filter::ScalarSubquery` variant
+
+**Files:**
+- Modify: `prax-query/src/filter.rs:551-602`
+- Modify: `prax-query/src/filter.rs:965-1115`
+
+The codegen plans (phase 5.5 and phase 5) need to splice raw SQL fragments into WHERE clauses for relation-aggregate virtuals and nested-write child lookups. Adding the variant now keeps phase 1 self-contained as the IR foundation.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside `mod tests` at the bottom of `prax-query/src/filter.rs`:
+
+```rust
+    #[test]
+    fn scalar_subquery_lowers_to_inline_sql_with_dialect_placeholders() {
+        use crate::dialect::Postgres;
+        let f = Filter::ScalarSubquery {
+            sql: std::borrow::Cow::Borrowed(
+                "(SELECT COUNT(*) FROM posts p WHERE p.author_id = users.id AND p.published = {0}) > {1}",
+            ),
+            params: vec![FilterValue::Bool(true), FilterValue::Int(5)],
+        };
+        let (sql, params) = f.to_sql(0, &Postgres);
+        assert_eq!(
+            sql,
+            "((SELECT COUNT(*) FROM posts p WHERE p.author_id = users.id AND p.published = $1) > $2)"
+        );
+        assert_eq!(params, vec![FilterValue::Bool(true), FilterValue::Int(5)]);
+    }
+
+    #[test]
+    fn scalar_subquery_offsets_placeholders_inside_and() {
+        use crate::dialect::Postgres;
+        let f = Filter::and([
+            Filter::Equals("active".into(), FilterValue::Bool(true)),
+            Filter::ScalarSubquery {
+                sql: std::borrow::Cow::Borrowed(
+                    "(SELECT COUNT(*) FROM posts p WHERE p.author_id = users.id) >= {0}",
+                ),
+                params: vec![FilterValue::Int(1)],
+            },
+        ]);
+        let (sql, params) = f.to_sql(0, &Postgres);
+        // First filter takes $1, the scalar subquery's {0} maps to $2.
+        assert!(sql.contains("$1"));
+        assert!(sql.contains("$2"));
+        assert_eq!(params.len(), 2);
+        assert_eq!(params[0], FilterValue::Bool(true));
+        assert_eq!(params[1], FilterValue::Int(1));
+    }
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cargo test -p prax-query --lib filter::tests::scalar_subquery`
+Expected: compile error — `Filter::ScalarSubquery` variant not found.
+
+- [ ] **Step 3: Add the variant + `#[non_exhaustive]`**
+
+In `prax-query/src/filter.rs`, replace the existing `Filter` definition (around line 551) with:
+
+```rust
+#[derive(Debug, Clone, PartialEq)]
+#[repr(C)]
+#[derive(Default)]
+#[non_exhaustive]
+pub enum Filter {
+    /// No filter (always true).
+    #[default]
+    None,
+
+    /// Equals comparison.
+    Equals(FieldName, FilterValue),
+    /// Not equals comparison.
+    NotEquals(FieldName, FilterValue),
+
+    /// Less than comparison.
+    Lt(FieldName, FilterValue),
+    /// Less than or equal comparison.
+    Lte(FieldName, FilterValue),
+    /// Greater than comparison.
+    Gt(FieldName, FilterValue),
+    /// Greater than or equal comparison.
+    Gte(FieldName, FilterValue),
+
+    /// In a list of values.
+    In(FieldName, ValueList),
+    /// Not in a list of values.
+    NotIn(FieldName, ValueList),
+
+    /// Contains (LIKE %value%).
+    Contains(FieldName, FilterValue),
+    /// Starts with (LIKE value%).
+    StartsWith(FieldName, FilterValue),
+    /// Ends with (LIKE %value).
+    EndsWith(FieldName, FilterValue),
+
+    /// Is null check.
+    IsNull(FieldName),
+    /// Is not null check.
+    IsNotNull(FieldName),
+
+    /// Logical AND of multiple filters.
+    And(Box<[Filter]>),
+    /// Logical OR of multiple filters.
+    Or(Box<[Filter]>),
+    /// Logical NOT of a filter.
+    Not(Box<Filter>),
+
+    /// A pre-built scalar subquery fragment.
+    ///
+    /// Used by relation-aggregate virtual fields and nested-write child
+    /// lookups (phase 5 / 5.5). The `sql` string contains portable `{N}`
+    /// placeholders that are substituted with dialect-specific placeholders
+    /// at SQL build time; `N` is the zero-based index into `params`.
+    ///
+    /// Phase 1 introduces the variant for forward compatibility; nothing
+    /// in the workspace constructs it yet.
+    ScalarSubquery {
+        /// SQL fragment with `{N}` placeholders.
+        sql: std::borrow::Cow<'static, str>,
+        /// Parameter values referenced by the `{N}` placeholders.
+        params: Vec<FilterValue>,
+    },
+}
+```
+
+- [ ] **Step 4: Extend `to_sql_with_params` for the new variant**
+
+In `prax-query/src/filter.rs::to_sql_with_params`, immediately before the closing `}` of the outer `match self {` (currently around line 1115), add:
+
+```rust
+            Self::ScalarSubquery { sql, params: inner_params } => {
+                // Reserve global placeholder indices for each inner param.
+                let base = param_idx + params.len();
+                let mut out = String::with_capacity(sql.len() + inner_params.len() * 4);
+                let mut chars = sql.chars().peekable();
+                while let Some(ch) = chars.next() {
+                    if ch == '{' {
+                        // Read the integer index up to '}'.
+                        let mut digits = String::new();
+                        while let Some(&c) = chars.peek() {
+                            if c == '}' {
+                                chars.next();
+                                break;
+                            }
+                            digits.push(c);
+                            chars.next();
+                        }
+                        let n: usize = digits.parse().unwrap_or_else(|_| {
+                            panic!("Filter::ScalarSubquery: invalid placeholder index `{{{}}}`", digits)
+                        });
+                        let value = inner_params.get(n).unwrap_or_else(|| {
+                            panic!(
+                                "Filter::ScalarSubquery: placeholder {{{}}} out of range (have {} params)",
+                                n,
+                                inner_params.len()
+                            )
+                        });
+                        params.push(value.clone());
+                        out.push_str(&dialect.placeholder(base + n + 1));
+                    } else {
+                        out.push(ch);
+                    }
+                }
+                format!("({})", out)
+            }
+```
+
+- [ ] **Step 5: Audit internal `match Filter` sites for the `#[non_exhaustive]` break**
+
+Run: `cargo check -p prax-query --all-features 2>&1 | grep -E 'non-exhaustive|E0004' | head -20`
+
+If any non-exhaustive-match warnings or errors come back, edit the call sites listed in the output and add `_ => unreachable!("unhandled Filter variant; see prax-query/src/inputs/lowering.rs")` arms. Re-run until clean.
+
+- [ ] **Step 6: Run new tests**
+
+Run: `cargo test -p prax-query --lib filter::tests::scalar_subquery`
+Expected: both new tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add prax-query/src/filter.rs
+git commit -m "feat(query): add Filter::ScalarSubquery variant + non_exhaustive
+
+Future phases (5 nested writes, 5.5 computed/virtual fields) need to
+splice raw SQL fragments into WHERE clauses without enumerating every
+shape in the IR. ScalarSubquery stores a SQL fragment with {N}
+placeholders and a params vec; to_sql_with_params substitutes the
+placeholders with dialect-correct positional placeholders at build
+time. Filter is marked non_exhaustive so further additions stay
+non-breaking."
+```
+
+---
+
+## Task 3: Add `QueryEngine::in_transaction` default
+
+**Files:**
+- Modify: `prax-query/src/traits.rs:108-264`
+
+The phase-5 nested-write executor inlines its ops into a wrapping transaction when one already exists. We add the detection hook now so phase 5 doesn't have to change the engine trait at the same time as its other work.
+
+- [ ] **Step 1: Write the failing test**
+
+Append at the end of the `mod tests` block in `prax-query/src/traits.rs`:
+
+```rust
+    #[test]
+    fn default_in_transaction_returns_false() {
+        // Re-use the DefaultEngine declared in the query_engine_dialect test below.
+        // Construct it inline to avoid scope issues.
+        #[derive(Clone)]
+        struct E;
+
+        impl QueryEngine for E {
+            fn query_many<T: Model + crate::row::FromRow + Send + 'static>(
+                &self,
+                _sql: &str,
+                _params: Vec<crate::filter::FilterValue>,
+            ) -> BoxFuture<'_, QueryResult<Vec<T>>> { Box::pin(async { Ok(Vec::new()) }) }
+            fn query_one<T: Model + crate::row::FromRow + Send + 'static>(
+                &self,
+                _sql: &str,
+                _params: Vec<crate::filter::FilterValue>,
+            ) -> BoxFuture<'_, QueryResult<T>> { Box::pin(async { Err(crate::error::QueryError::not_found("t")) }) }
+            fn query_optional<T: Model + crate::row::FromRow + Send + 'static>(
+                &self,
+                _sql: &str,
+                _params: Vec<crate::filter::FilterValue>,
+            ) -> BoxFuture<'_, QueryResult<Option<T>>> { Box::pin(async { Ok(None) }) }
+            fn execute_insert<T: Model + crate::row::FromRow + Send + 'static>(
+                &self,
+                _sql: &str,
+                _params: Vec<crate::filter::FilterValue>,
+            ) -> BoxFuture<'_, QueryResult<T>> { Box::pin(async { Err(crate::error::QueryError::not_found("t")) }) }
+            fn execute_update<T: Model + crate::row::FromRow + Send + 'static>(
+                &self,
+                _sql: &str,
+                _params: Vec<crate::filter::FilterValue>,
+            ) -> BoxFuture<'_, QueryResult<Vec<T>>> { Box::pin(async { Ok(Vec::new()) }) }
+            fn execute_delete(
+                &self,
+                _sql: &str,
+                _params: Vec<crate::filter::FilterValue>,
+            ) -> BoxFuture<'_, QueryResult<u64>> { Box::pin(async { Ok(0) }) }
+            fn execute_raw(
+                &self,
+                _sql: &str,
+                _params: Vec<crate::filter::FilterValue>,
+            ) -> BoxFuture<'_, QueryResult<u64>> { Box::pin(async { Ok(0) }) }
+            fn count(
+                &self,
+                _sql: &str,
+                _params: Vec<crate::filter::FilterValue>,
+            ) -> BoxFuture<'_, QueryResult<u64>> { Box::pin(async { Ok(0) }) }
+        }
+
+        let e = E;
+        assert!(!e.in_transaction());
+    }
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cargo test -p prax-query --lib traits::tests::default_in_transaction_returns_false`
+Expected: compile error — no method `in_transaction` on `QueryEngine`.
+
+- [ ] **Step 3: Add the method to the trait**
+
+In `prax-query/src/traits.rs` inside `pub trait QueryEngine`, immediately above `fn transaction<…>`, add:
+
+```rust
+    /// Whether this engine is currently executing inside an open
+    /// transaction.
+    ///
+    /// The nested-write executor (phase 5) checks this to decide
+    /// whether to issue its own `BEGIN`/`COMMIT` around a write plan
+    /// or inline into a transaction the caller already started.
+    ///
+    /// Default returns `false`. Driver engines that wrap a
+    /// driver-native transaction object override and return `true`.
+    fn in_transaction(&self) -> bool {
+        false
+    }
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `cargo test -p prax-query --lib traits::tests::default_in_transaction_returns_false`
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add prax-query/src/traits.rs
+git commit -m "feat(query): add QueryEngine::in_transaction default
+
+Lets the nested-write executor (phase 5) detect whether it's running
+inside a caller-started transaction and inline its child operations
+instead of opening a new BEGIN/COMMIT. Default is false; driver
+crates that own a real transaction object override."
+```
+
+---
+
+## Task 4: Create `capabilities` module with marker traits
+
+**Files:**
+- Create: `prax-query/src/capabilities.rs`
+- Modify: `prax-query/src/lib.rs` (add `pub mod capabilities;`)
+
+- [ ] **Step 1: Create the file**
+
+Create `prax-query/src/capabilities.rs`:
+
+```rust
+//! Engine capability marker traits.
+//!
+//! Each trait in this module marks a capability that some `QueryEngine`
+//! impls satisfy and others don't. The macro DSL (phase 3+) and the
+//! generated input types (phase 2) carry `where E: SupportsX` bounds on
+//! the methods that produce capability-dependent SQL. Using such a
+//! method against an engine that doesn't impl the trait fails to compile
+//! with a clear diagnostic.
+//!
+//! Engine crates (`prax-postgres`, `prax-mysql`, ...) impl the traits
+//! they satisfy on their concrete engine types. Phase 1 only defines
+//! the traits; engine impls land in phase 2.
+
+use crate::traits::QueryEngine;
+
+/// Engine supports relation filters (`some`/`every`/`none`/`is`/`is_not`)
+/// that lower to correlated EXISTS / NOT EXISTS subqueries (or the
+/// equivalent in non-SQL engines).
+#[diagnostic::on_unimplemented(
+    message = "the engine `{Self}` does not support relation filters (`some` / `every` / `none` / `is` / `is_not`)",
+    note = "ScyllaDB / Cassandra do not support correlated subqueries. Consider flattening the join or restructuring the model."
+)]
+pub trait SupportsRelationFilter: QueryEngine {}
+
+/// Engine supports correlated subqueries in WHERE clauses.
+///
+/// Superset of `SupportsRelationFilter` — used by features that need
+/// arbitrary subqueries (e.g. computed-field WHERE lowering in phase 5.5).
+#[diagnostic::on_unimplemented(
+    message = "the engine `{Self}` does not support correlated subqueries in WHERE clauses"
+)]
+pub trait SupportsCorrelatedSubquery: QueryEngine {}
+
+/// Engine supports JSON-path filter operators (`path_eq`, `path_gt`, etc.).
+#[diagnostic::on_unimplemented(
+    message = "the engine `{Self}` does not support JSON path operators",
+    note = "Postgres / MySQL >= 5.7 / SQLite + JSON1 / MSSQL support JSON paths."
+)]
+pub trait SupportsJsonPath: QueryEngine {}
+
+/// Engine has native case-insensitive comparison (`ILIKE`, `COLLATE NOCASE`,
+/// equivalent). Engines without it fall back to `LOWER(...)` comparisons and
+/// **do not** need to impl this trait.
+#[diagnostic::on_unimplemented(
+    message = "the engine `{Self}` does not advertise native case-insensitive comparison"
+)]
+pub trait SupportsCaseInsensitiveMode: QueryEngine {}
+
+/// Engine supports full-text search predicates.
+#[diagnostic::on_unimplemented(
+    message = "the engine `{Self}` does not support full-text search"
+)]
+pub trait SupportsFullTextSearch: QueryEngine {}
+
+/// Engine supports native array column operators (`contains`, `overlaps`, ...).
+#[diagnostic::on_unimplemented(
+    message = "the engine `{Self}` does not support array operators"
+)]
+pub trait SupportsArrayOps: QueryEngine {}
+
+/// Engine supports DDL for `GENERATED ALWAYS AS (expr) STORED|VIRTUAL`
+/// computed columns.
+#[diagnostic::on_unimplemented(
+    message = "the engine `{Self}` does not support generated columns",
+    note = "Postgres / MySQL / SQLite / MSSQL / DuckDB support GENERATED ALWAYS AS."
+)]
+pub trait SupportsGeneratedColumns: QueryEngine {}
+
+/// Engine supports scalar subqueries in the SELECT list.
+///
+/// Required for relation-aggregate virtual fields (`@count`, `@sum`,
+/// `@avg`, `@min`, `@max`) and Prisma-style `_count`.
+#[diagnostic::on_unimplemented(
+    message = "the engine `{Self}` does not support scalar subqueries in SELECT",
+    note = "All SQL engines satisfy this. MongoDB requires the $lookup-lowering follow-up plan."
+)]
+pub trait SupportsScalarSubqueryInSelect: QueryEngine {}
+
+/// Engine supports Prisma-style nested writes
+/// (`create` / `connect` / `connect_or_create` / `disconnect` / `set`
+/// / `update` / `upsert` / `delete` / `delete_many` inside `data`).
+///
+/// CQL engines (`prax-scylladb`, `prax-cassandra`) deliberately do not
+/// impl this trait — phase 5's `*CreateNestedInput` / `*UpdateNestedInput`
+/// types carry `where E: SupportsNestedWrites` bounds so misuse fails
+/// to compile.
+#[diagnostic::on_unimplemented(
+    message = "the engine `{Self}` does not support nested writes",
+    note = "ScyllaDB / Cassandra batch semantics don't map onto Prisma-style nested writes. Use the engine-native BATCH API or restructure."
+)]
+pub trait SupportsNestedWrites: QueryEngine {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A tiny stub engine for trait-impl smoke tests.
+    #[derive(Clone)]
+    struct StubEngine;
+
+    impl QueryEngine for StubEngine {
+        fn query_many<T: crate::traits::Model + crate::row::FromRow + Send + 'static>(
+            &self,
+            _sql: &str,
+            _params: Vec<crate::filter::FilterValue>,
+        ) -> crate::traits::BoxFuture<'_, crate::error::QueryResult<Vec<T>>> {
+            Box::pin(async { Ok(Vec::new()) })
+        }
+        fn query_one<T: crate::traits::Model + crate::row::FromRow + Send + 'static>(
+            &self,
+            _sql: &str,
+            _params: Vec<crate::filter::FilterValue>,
+        ) -> crate::traits::BoxFuture<'_, crate::error::QueryResult<T>> {
+            Box::pin(async { Err(crate::error::QueryError::not_found("t")) })
+        }
+        fn query_optional<T: crate::traits::Model + crate::row::FromRow + Send + 'static>(
+            &self,
+            _sql: &str,
+            _params: Vec<crate::filter::FilterValue>,
+        ) -> crate::traits::BoxFuture<'_, crate::error::QueryResult<Option<T>>> {
+            Box::pin(async { Ok(None) })
+        }
+        fn execute_insert<T: crate::traits::Model + crate::row::FromRow + Send + 'static>(
+            &self,
+            _sql: &str,
+            _params: Vec<crate::filter::FilterValue>,
+        ) -> crate::traits::BoxFuture<'_, crate::error::QueryResult<T>> {
+            Box::pin(async { Err(crate::error::QueryError::not_found("t")) })
+        }
+        fn execute_update<T: crate::traits::Model + crate::row::FromRow + Send + 'static>(
+            &self,
+            _sql: &str,
+            _params: Vec<crate::filter::FilterValue>,
+        ) -> crate::traits::BoxFuture<'_, crate::error::QueryResult<Vec<T>>> {
+            Box::pin(async { Ok(Vec::new()) })
+        }
+        fn execute_delete(&self, _sql: &str, _params: Vec<crate::filter::FilterValue>) -> crate::traits::BoxFuture<'_, crate::error::QueryResult<u64>> {
+            Box::pin(async { Ok(0) })
+        }
+        fn execute_raw(&self, _sql: &str, _params: Vec<crate::filter::FilterValue>) -> crate::traits::BoxFuture<'_, crate::error::QueryResult<u64>> {
+            Box::pin(async { Ok(0) })
+        }
+        fn count(&self, _sql: &str, _params: Vec<crate::filter::FilterValue>) -> crate::traits::BoxFuture<'_, crate::error::QueryResult<u64>> {
+            Box::pin(async { Ok(0) })
+        }
+    }
+
+    impl SupportsRelationFilter for StubEngine {}
+
+    fn needs_relation_filter<E: SupportsRelationFilter>() {}
+
+    #[test]
+    fn marker_trait_dispatch_compiles() {
+        needs_relation_filter::<StubEngine>();
+    }
+}
+```
+
+- [ ] **Step 2: Register the module**
+
+In `prax-query/src/lib.rs`, after the `pub mod dialect;` declaration block (search for an existing `pub mod` near the top), add:
+
+```rust
+pub mod capabilities;
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p prax-query --lib capabilities::tests::marker_trait_dispatch_compiles`
+Expected: pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add prax-query/src/capabilities.rs prax-query/src/lib.rs
+git commit -m "feat(query): add engine capability marker traits
+
+Nine marker traits gate features per engine: SupportsRelationFilter,
+SupportsCorrelatedSubquery, SupportsJsonPath,
+SupportsCaseInsensitiveMode, SupportsFullTextSearch,
+SupportsArrayOps, SupportsGeneratedColumns,
+SupportsScalarSubqueryInSelect, SupportsNestedWrites. Each carries a
+#[diagnostic::on_unimplemented] message so misuse fails to compile
+with engine-specific guidance. Engine crates impl the relevant
+subset in phase 2."
+```
+
+---
+
+## Task 5: Scaffold the `inputs` module and define the 10 input traits
+
+**Files:**
+- Create: `prax-query/src/inputs/mod.rs`
+- Create: `prax-query/src/inputs/traits.rs`
+- Modify: `prax-query/src/lib.rs`
+
+- [ ] **Step 1: Create the module root**
+
+Create `prax-query/src/inputs/mod.rs`:
+
+```rust
+//! Typed input shapes for the Prisma-style DSL.
+//!
+//! This module holds the trait spine (`WhereInput`, `IncludeInput`, …),
+//! the reusable scalar filter wrappers (`StringFilter`, `IntFilter`, …),
+//! the relation filter wrappers (`ListRelationFilter`,
+//! `SingleRelationFilter`), the scalar update wrappers
+//! (`IntFieldUpdate`, `StringFieldUpdate`, …), and the per-operation
+//! containers (`FindManyArgs`, `CreateArgs`, …).
+//!
+//! Codegen (phase 2) emits per-model concrete structs that implement
+//! these traits and use these wrappers. The operation macros (phase 3+)
+//! emit token streams that construct these inputs and feed them to
+//! existing `*Operation` builders via `with_*_input` extension methods.
+//!
+//! Layer-1 callers can also build these inputs by hand — they form the
+//! "third interface" alongside the macro DSL and the existing fluent
+//! builder.
+
+pub mod args;
+pub mod relation;
+pub mod scalar;
+pub mod scalar_update;
+pub mod traits;
+
+pub use args::*;
+pub use relation::*;
+pub use scalar::*;
+pub use scalar_update::*;
+pub use traits::*;
+```
+
+- [ ] **Step 2: Create the trait spine**
+
+Create `prax-query/src/inputs/traits.rs`:
+
+```rust
+//! Traits implemented by per-model generated input types.
+//!
+//! Each trait has one method, `into_ir`, that lowers the input to the
+//! runtime IR that the SQL builders already consume. The associated
+//! `Model` type keeps generic bounds tight: a `FindManyOperation<E, User>`
+//! can only accept a `WhereInput<Model = User>`, never a `PostWhereInput`.
+
+use crate::filter::Filter;
+use crate::pagination::Pagination;
+use crate::relations::{Include, IncludeSpec};
+use crate::traits::Model;
+use crate::types::{OrderBy, Select};
+
+/// A typed shape that lowers to a runtime [`Filter`].
+///
+/// Implemented by per-model `UserWhereInput`, `PostWhereInput`, ...
+pub trait WhereInput {
+    /// The model this WHERE shape applies to.
+    type Model: Model;
+    /// Lower this input to the runtime IR.
+    fn into_ir(self) -> Filter;
+}
+
+/// A WHERE shape constrained to a unique key (PK or `@unique` column).
+///
+/// Used by `find_unique` / `update` / `upsert` / `delete` where the
+/// operation requires the filter to identify at most one row.
+pub trait WhereUniqueInput {
+    /// The model this WHERE shape applies to.
+    type Model: Model;
+    /// Lower this input to the runtime IR.
+    fn into_ir(self) -> Filter;
+}
+
+/// A typed shape that lowers to an [`Include`] specification.
+pub trait IncludeInput {
+    /// The model this include shape applies to.
+    type Model: Model;
+    /// Lower this input to the runtime IR.
+    fn into_ir(self) -> Include;
+}
+
+/// A typed shape that lowers to a [`Select`] specification.
+pub trait SelectInput {
+    /// The model this select shape applies to.
+    type Model: Model;
+    /// Lower this input to the runtime IR.
+    fn into_ir(self) -> Select;
+}
+
+/// A typed shape that lowers to an [`OrderBy`] specification.
+pub trait OrderByInput {
+    /// The model this order shape applies to.
+    type Model: Model;
+    /// Lower this input to the runtime IR.
+    fn into_ir(self) -> OrderBy;
+}
+
+/// A typed shape that lowers to the `Data` payload for a `create`.
+///
+/// The associated `Data` type is the existing `<Model as CreateData>::Data`
+/// from `prax_query::traits::CreateData` — phase 5 will introduce a
+/// `NestedWritePlan` lowering path; phase 1 keeps the lowering simple.
+pub trait CreateInput {
+    /// The model this create input applies to.
+    type Model: Model;
+    /// The runtime payload type.
+    type Data: Send + Sync;
+    /// Lower this input to the runtime payload.
+    fn into_ir(self) -> Self::Data;
+}
+
+/// A typed shape that lowers to the `Data` payload for an `update`.
+pub trait UpdateInput {
+    /// The model this update input applies to.
+    type Model: Model;
+    /// The runtime payload type.
+    type Data: Send + Sync;
+    /// Lower this input to the runtime payload.
+    fn into_ir(self) -> Self::Data;
+}
+
+/// A typed shape that lowers to a `_count` aggregate selection.
+pub trait CountSelect {
+    /// The model this count selection applies to.
+    type Model: Model;
+    /// Concrete representation as a list of relation names to count.
+    fn into_relation_names(self) -> Vec<String>;
+}
+
+/// A typed shape that lowers to an aggregate spec
+/// (`_count` / `_avg` / `_sum` / `_min` / `_max`).
+///
+/// The IR target for this trait is finalized in phase 6 when aggregate
+/// macros are wired up. For phase 1 the trait only carries the `Model`
+/// associated type.
+pub trait AggregateInput {
+    /// The model this aggregate spec applies to.
+    type Model: Model;
+}
+
+/// A typed shape that lowers to a group-by spec.
+///
+/// As with [`AggregateInput`], the IR target is finalized in phase 6.
+pub trait GroupByInput {
+    /// The model this group-by spec applies to.
+    type Model: Model;
+}
+
+/// Pagination fragment shared by every read input.
+///
+/// Phase 1 keeps pagination on the operation itself (matching the
+/// current builder API). This struct exists so phase 3+ macros can
+/// surface `skip`/`take`/`cursor` inside the input AST without having
+/// to construct an entire `*Args`.
+#[derive(Debug, Clone, Default)]
+pub struct PaginationInput {
+    /// Number of rows to skip.
+    pub skip: Option<u64>,
+    /// Number of rows to take.
+    pub take: Option<u64>,
+}
+
+impl From<PaginationInput> for Pagination {
+    fn from(p: PaginationInput) -> Self {
+        let mut out = Pagination::new();
+        if let Some(n) = p.skip {
+            out = out.skip(n);
+        }
+        if let Some(n) = p.take {
+            out = out.take(n);
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestModel;
+    impl Model for TestModel {
+        const MODEL_NAME: &'static str = "TestModel";
+        const TABLE_NAME: &'static str = "test_models";
+        const PRIMARY_KEY: &'static [&'static str] = &["id"];
+        const COLUMNS: &'static [&'static str] = &["id"];
+    }
+
+    struct TestWhere;
+    impl WhereInput for TestWhere {
+        type Model = TestModel;
+        fn into_ir(self) -> Filter {
+            Filter::None
+        }
+    }
+
+    #[test]
+    fn where_input_lowers_to_filter_none() {
+        assert!(matches!(TestWhere.into_ir(), Filter::None));
+    }
+
+    #[test]
+    fn pagination_input_roundtrip() {
+        let p = PaginationInput { skip: Some(5), take: Some(10) };
+        let raw: Pagination = p.into();
+        assert_eq!(raw.skip(), Some(5));
+        assert_eq!(raw.take(), Some(10));
+    }
+}
+```
+
+- [ ] **Step 3: Register the module**
+
+In `prax-query/src/lib.rs`, near the existing `pub mod capabilities;` you added in Task 4, add:
+
+```rust
+pub mod inputs;
+```
+
+- [ ] **Step 4: Build to check Pagination API**
+
+Run: `cargo check -p prax-query --lib`
+
+If the `Pagination::skip()` / `take()` getters are named differently, adapt the test. Find them with:
+
+```bash
+grep -n "pub fn skip\|pub fn take\|pub fn new" prax-query/src/pagination.rs
+```
+
+and update `pagination_input_roundtrip` accordingly. Re-run.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test -p prax-query --lib inputs::traits::tests`
+Expected: both tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add prax-query/src/inputs/ prax-query/src/lib.rs
+git commit -m "feat(query): scaffold inputs module + ten input traits
+
+Each trait (WhereInput, WhereUniqueInput, IncludeInput, SelectInput,
+OrderByInput, CreateInput, UpdateInput, CountSelect, AggregateInput,
+GroupByInput) has one method that lowers to existing runtime IR, plus
+an associated Model type so per-operation generics stay tight.
+AggregateInput / GroupByInput / CountSelect get their IR targets
+finalized in phase 6; phase 1 only fixes their Model boundary.
+PaginationInput rounds-trips into Pagination for phase 3+ macros."
+```
+
+---
+
+## Task 6: Add `QueryMode` and the string-family scalar filters
+
+**Files:**
+- Create: `prax-query/src/inputs/scalar.rs`
+- Create: `prax-query/tests/inputs_scalar.rs`
+
+`scalar.rs` will hold every scalar filter wrapper. We add the string-family and `QueryMode` first so subsequent numeric/datetime tasks can follow the same template.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `prax-query/tests/inputs_scalar.rs`:
+
+```rust
+use prax_query::filter::{Filter, FilterValue};
+use prax_query::inputs::{QueryMode, ScalarFilter, StringFilter, StringNullableFilter};
+
+#[test]
+fn string_filter_equals_lowers_to_filter_equals() {
+    let f = StringFilter::equals("alice@example.com");
+    let filter = f.into_filter("email");
+    assert_eq!(
+        filter,
+        Filter::Equals("email".into(), FilterValue::String("alice@example.com".into()))
+    );
+}
+
+#[test]
+fn string_filter_contains_lowers_to_filter_contains() {
+    let f = StringFilter::contains("@example.com");
+    let filter = f.into_filter("email");
+    assert!(matches!(filter, Filter::Contains(_, _)));
+}
+
+#[test]
+fn string_filter_combines_with_and_when_multiple_ops_set() {
+    let f = StringFilter {
+        contains: Some("@x.com".into()),
+        starts_with: Some("a".into()),
+        ..Default::default()
+    };
+    let filter = f.into_filter("email");
+    match filter {
+        Filter::And(parts) => assert_eq!(parts.len(), 2),
+        other => panic!("expected Filter::And, got {:?}", other),
+    }
+}
+
+#[test]
+fn string_nullable_filter_is_null_lowers_to_is_null() {
+    let f = StringNullableFilter { is_null: Some(true), ..Default::default() };
+    let filter = f.into_filter("name");
+    assert_eq!(filter, Filter::IsNull("name".into()));
+}
+
+#[test]
+fn string_nullable_filter_is_not_null_lowers_to_is_not_null() {
+    let f = StringNullableFilter { is_null: Some(false), ..Default::default() };
+    let filter = f.into_filter("name");
+    assert_eq!(filter, Filter::IsNotNull("name".into()));
+}
+
+#[test]
+fn query_mode_default_is_default() {
+    assert_eq!(QueryMode::default(), QueryMode::Default);
+}
+
+#[test]
+fn string_filter_from_scalar_shortcut() {
+    let f: StringFilter = "alice@x.com".into();
+    assert_eq!(f.equals, Some("alice@x.com".into()));
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cargo test -p prax-query --test inputs_scalar`
+Expected: compile error — `StringFilter`, `StringNullableFilter`, `QueryMode`, `ScalarFilter` not found.
+
+- [ ] **Step 3: Create `scalar.rs` with `QueryMode`, `ScalarFilter` helper trait, and the string filters**
+
+Create `prax-query/src/inputs/scalar.rs`:
+
+```rust
+//! Reusable scalar filter wrappers shared by every generated `*WhereInput`.
+//!
+//! Each wrapper is a struct of `Option`-fields, one per operator. Empty
+//! wrappers (all fields `None`) lower to `Filter::None`. Multiple set
+//! fields AND-combine. `From<scalar>` impls support the macro shorthand
+//! `email: "alice@x.com"` => `StringFilter { equals: Some("..."), .. }`.
+//!
+//! Every wrapper implements [`ScalarFilter`], whose `into_filter`
+//! method takes the column name (which the parent `WhereInput` knows)
+//! and produces a runtime [`Filter`].
+
+use crate::filter::{Filter, FilterValue};
+use serde::{Deserialize, Serialize};
+
+/// Helper trait implemented by every scalar filter wrapper.
+///
+/// The wrapper itself doesn't know its column name — the parent
+/// `WhereInput::into_ir` impl threads the column in when lowering.
+pub trait ScalarFilter {
+    /// Lower this scalar filter to a runtime [`Filter`] keyed by
+    /// the given column name.
+    fn into_filter(self, column: &str) -> Filter;
+}
+
+/// Comparison mode for string filters.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum QueryMode {
+    /// Default (case-sensitive) comparison.
+    #[default]
+    Default,
+    /// Case-insensitive comparison. Requires `SupportsCaseInsensitiveMode`
+    /// for engines that don't fall back to `LOWER(...)`.
+    Insensitive,
+}
+
+/// Filter operators for a non-nullable `String` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct StringFilter {
+    /// `column = value`
+    pub equals: Option<String>,
+    /// Negation of the inner filter.
+    pub not: Option<Box<StringFilter>>,
+    /// `column IN (...)`
+    pub in_list: Option<Vec<String>>,
+    /// `column NOT IN (...)`
+    pub not_in: Option<Vec<String>>,
+    /// `column < value`
+    pub lt: Option<String>,
+    /// `column <= value`
+    pub lte: Option<String>,
+    /// `column > value`
+    pub gt: Option<String>,
+    /// `column >= value`
+    pub gte: Option<String>,
+    /// `column LIKE %value%`
+    pub contains: Option<String>,
+    /// `column LIKE value%`
+    pub starts_with: Option<String>,
+    /// `column LIKE %value`
+    pub ends_with: Option<String>,
+    /// Comparison mode (case sensitivity).
+    pub mode: Option<QueryMode>,
+}
+
+impl StringFilter {
+    /// `equals: Some(value)`.
+    pub fn equals(v: impl Into<String>) -> Self {
+        Self { equals: Some(v.into()), ..Default::default() }
+    }
+    /// `contains: Some(value)`.
+    pub fn contains(v: impl Into<String>) -> Self {
+        Self { contains: Some(v.into()), ..Default::default() }
+    }
+    /// `starts_with: Some(value)`.
+    pub fn starts_with(v: impl Into<String>) -> Self {
+        Self { starts_with: Some(v.into()), ..Default::default() }
+    }
+    /// `ends_with: Some(value)`.
+    pub fn ends_with(v: impl Into<String>) -> Self {
+        Self { ends_with: Some(v.into()), ..Default::default() }
+    }
+}
+
+impl From<&str> for StringFilter {
+    fn from(v: &str) -> Self { Self::equals(v) }
+}
+impl From<String> for StringFilter {
+    fn from(v: String) -> Self { Self::equals(v) }
+}
+
+impl ScalarFilter for StringFilter {
+    fn into_filter(self, column: &str) -> Filter {
+        let mut parts: Vec<Filter> = Vec::new();
+        let col = column.to_string();
+        if let Some(v) = self.equals {
+            parts.push(Filter::Equals(col.clone().into(), FilterValue::String(v)));
+        }
+        if let Some(boxed) = self.not {
+            let inner = boxed.into_filter(column);
+            parts.push(Filter::Not(Box::new(inner)));
+        }
+        if let Some(values) = self.in_list {
+            let vs: Vec<FilterValue> = values.into_iter().map(FilterValue::String).collect();
+            parts.push(Filter::In(col.clone().into(), vs));
+        }
+        if let Some(values) = self.not_in {
+            let vs: Vec<FilterValue> = values.into_iter().map(FilterValue::String).collect();
+            parts.push(Filter::NotIn(col.clone().into(), vs));
+        }
+        if let Some(v) = self.lt {
+            parts.push(Filter::Lt(col.clone().into(), FilterValue::String(v)));
+        }
+        if let Some(v) = self.lte {
+            parts.push(Filter::Lte(col.clone().into(), FilterValue::String(v)));
+        }
+        if let Some(v) = self.gt {
+            parts.push(Filter::Gt(col.clone().into(), FilterValue::String(v)));
+        }
+        if let Some(v) = self.gte {
+            parts.push(Filter::Gte(col.clone().into(), FilterValue::String(v)));
+        }
+        if let Some(v) = self.contains {
+            parts.push(Filter::Contains(col.clone().into(), FilterValue::String(v)));
+        }
+        if let Some(v) = self.starts_with {
+            parts.push(Filter::StartsWith(col.clone().into(), FilterValue::String(v)));
+        }
+        if let Some(v) = self.ends_with {
+            parts.push(Filter::EndsWith(col.clone().into(), FilterValue::String(v)));
+        }
+        // `mode` is honored by the dialect layer in phase 2+; phase 1 ignores
+        // it here. The field is kept so downstream phases don't need a
+        // breaking-shape change.
+        let _ = self.mode;
+        match parts.len() {
+            0 => Filter::None,
+            1 => parts.into_iter().next().unwrap(),
+            _ => Filter::and(parts),
+        }
+    }
+}
+
+/// Filter operators for a nullable `String` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct StringNullableFilter {
+    /// `column = value`
+    pub equals: Option<String>,
+    /// Negation of the inner filter.
+    pub not: Option<Box<StringNullableFilter>>,
+    /// `column IN (...)`
+    pub in_list: Option<Vec<String>>,
+    /// `column NOT IN (...)`
+    pub not_in: Option<Vec<String>>,
+    /// `column < value`
+    pub lt: Option<String>,
+    /// `column <= value`
+    pub lte: Option<String>,
+    /// `column > value`
+    pub gt: Option<String>,
+    /// `column >= value`
+    pub gte: Option<String>,
+    /// `column LIKE %value%`
+    pub contains: Option<String>,
+    /// `column LIKE value%`
+    pub starts_with: Option<String>,
+    /// `column LIKE %value`
+    pub ends_with: Option<String>,
+    /// Comparison mode.
+    pub mode: Option<QueryMode>,
+    /// `is_null: Some(true)` ⇒ `IS NULL`; `Some(false)` ⇒ `IS NOT NULL`.
+    pub is_null: Option<bool>,
+}
+
+impl From<&str> for StringNullableFilter {
+    fn from(v: &str) -> Self {
+        Self { equals: Some(v.into()), ..Default::default() }
+    }
+}
+impl From<String> for StringNullableFilter {
+    fn from(v: String) -> Self {
+        Self { equals: Some(v), ..Default::default() }
+    }
+}
+
+impl ScalarFilter for StringNullableFilter {
+    fn into_filter(self, column: &str) -> Filter {
+        let mut parts: Vec<Filter> = Vec::new();
+        let col = column.to_string();
+        if let Some(b) = self.is_null {
+            parts.push(if b {
+                Filter::IsNull(col.clone().into())
+            } else {
+                Filter::IsNotNull(col.clone().into())
+            });
+        }
+        // Reuse StringFilter's lowering for the remaining ops.
+        let inner = StringFilter {
+            equals: self.equals,
+            not: self.not.map(|b| Box::new(StringFilter {
+                equals: b.equals,
+                in_list: b.in_list,
+                not_in: b.not_in,
+                lt: b.lt,
+                lte: b.lte,
+                gt: b.gt,
+                gte: b.gte,
+                contains: b.contains,
+                starts_with: b.starts_with,
+                ends_with: b.ends_with,
+                mode: b.mode,
+                not: None,
+            })),
+            in_list: self.in_list,
+            not_in: self.not_in,
+            lt: self.lt,
+            lte: self.lte,
+            gt: self.gt,
+            gte: self.gte,
+            contains: self.contains,
+            starts_with: self.starts_with,
+            ends_with: self.ends_with,
+            mode: self.mode,
+        };
+        let inner_filter = inner.into_filter(column);
+        if !matches!(inner_filter, Filter::None) {
+            parts.push(inner_filter);
+        }
+        match parts.len() {
+            0 => Filter::None,
+            1 => parts.into_iter().next().unwrap(),
+            _ => Filter::and(parts),
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p prax-query --test inputs_scalar`
+Expected: every test passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add prax-query/src/inputs/scalar.rs prax-query/tests/inputs_scalar.rs
+git commit -m "feat(query): add QueryMode and StringFilter / StringNullableFilter
+
+ScalarFilter helper trait takes a column name and produces a runtime
+Filter; per-model WhereInput impls thread the column in when
+lowering. Multiple Option fields AND-combine. From<&str> / From<String>
+shortcuts power the macro DSL's bare-value shorthand. mode is parsed
+but lowered in phase 2 by the dialect layer."
+```
+
+---
+
+## Task 7: Add numeric, boolean, bytes, uuid, json filters
+
+**Files:**
+- Modify: `prax-query/src/inputs/scalar.rs`
+- Modify: `prax-query/tests/inputs_scalar.rs`
+
+- [ ] **Step 1: Append failing tests**
+
+Append at the bottom of `prax-query/tests/inputs_scalar.rs`:
+
+```rust
+use prax_query::inputs::{
+    BigIntFilter, BigIntNullableFilter, BoolFilter, BoolNullableFilter, BytesFilter,
+    BytesNullableFilter, DecimalFilter, DecimalNullableFilter, FloatFilter,
+    FloatNullableFilter, IntFilter, IntNullableFilter, JsonFilter, JsonNullableFilter,
+    UuidFilter, UuidNullableFilter,
+};
+
+#[test]
+fn int_filter_equals_lowers() {
+    let f = IntFilter::equals(42i32);
+    let filter = f.into_filter("age");
+    assert_eq!(filter, Filter::Equals("age".into(), FilterValue::Int(42)));
+}
+
+#[test]
+fn int_filter_gt_lowers() {
+    let f = IntFilter::gt(18i32);
+    let filter = f.into_filter("age");
+    assert_eq!(filter, Filter::Gt("age".into(), FilterValue::Int(18)));
+}
+
+#[test]
+fn int_filter_in_list_lowers() {
+    let f = IntFilter { in_list: Some(vec![1, 2, 3]), ..Default::default() };
+    let filter = f.into_filter("id");
+    match filter {
+        Filter::In(col, values) => {
+            assert_eq!(col, "id");
+            assert_eq!(values.len(), 3);
+        }
+        other => panic!("expected Filter::In, got {:?}", other),
+    }
+}
+
+#[test]
+fn int_nullable_filter_is_null() {
+    let f = IntNullableFilter { is_null: Some(true), ..Default::default() };
+    let filter = f.into_filter("deleted_at");
+    assert_eq!(filter, Filter::IsNull("deleted_at".into()));
+}
+
+#[test]
+fn bool_filter_equals_lowers() {
+    let f = BoolFilter::equals(true);
+    let filter = f.into_filter("active");
+    assert_eq!(filter, Filter::Equals("active".into(), FilterValue::Bool(true)));
+}
+
+#[test]
+fn big_int_filter_equals_lowers() {
+    let f = BigIntFilter::equals(9_999_999_999i64);
+    let filter = f.into_filter("counter");
+    assert_eq!(filter, Filter::Equals("counter".into(), FilterValue::Int(9_999_999_999)));
+}
+
+#[test]
+fn float_filter_equals_lowers() {
+    let f = FloatFilter::equals(3.14f64);
+    let filter = f.into_filter("score");
+    assert_eq!(filter, Filter::Equals("score".into(), FilterValue::Float(3.14)));
+}
+
+#[test]
+fn decimal_filter_equals_lowers() {
+    use rust_decimal::Decimal;
+    use std::str::FromStr;
+    let v = Decimal::from_str("12.34").unwrap();
+    let f = DecimalFilter::equals(v);
+    let filter = f.into_filter("amount");
+    // Decimal flows through as a string in FilterValue::String — see lowering.
+    match filter {
+        Filter::Equals(col, FilterValue::String(s)) => {
+            assert_eq!(col, "amount");
+            assert_eq!(s, "12.34");
+        }
+        other => panic!("expected Decimal Equals to string, got {:?}", other),
+    }
+}
+
+#[test]
+fn uuid_filter_equals_lowers() {
+    use uuid::Uuid;
+    let id = Uuid::nil();
+    let f = UuidFilter::equals(id);
+    let filter = f.into_filter("id");
+    match filter {
+        Filter::Equals(col, FilterValue::String(s)) => {
+            assert_eq!(col, "id");
+            assert_eq!(s, id.to_string());
+        }
+        other => panic!("expected Uuid Equals to string, got {:?}", other),
+    }
+}
+
+#[test]
+fn json_filter_equals_lowers() {
+    let f = JsonFilter { equals: Some(serde_json::json!({"k": 1})), ..Default::default() };
+    let filter = f.into_filter("data");
+    match filter {
+        Filter::Equals(col, FilterValue::Json(v)) => {
+            assert_eq!(col, "data");
+            assert_eq!(v, serde_json::json!({"k": 1}));
+        }
+        other => panic!("expected Json Equals, got {:?}", other),
+    }
+}
+
+#[test]
+fn bytes_filter_equals_lowers() {
+    let f = BytesFilter::equals(vec![1u8, 2, 3]);
+    let filter = f.into_filter("blob");
+    match filter {
+        Filter::Equals(col, FilterValue::String(s)) => {
+            assert_eq!(col, "blob");
+            assert!(!s.is_empty());
+        }
+        other => panic!("expected Bytes Equals (base64-encoded), got {:?}", other),
+    }
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cargo test -p prax-query --test inputs_scalar`
+Expected: compile error — none of the new filters exist yet.
+
+- [ ] **Step 3: Append the numeric/bool/bytes/uuid/json filter definitions**
+
+Append to `prax-query/src/inputs/scalar.rs`:
+
+```rust
+/// Macro to emit a scalar filter wrapper + nullable counterpart that
+/// lowers to a `FilterValue::$variant`. Keeps the table of integer /
+/// floating / temporal / blob types DRY without sacrificing rustdoc
+/// per-type.
+macro_rules! scalar_filter {
+    (
+        $(#[$nn_meta:meta])*
+        $name:ident<$rust:ty> => |$conv_v:ident: $rust2:ty| $conv:block as $fv:expr,
+        $(#[$null_meta:meta])*
+        nullable $null:ident
+    ) => {
+        $(#[$nn_meta])*
+        #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+        #[serde(rename_all = "snake_case")]
+        pub struct $name {
+            /// `column = value`
+            pub equals: Option<$rust>,
+            /// Negation.
+            pub not: Option<Box<$name>>,
+            /// `column IN (...)`
+            pub in_list: Option<Vec<$rust>>,
+            /// `column NOT IN (...)`
+            pub not_in: Option<Vec<$rust>>,
+            /// `column < value`
+            pub lt: Option<$rust>,
+            /// `column <= value`
+            pub lte: Option<$rust>,
+            /// `column > value`
+            pub gt: Option<$rust>,
+            /// `column >= value`
+            pub gte: Option<$rust>,
+        }
+
+        impl $name {
+            /// `equals: Some(value)`.
+            pub fn equals(v: impl Into<$rust>) -> Self {
+                Self { equals: Some(v.into()), ..Default::default() }
+            }
+            /// `lt: Some(value)`.
+            pub fn lt(v: impl Into<$rust>) -> Self {
+                Self { lt: Some(v.into()), ..Default::default() }
+            }
+            /// `lte: Some(value)`.
+            pub fn lte(v: impl Into<$rust>) -> Self {
+                Self { lte: Some(v.into()), ..Default::default() }
+            }
+            /// `gt: Some(value)`.
+            pub fn gt(v: impl Into<$rust>) -> Self {
+                Self { gt: Some(v.into()), ..Default::default() }
+            }
+            /// `gte: Some(value)`.
+            pub fn gte(v: impl Into<$rust>) -> Self {
+                Self { gte: Some(v.into()), ..Default::default() }
+            }
+        }
+
+        impl ScalarFilter for $name {
+            fn into_filter(self, column: &str) -> Filter {
+                fn to_fv($conv_v: $rust2) -> FilterValue $conv
+                let col: crate::filter::FieldName = column.to_string().into();
+                let mut parts: Vec<Filter> = Vec::new();
+                if let Some(v) = self.equals {
+                    parts.push(Filter::Equals(col.clone(), to_fv(v)));
+                }
+                if let Some(boxed) = self.not {
+                    let inner = boxed.into_filter(column);
+                    parts.push(Filter::Not(Box::new(inner)));
+                }
+                if let Some(values) = self.in_list {
+                    let vs: Vec<FilterValue> = values.into_iter().map(to_fv).collect();
+                    parts.push(Filter::In(col.clone(), vs));
+                }
+                if let Some(values) = self.not_in {
+                    let vs: Vec<FilterValue> = values.into_iter().map(to_fv).collect();
+                    parts.push(Filter::NotIn(col.clone(), vs));
+                }
+                if let Some(v) = self.lt { parts.push(Filter::Lt(col.clone(), to_fv(v))); }
+                if let Some(v) = self.lte { parts.push(Filter::Lte(col.clone(), to_fv(v))); }
+                if let Some(v) = self.gt { parts.push(Filter::Gt(col.clone(), to_fv(v))); }
+                if let Some(v) = self.gte { parts.push(Filter::Gte(col, to_fv(v))); }
+                match parts.len() {
+                    0 => Filter::None,
+                    1 => parts.into_iter().next().unwrap(),
+                    _ => Filter::and(parts),
+                }
+            }
+        }
+
+        $(#[$null_meta])*
+        #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+        #[serde(rename_all = "snake_case")]
+        pub struct $null {
+            /// `column = value`
+            pub equals: Option<$rust>,
+            /// Negation.
+            pub not: Option<Box<$null>>,
+            /// `column IN (...)`
+            pub in_list: Option<Vec<$rust>>,
+            /// `column NOT IN (...)`
+            pub not_in: Option<Vec<$rust>>,
+            /// `column < value`
+            pub lt: Option<$rust>,
+            /// `column <= value`
+            pub lte: Option<$rust>,
+            /// `column > value`
+            pub gt: Option<$rust>,
+            /// `column >= value`
+            pub gte: Option<$rust>,
+            /// IS NULL / IS NOT NULL.
+            pub is_null: Option<bool>,
+        }
+
+        impl ScalarFilter for $null {
+            fn into_filter(self, column: &str) -> Filter {
+                let mut parts: Vec<Filter> = Vec::new();
+                if let Some(b) = self.is_null {
+                    parts.push(if b {
+                        Filter::IsNull(column.to_string().into())
+                    } else {
+                        Filter::IsNotNull(column.to_string().into())
+                    });
+                }
+                let inner = $name {
+                    equals: self.equals,
+                    not: self.not.map(|b| Box::new($name {
+                        equals: b.equals,
+                        in_list: b.in_list,
+                        not_in: b.not_in,
+                        lt: b.lt, lte: b.lte, gt: b.gt, gte: b.gte,
+                        not: None,
+                    })),
+                    in_list: self.in_list,
+                    not_in: self.not_in,
+                    lt: self.lt, lte: self.lte, gt: self.gt, gte: self.gte,
+                };
+                let f = inner.into_filter(column);
+                if !matches!(f, Filter::None) { parts.push(f); }
+                match parts.len() {
+                    0 => Filter::None,
+                    1 => parts.into_iter().next().unwrap(),
+                    _ => Filter::and(parts),
+                }
+            }
+        }
+    };
+}
+
+scalar_filter!(
+    /// Filter for non-nullable `Int` (`i32`) columns.
+    IntFilter<i32> => |v: i32| { FilterValue::Int(v as i64) } as FilterValue::Int,
+    /// Filter for nullable `Int` columns.
+    nullable IntNullableFilter
+);
+
+scalar_filter!(
+    /// Filter for non-nullable `BigInt` (`i64`) columns.
+    BigIntFilter<i64> => |v: i64| { FilterValue::Int(v) } as FilterValue::Int,
+    /// Filter for nullable `BigInt` columns.
+    nullable BigIntNullableFilter
+);
+
+scalar_filter!(
+    /// Filter for non-nullable `Float` (`f64`) columns.
+    FloatFilter<f64> => |v: f64| { FilterValue::Float(v) } as FilterValue::Float,
+    /// Filter for nullable `Float` columns.
+    nullable FloatNullableFilter
+);
+
+scalar_filter!(
+    /// Filter for non-nullable `Decimal` (`rust_decimal::Decimal`) columns.
+    ///
+    /// Lowered as `FilterValue::String` because the runtime IR does not
+    /// have a dedicated `Decimal` variant; the driver layer parses it on
+    /// the wire.
+    DecimalFilter<rust_decimal::Decimal> => |v: rust_decimal::Decimal| { FilterValue::String(v.to_string()) } as FilterValue::String,
+    /// Filter for nullable `Decimal` columns.
+    nullable DecimalNullableFilter
+);
+
+scalar_filter!(
+    /// Filter for non-nullable `Uuid` columns.
+    UuidFilter<uuid::Uuid> => |v: uuid::Uuid| { FilterValue::String(v.to_string()) } as FilterValue::String,
+    /// Filter for nullable `Uuid` columns.
+    nullable UuidNullableFilter
+);
+
+scalar_filter!(
+    /// Filter for non-nullable `Bytes` (`Vec<u8>`) columns.
+    ///
+    /// Encoded as a base64-of-bytes string in FilterValue::String. The
+    /// driver layer decodes back to bytes on the wire.
+    BytesFilter<Vec<u8>> => |v: Vec<u8>| {
+        use base64::Engine as _;
+        FilterValue::String(base64::engine::general_purpose::STANDARD.encode(&v))
+    } as FilterValue::String,
+    /// Filter for nullable `Bytes` columns.
+    nullable BytesNullableFilter
+);
+
+/// Filter operators for a non-nullable `Boolean` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct BoolFilter {
+    /// `column = value`
+    pub equals: Option<bool>,
+    /// Negation of the inner filter.
+    pub not: Option<Box<BoolFilter>>,
+}
+
+impl BoolFilter {
+    /// `equals: Some(value)`.
+    pub fn equals(v: bool) -> Self { Self { equals: Some(v), ..Default::default() } }
+}
+
+impl From<bool> for BoolFilter {
+    fn from(v: bool) -> Self { Self::equals(v) }
+}
+
+impl ScalarFilter for BoolFilter {
+    fn into_filter(self, column: &str) -> Filter {
+        let col: crate::filter::FieldName = column.to_string().into();
+        let mut parts: Vec<Filter> = Vec::new();
+        if let Some(v) = self.equals {
+            parts.push(Filter::Equals(col.clone(), FilterValue::Bool(v)));
+        }
+        if let Some(boxed) = self.not {
+            parts.push(Filter::Not(Box::new(boxed.into_filter(column))));
+        }
+        match parts.len() {
+            0 => Filter::None,
+            1 => parts.into_iter().next().unwrap(),
+            _ => Filter::and(parts),
+        }
+    }
+}
+
+/// Filter operators for a nullable `Boolean` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct BoolNullableFilter {
+    /// `column = value`
+    pub equals: Option<bool>,
+    /// Negation.
+    pub not: Option<Box<BoolNullableFilter>>,
+    /// IS NULL / IS NOT NULL.
+    pub is_null: Option<bool>,
+}
+
+impl ScalarFilter for BoolNullableFilter {
+    fn into_filter(self, column: &str) -> Filter {
+        let mut parts: Vec<Filter> = Vec::new();
+        if let Some(b) = self.is_null {
+            parts.push(if b {
+                Filter::IsNull(column.to_string().into())
+            } else {
+                Filter::IsNotNull(column.to_string().into())
+            });
+        }
+        let inner = BoolFilter {
+            equals: self.equals,
+            not: self.not.map(|b| Box::new(BoolFilter { equals: b.equals, not: None })),
+        };
+        let f = inner.into_filter(column);
+        if !matches!(f, Filter::None) { parts.push(f); }
+        match parts.len() {
+            0 => Filter::None,
+            1 => parts.into_iter().next().unwrap(),
+            _ => Filter::and(parts),
+        }
+    }
+}
+
+/// Filter operators for a non-nullable `Json` column.
+///
+/// Phase 1 supports `equals`/`not`. JSON-path operators land behind
+/// `SupportsJsonPath` in a follow-up.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct JsonFilter {
+    /// `column = value`
+    pub equals: Option<serde_json::Value>,
+    /// Negation.
+    pub not: Option<Box<JsonFilter>>,
+}
+
+impl ScalarFilter for JsonFilter {
+    fn into_filter(self, column: &str) -> Filter {
+        let col: crate::filter::FieldName = column.to_string().into();
+        let mut parts: Vec<Filter> = Vec::new();
+        if let Some(v) = self.equals {
+            parts.push(Filter::Equals(col.clone(), FilterValue::Json(v)));
+        }
+        if let Some(boxed) = self.not {
+            parts.push(Filter::Not(Box::new(boxed.into_filter(column))));
+        }
+        match parts.len() {
+            0 => Filter::None,
+            1 => parts.into_iter().next().unwrap(),
+            _ => Filter::and(parts),
+        }
+    }
+}
+
+/// Filter operators for a nullable `Json` column.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct JsonNullableFilter {
+    /// `column = value`
+    pub equals: Option<serde_json::Value>,
+    /// Negation.
+    pub not: Option<Box<JsonNullableFilter>>,
+    /// IS NULL / IS NOT NULL.
+    pub is_null: Option<bool>,
+}
+
+impl ScalarFilter for JsonNullableFilter {
+    fn into_filter(self, column: &str) -> Filter {
+        let mut parts: Vec<Filter> = Vec::new();
+        if let Some(b) = self.is_null {
+            parts.push(if b {
+                Filter::IsNull(column.to_string().into())
+            } else {
+                Filter::IsNotNull(column.to_string().into())
+            });
+        }
+        let inner = JsonFilter {
+            equals: self.equals,
+            not: self.not.map(|b| Box::new(JsonFilter { equals: b.equals, not: None })),
+        };
+        let f = inner.into_filter(column);
+        if !matches!(f, Filter::None) { parts.push(f); }
+        match parts.len() {
+            0 => Filter::None,
+            1 => parts.into_iter().next().unwrap(),
+            _ => Filter::and(parts),
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Add `base64` to `prax-query` deps**
+
+The bytes filter uses `base64`. Edit `prax-query/Cargo.toml`'s `[dependencies]` and add:
+
+```toml
+base64 = { workspace = true }
+```
+
+If `base64` isn't already in `[workspace.dependencies]`, add it to the root `Cargo.toml`'s `[workspace.dependencies]` first:
+
+```toml
+base64 = "0.22"
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test -p prax-query --test inputs_scalar`
+Expected: all numeric/bool/bytes/uuid/json tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add prax-query/src/inputs/scalar.rs prax-query/tests/inputs_scalar.rs prax-query/Cargo.toml Cargo.toml Cargo.lock
+git commit -m "feat(query): add numeric, bool, bytes, uuid, json scalar filters
+
+IntFilter / BigIntFilter / FloatFilter / DecimalFilter / UuidFilter /
+BytesFilter generated via a scalar_filter! macro for consistency.
+BoolFilter / JsonFilter and their nullable variants are written out
+because their op set is smaller. Decimal / Uuid / Bytes lower to
+FilterValue::String (Decimal as digits, Uuid as hyphenated, Bytes as
+base64) since the runtime IR has no dedicated variants; the driver
+layer parses on the wire."
+```
+
+---
+
+## Task 8: Add datetime/date/time/enum filters
+
+**Files:**
+- Modify: `prax-query/src/inputs/scalar.rs`
+- Modify: `prax-query/tests/inputs_scalar.rs`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `prax-query/tests/inputs_scalar.rs`:
+
+```rust
+use prax_query::inputs::{
+    DateFilter, DateNullableFilter, DateTimeFilter, DateTimeNullableFilter, EnumFilter,
+    EnumNullableFilter, TimeFilter, TimeNullableFilter,
+};
+
+#[test]
+fn datetime_filter_equals_lowers() {
+    use chrono::{TimeZone, Utc};
+    let dt = Utc.with_ymd_and_hms(2026, 5, 18, 12, 0, 0).unwrap();
+    let f = DateTimeFilter::equals(dt);
+    let filter = f.into_filter("created_at");
+    // Encoded as RFC3339 string.
+    match filter {
+        Filter::Equals(col, FilterValue::String(s)) => {
+            assert_eq!(col, "created_at");
+            assert!(s.starts_with("2026-05-18T12:00:00"));
+        }
+        other => panic!("expected DateTime Equals, got {:?}", other),
+    }
+}
+
+#[test]
+fn date_filter_equals_lowers() {
+    use chrono::NaiveDate;
+    let d = NaiveDate::from_ymd_opt(2026, 5, 18).unwrap();
+    let f = DateFilter::equals(d);
+    let filter = f.into_filter("birthday");
+    match filter {
+        Filter::Equals(col, FilterValue::String(s)) => {
+            assert_eq!(col, "birthday");
+            assert_eq!(s, "2026-05-18");
+        }
+        other => panic!("expected Date Equals, got {:?}", other),
+    }
+}
+
+#[test]
+fn time_filter_equals_lowers() {
+    use chrono::NaiveTime;
+    let t = NaiveTime::from_hms_opt(13, 45, 0).unwrap();
+    let f = TimeFilter::equals(t);
+    let filter = f.into_filter("opens_at");
+    match filter {
+        Filter::Equals(col, FilterValue::String(s)) => {
+            assert_eq!(col, "opens_at");
+            assert_eq!(s, "13:45:00");
+        }
+        other => panic!("expected Time Equals, got {:?}", other),
+    }
+}
+
+#[test]
+fn enum_filter_equals_lowers() {
+    let f: EnumFilter<&str> = EnumFilter::equals("Admin");
+    let filter = f.into_filter("role");
+    assert_eq!(filter, Filter::Equals("role".into(), FilterValue::String("Admin".into())));
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cargo test -p prax-query --test inputs_scalar`
+Expected: compile errors — the new filter types don't exist.
+
+- [ ] **Step 3: Append the datetime/date/time/enum filters**
+
+Append to `prax-query/src/inputs/scalar.rs`:
+
+```rust
+scalar_filter!(
+    /// Filter for non-nullable `DateTime` columns (encoded RFC3339).
+    DateTimeFilter<chrono::DateTime<chrono::Utc>> => |v: chrono::DateTime<chrono::Utc>| {
+        FilterValue::String(v.to_rfc3339())
+    } as FilterValue::String,
+    /// Filter for nullable `DateTime` columns.
+    nullable DateTimeNullableFilter
+);
+
+scalar_filter!(
+    /// Filter for non-nullable `Date` columns (encoded YYYY-MM-DD).
+    DateFilter<chrono::NaiveDate> => |v: chrono::NaiveDate| {
+        FilterValue::String(v.to_string())
+    } as FilterValue::String,
+    /// Filter for nullable `Date` columns.
+    nullable DateNullableFilter
+);
+
+scalar_filter!(
+    /// Filter for non-nullable `Time` columns (encoded HH:MM:SS).
+    TimeFilter<chrono::NaiveTime> => |v: chrono::NaiveTime| {
+        FilterValue::String(v.format("%H:%M:%S").to_string())
+    } as FilterValue::String,
+    /// Filter for nullable `Time` columns.
+    nullable TimeNullableFilter
+);
+
+/// Filter operators for an enum-typed column.
+///
+/// `E` is the user-defined enum. Codegen `impl From<E> for String` so
+/// the macro's bare-ident shorthand (`role: Admin`) flows through.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", bound = "E: Serialize + for<'de2> Deserialize<'de2>")]
+pub struct EnumFilter<E> {
+    /// `column = value`
+    pub equals: Option<E>,
+    /// Negation.
+    pub not: Option<Box<EnumFilter<E>>>,
+    /// `column IN (...)`
+    pub in_list: Option<Vec<E>>,
+    /// `column NOT IN (...)`
+    pub not_in: Option<Vec<E>>,
+}
+
+impl<E> EnumFilter<E> {
+    /// `equals: Some(value)`.
+    pub fn equals(v: E) -> Self {
+        Self { equals: Some(v), not: None, in_list: None, not_in: None }
+    }
+}
+
+impl<E: ToString + Clone> ScalarFilter for EnumFilter<E> {
+    fn into_filter(self, column: &str) -> Filter {
+        let col: crate::filter::FieldName = column.to_string().into();
+        let mut parts: Vec<Filter> = Vec::new();
+        if let Some(v) = self.equals {
+            parts.push(Filter::Equals(col.clone(), FilterValue::String(v.to_string())));
+        }
+        if let Some(boxed) = self.not {
+            parts.push(Filter::Not(Box::new(boxed.into_filter(column))));
+        }
+        if let Some(values) = self.in_list {
+            let vs: Vec<FilterValue> = values.into_iter().map(|v| FilterValue::String(v.to_string())).collect();
+            parts.push(Filter::In(col.clone(), vs));
+        }
+        if let Some(values) = self.not_in {
+            let vs: Vec<FilterValue> = values.into_iter().map(|v| FilterValue::String(v.to_string())).collect();
+            parts.push(Filter::NotIn(col, vs));
+        }
+        match parts.len() {
+            0 => Filter::None,
+            1 => parts.into_iter().next().unwrap(),
+            _ => Filter::and(parts),
+        }
+    }
+}
+
+/// Filter operators for a nullable enum-typed column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", bound = "E: Serialize + for<'de2> Deserialize<'de2>")]
+pub struct EnumNullableFilter<E> {
+    /// `column = value`
+    pub equals: Option<E>,
+    /// Negation.
+    pub not: Option<Box<EnumNullableFilter<E>>>,
+    /// `column IN (...)`
+    pub in_list: Option<Vec<E>>,
+    /// `column NOT IN (...)`
+    pub not_in: Option<Vec<E>>,
+    /// IS NULL / IS NOT NULL.
+    pub is_null: Option<bool>,
+}
+
+impl<E: ToString + Clone> ScalarFilter for EnumNullableFilter<E> {
+    fn into_filter(self, column: &str) -> Filter {
+        let mut parts: Vec<Filter> = Vec::new();
+        if let Some(b) = self.is_null {
+            parts.push(if b {
+                Filter::IsNull(column.to_string().into())
+            } else {
+                Filter::IsNotNull(column.to_string().into())
+            });
+        }
+        let inner = EnumFilter::<E> {
+            equals: self.equals,
+            not: self.not.map(|b| Box::new(EnumFilter {
+                equals: b.equals,
+                in_list: b.in_list,
+                not_in: b.not_in,
+                not: None,
+            })),
+            in_list: self.in_list,
+            not_in: self.not_in,
+        };
+        let f = inner.into_filter(column);
+        if !matches!(f, Filter::None) { parts.push(f); }
+        match parts.len() {
+            0 => Filter::None,
+            1 => parts.into_iter().next().unwrap(),
+            _ => Filter::and(parts),
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p prax-query --test inputs_scalar`
+Expected: all datetime/date/time/enum tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add prax-query/src/inputs/scalar.rs prax-query/tests/inputs_scalar.rs
+git commit -m "feat(query): add datetime/date/time/enum scalar filters
+
+DateTimeFilter encodes as RFC3339, DateFilter as YYYY-MM-DD,
+TimeFilter as HH:MM:SS, EnumFilter<E> via the user enum's ToString.
+All lower to FilterValue::String — the driver layer parses on the
+wire."
+```
+
+---
+
+## Task 9: Relation filter wrappers
+
+**Files:**
+- Create: `prax-query/src/inputs/relation.rs`
+- Create: `prax-query/tests/inputs_relation.rs`
+
+`ListRelationFilter<W>` and `SingleRelationFilter<W>` lower to
+`Filter::ScalarSubquery` via a per-relation `RelationMeta` adapter that
+phase 2's codegen will supply. Phase 1 introduces the wrappers and a
+hand-built adapter trait used in tests.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `prax-query/tests/inputs_relation.rs`:
+
+```rust
+use prax_query::filter::{Filter, FilterValue};
+use prax_query::inputs::{
+    relation::{LowerRelationFilter, RelationMeta, ListRelationFilter, SingleRelationFilter},
+    StringFilter, WhereInput,
+};
+use prax_query::traits::Model;
+
+struct Post;
+impl Model for Post {
+    const MODEL_NAME: &'static str = "Post";
+    const TABLE_NAME: &'static str = "posts";
+    const PRIMARY_KEY: &'static [&'static str] = &["id"];
+    const COLUMNS: &'static [&'static str] = &["id", "author_id", "published"];
+}
+
+#[derive(Default, Clone)]
+struct PostWhereInput {
+    pub published: Option<prax_query::inputs::BoolFilter>,
+}
+impl WhereInput for PostWhereInput {
+    type Model = Post;
+    fn into_ir(self) -> Filter {
+        use prax_query::inputs::ScalarFilter;
+        match self.published {
+            Some(f) => f.into_filter("published"),
+            None => Filter::None,
+        }
+    }
+}
+
+// Hand-built relation meta for `User.posts` so we don't need the codegen.
+struct UserPostsMeta;
+impl RelationMeta for UserPostsMeta {
+    const PARENT_TABLE: &'static str = "users";
+    const PARENT_PK: &'static str = "id";
+    const CHILD_TABLE: &'static str = "posts";
+    const CHILD_FK: &'static str = "author_id";
+}
+
+#[test]
+fn list_relation_some_lowers_to_exists_scalar_subquery() {
+    let rf = ListRelationFilter {
+        some: Some(PostWhereInput {
+            published: Some(prax_query::inputs::BoolFilter::equals(true)),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let filter = rf.lower::<UserPostsMeta>();
+    match filter {
+        Filter::ScalarSubquery { sql, params } => {
+            assert!(sql.contains("EXISTS"));
+            assert!(sql.contains("posts"));
+            assert!(sql.contains("author_id"));
+            // The inner filter pulls `published = $?` into the subquery.
+            assert!(params.iter().any(|p| matches!(p, FilterValue::Bool(true))));
+        }
+        other => panic!("expected Filter::ScalarSubquery, got {:?}", other),
+    }
+}
+
+#[test]
+fn list_relation_none_lowers_to_not_exists() {
+    let rf = ListRelationFilter::<PostWhereInput> {
+        none: Some(PostWhereInput {
+            published: Some(prax_query::inputs::BoolFilter::equals(true)),
+        }),
+        ..Default::default()
+    };
+    let filter = rf.lower::<UserPostsMeta>();
+    match filter {
+        Filter::ScalarSubquery { sql, .. } => assert!(sql.starts_with("NOT EXISTS")),
+        other => panic!("expected NOT EXISTS subquery, got {:?}", other),
+    }
+}
+
+#[test]
+fn list_relation_every_lowers_to_not_exists_negated() {
+    let rf = ListRelationFilter::<PostWhereInput> {
+        every: Some(PostWhereInput {
+            published: Some(prax_query::inputs::BoolFilter::equals(true)),
+        }),
+        ..Default::default()
+    };
+    let filter = rf.lower::<UserPostsMeta>();
+    // `every: F` == `NOT EXISTS (child WHERE parent.pk = child.fk AND NOT (F))`.
+    match filter {
+        Filter::ScalarSubquery { sql, .. } => {
+            assert!(sql.starts_with("NOT EXISTS"));
+            assert!(sql.contains("NOT ("));
+        }
+        other => panic!("expected NOT EXISTS subquery, got {:?}", other),
+    }
+}
+
+#[test]
+fn single_relation_is_lowers_to_exists() {
+    let rf = SingleRelationFilter::<PostWhereInput> {
+        is: Some(PostWhereInput {
+            published: Some(prax_query::inputs::BoolFilter::equals(true)),
+        }),
+        ..Default::default()
+    };
+    let filter = rf.lower::<UserPostsMeta>();
+    match filter {
+        Filter::ScalarSubquery { sql, .. } => assert!(sql.starts_with("EXISTS")),
+        other => panic!("expected EXISTS subquery, got {:?}", other),
+    }
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cargo test -p prax-query --test inputs_relation`
+Expected: compile error — types not found.
+
+- [ ] **Step 3: Implement the relation module**
+
+Create `prax-query/src/inputs/relation.rs`:
+
+```rust
+//! Relation-aware filter wrappers.
+//!
+//! `ListRelationFilter<W>` and `SingleRelationFilter<W>` carry the
+//! Prisma operator shape (`some`/`every`/`none` for to-many;
+//! `is`/`is_not` for to-one). They lower to [`Filter::ScalarSubquery`]
+//! fragments via a per-relation [`RelationMeta`] adapter that codegen
+//! emits (phase 2) but tests / hand-built users can supply directly.
+
+use crate::filter::{Filter, FilterValue};
+use crate::inputs::traits::WhereInput;
+
+/// Static metadata for one parent→child relation.
+///
+/// Phase 2 codegen emits one impl per relation declared in the schema.
+/// Hand-rolled callers can implement this trait themselves.
+pub trait RelationMeta {
+    /// Parent SQL table name.
+    const PARENT_TABLE: &'static str;
+    /// Parent primary-key column name.
+    const PARENT_PK: &'static str;
+    /// Child SQL table name.
+    const CHILD_TABLE: &'static str;
+    /// Child foreign-key column name pointing back at the parent.
+    const CHILD_FK: &'static str;
+}
+
+/// Filter operators for a to-many relation.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ListRelationFilter<W> {
+    /// At least one child matches `W`.
+    pub some: Option<W>,
+    /// Every existing child matches `W`.
+    pub every: Option<W>,
+    /// No child matches `W`.
+    pub none: Option<W>,
+}
+
+/// Filter operators for a to-one relation.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct SingleRelationFilter<W> {
+    /// The related row matches `W`.
+    pub is: Option<W>,
+    /// The related row does NOT match `W` (or doesn't exist).
+    pub is_not: Option<W>,
+}
+
+/// Lowering helper: produces `Filter::ScalarSubquery` from a relation
+/// filter + `RelationMeta`.
+///
+/// Implemented blanket-style for any `W: WhereInput` so neither the
+/// codegen nor the macro layer needs to manually thread metadata.
+pub trait LowerRelationFilter {
+    /// Lower this relation filter to a runtime [`Filter`] using the
+    /// supplied metadata.
+    fn lower<M: RelationMeta>(self) -> Filter;
+}
+
+fn render_inline_filter(
+    inner: Filter,
+    out_sql: &mut String,
+    out_params: &mut Vec<FilterValue>,
+    base: usize,
+) {
+    // Walk a Filter producing `{N}`-placeholder SQL keyed by inner-param indices.
+    // For phase 1 we keep this minimal: support the AND/OR/NOT plus the leaf
+    // operators that the scalar filters emit. ScalarSubquery nesting is not
+    // expected at phase 1.
+    fn write(f: &Filter, sql: &mut String, params: &mut Vec<FilterValue>) {
+        match f {
+            Filter::None => sql.push_str("TRUE"),
+            Filter::Equals(c, v) => {
+                if matches!(v, FilterValue::Null) {
+                    sql.push_str(&format!("{} IS NULL", c));
+                } else {
+                    let idx = params.len();
+                    params.push(v.clone());
+                    sql.push_str(&format!("{} = {{{}}}", c, idx));
+                }
+            }
+            Filter::NotEquals(c, v) => {
+                if matches!(v, FilterValue::Null) {
+                    sql.push_str(&format!("{} IS NOT NULL", c));
+                } else {
+                    let idx = params.len();
+                    params.push(v.clone());
+                    sql.push_str(&format!("{} <> {{{}}}", c, idx));
+                }
+            }
+            Filter::Lt(c, v) => { let i = params.len(); params.push(v.clone()); sql.push_str(&format!("{} < {{{}}}", c, i)); }
+            Filter::Lte(c, v) => { let i = params.len(); params.push(v.clone()); sql.push_str(&format!("{} <= {{{}}}", c, i)); }
+            Filter::Gt(c, v) => { let i = params.len(); params.push(v.clone()); sql.push_str(&format!("{} > {{{}}}", c, i)); }
+            Filter::Gte(c, v) => { let i = params.len(); params.push(v.clone()); sql.push_str(&format!("{} >= {{{}}}", c, i)); }
+            Filter::IsNull(c) => sql.push_str(&format!("{} IS NULL", c)),
+            Filter::IsNotNull(c) => sql.push_str(&format!("{} IS NOT NULL", c)),
+            Filter::Contains(c, FilterValue::String(s)) => {
+                let i = params.len(); params.push(FilterValue::String(format!("%{}%", s)));
+                sql.push_str(&format!("{} LIKE {{{}}}", c, i));
+            }
+            Filter::StartsWith(c, FilterValue::String(s)) => {
+                let i = params.len(); params.push(FilterValue::String(format!("{}%", s)));
+                sql.push_str(&format!("{} LIKE {{{}}}", c, i));
+            }
+            Filter::EndsWith(c, FilterValue::String(s)) => {
+                let i = params.len(); params.push(FilterValue::String(format!("%{}", s)));
+                sql.push_str(&format!("{} LIKE {{{}}}", c, i));
+            }
+            Filter::Contains(_, _) | Filter::StartsWith(_, _) | Filter::EndsWith(_, _) => {
+                panic!("phase 1 inline lowering supports only String LIKE values");
+            }
+            Filter::In(c, values) => {
+                if values.is_empty() { sql.push_str("FALSE"); return; }
+                sql.push_str(&format!("{} IN (", c));
+                for (n, v) in values.iter().enumerate() {
+                    if n > 0 { sql.push_str(", "); }
+                    let i = params.len(); params.push(v.clone()); sql.push_str(&format!("{{{}}}", i));
+                }
+                sql.push(')');
+            }
+            Filter::NotIn(c, values) => {
+                if values.is_empty() { sql.push_str("TRUE"); return; }
+                sql.push_str(&format!("{} NOT IN (", c));
+                for (n, v) in values.iter().enumerate() {
+                    if n > 0 { sql.push_str(", "); }
+                    let i = params.len(); params.push(v.clone()); sql.push_str(&format!("{{{}}}", i));
+                }
+                sql.push(')');
+            }
+            Filter::And(parts) => {
+                if parts.is_empty() { sql.push_str("TRUE"); return; }
+                sql.push('(');
+                for (n, p) in parts.iter().enumerate() {
+                    if n > 0 { sql.push_str(" AND "); }
+                    write(p, sql, params);
+                }
+                sql.push(')');
+            }
+            Filter::Or(parts) => {
+                if parts.is_empty() { sql.push_str("FALSE"); return; }
+                sql.push('(');
+                for (n, p) in parts.iter().enumerate() {
+                    if n > 0 { sql.push_str(" OR "); }
+                    write(p, sql, params);
+                }
+                sql.push(')');
+            }
+            Filter::Not(inner) => { sql.push_str("NOT ("); write(inner, sql, params); sql.push(')'); }
+            Filter::ScalarSubquery { .. } => {
+                panic!("phase 1 does not support nesting ScalarSubquery inside relation filters");
+            }
+        }
+    }
+    let mut sql = String::new();
+    write(&inner, &mut sql, out_params);
+    // Re-key placeholders to start at `base` instead of 0.
+    let rekeyed = sql
+        .as_bytes()
+        .iter()
+        .scan(false, |in_brace, b| Some((b, in_brace)))
+        .map(|(_, _)| ()) // placeholder so we can use sql below
+        .count();
+    let _ = rekeyed;
+    // Rewrite `{n}` => `{base+n}` so the outer to_sql_with_params indexes correctly.
+    let mut rewritten = String::with_capacity(sql.len());
+    let mut chars = sql.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '{' {
+            let mut digits = String::new();
+            while let Some(&p) = chars.peek() {
+                if p == '}' { chars.next(); break; }
+                digits.push(p); chars.next();
+            }
+            let n: usize = digits.parse().expect("placeholder index");
+            rewritten.push_str(&format!("{{{}}}", base + n));
+        } else {
+            rewritten.push(c);
+        }
+    }
+    out_sql.push_str(&rewritten);
+}
+
+impl<W: WhereInput> LowerRelationFilter for ListRelationFilter<W> {
+    fn lower<M: RelationMeta>(self) -> Filter {
+        let mut clauses: Vec<Filter> = Vec::new();
+        if let Some(w) = self.some {
+            let inner = w.into_ir();
+            let mut params: Vec<FilterValue> = Vec::new();
+            let mut body = String::new();
+            render_inline_filter(inner, &mut body, &mut params, 0);
+            let sql = format!(
+                "EXISTS (SELECT 1 FROM {} WHERE {}.{} = {}.{} AND {})",
+                M::CHILD_TABLE, M::CHILD_TABLE, M::CHILD_FK, M::PARENT_TABLE, M::PARENT_PK, body
+            );
+            clauses.push(Filter::ScalarSubquery { sql: sql.into(), params });
+        }
+        if let Some(w) = self.every {
+            let inner = w.into_ir();
+            let mut params: Vec<FilterValue> = Vec::new();
+            let mut body = String::new();
+            render_inline_filter(inner, &mut body, &mut params, 0);
+            let sql = format!(
+                "NOT EXISTS (SELECT 1 FROM {} WHERE {}.{} = {}.{} AND NOT ({}))",
+                M::CHILD_TABLE, M::CHILD_TABLE, M::CHILD_FK, M::PARENT_TABLE, M::PARENT_PK, body
+            );
+            clauses.push(Filter::ScalarSubquery { sql: sql.into(), params });
+        }
+        if let Some(w) = self.none {
+            let inner = w.into_ir();
+            let mut params: Vec<FilterValue> = Vec::new();
+            let mut body = String::new();
+            render_inline_filter(inner, &mut body, &mut params, 0);
+            let sql = format!(
+                "NOT EXISTS (SELECT 1 FROM {} WHERE {}.{} = {}.{} AND {})",
+                M::CHILD_TABLE, M::CHILD_TABLE, M::CHILD_FK, M::PARENT_TABLE, M::PARENT_PK, body
+            );
+            clauses.push(Filter::ScalarSubquery { sql: sql.into(), params });
+        }
+        match clauses.len() {
+            0 => Filter::None,
+            1 => clauses.into_iter().next().unwrap(),
+            _ => Filter::and(clauses),
+        }
+    }
+}
+
+impl<W: WhereInput> LowerRelationFilter for SingleRelationFilter<W> {
+    fn lower<M: RelationMeta>(self) -> Filter {
+        let mut clauses: Vec<Filter> = Vec::new();
+        if let Some(w) = self.is {
+            let inner = w.into_ir();
+            let mut params: Vec<FilterValue> = Vec::new();
+            let mut body = String::new();
+            render_inline_filter(inner, &mut body, &mut params, 0);
+            let sql = format!(
+                "EXISTS (SELECT 1 FROM {} WHERE {}.{} = {}.{} AND {})",
+                M::CHILD_TABLE, M::CHILD_TABLE, M::CHILD_FK, M::PARENT_TABLE, M::PARENT_PK, body
+            );
+            clauses.push(Filter::ScalarSubquery { sql: sql.into(), params });
+        }
+        if let Some(w) = self.is_not {
+            let inner = w.into_ir();
+            let mut params: Vec<FilterValue> = Vec::new();
+            let mut body = String::new();
+            render_inline_filter(inner, &mut body, &mut params, 0);
+            let sql = format!(
+                "NOT EXISTS (SELECT 1 FROM {} WHERE {}.{} = {}.{} AND {})",
+                M::CHILD_TABLE, M::CHILD_TABLE, M::CHILD_FK, M::PARENT_TABLE, M::PARENT_PK, body
+            );
+            clauses.push(Filter::ScalarSubquery { sql: sql.into(), params });
+        }
+        match clauses.len() {
+            0 => Filter::None,
+            1 => clauses.into_iter().next().unwrap(),
+            _ => Filter::and(clauses),
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p prax-query --test inputs_relation`
+Expected: every relation test passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add prax-query/src/inputs/relation.rs prax-query/tests/inputs_relation.rs
+git commit -m "feat(query): add relation filter wrappers + EXISTS/NOT EXISTS lowering
+
+ListRelationFilter (some/every/none) and SingleRelationFilter
+(is/is_not) lower to Filter::ScalarSubquery via a per-relation
+RelationMeta adapter. Phase 1 supplies a hand-rolled inline filter
+renderer scoped to the operators the scalar filters emit;
+phase 2 codegen supplies RelationMeta impls per relation."
+```
+
+---
+
+## Task 10: Scalar field update wrappers
+
+**Files:**
+- Create: `prax-query/src/inputs/scalar_update.rs`
+- Create: `prax-query/tests/inputs_update.rs`
+
+These match the spec's `IntFieldUpdate { set, increment, decrement, multiply, divide }` and string/bool/enum cousins. Phase 1 stores them; phase 5 (writes) consumes them.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `prax-query/tests/inputs_update.rs`:
+
+```rust
+use prax_query::inputs::{
+    BoolFieldUpdate, IntFieldUpdate, IntNullableFieldUpdate, StringFieldUpdate,
+    StringNullableFieldUpdate,
+};
+
+#[test]
+fn int_field_update_from_scalar_shortcut() {
+    let u: IntFieldUpdate = 5i32.into();
+    assert_eq!(u.set, Some(5));
+    assert!(u.increment.is_none());
+}
+
+#[test]
+fn int_field_update_increment_and_set_keeps_both() {
+    let u = IntFieldUpdate { set: Some(0), increment: Some(1), ..Default::default() };
+    assert_eq!(u.set, Some(0));
+    assert_eq!(u.increment, Some(1));
+}
+
+#[test]
+fn string_nullable_field_update_unset_marker() {
+    let u = StringNullableFieldUpdate { unset: Some(true), ..Default::default() };
+    assert_eq!(u.unset, Some(true));
+}
+
+#[test]
+fn string_field_update_from_scalar_shortcut() {
+    let u: StringFieldUpdate = "Alice".into();
+    assert_eq!(u.set.as_deref(), Some("Alice"));
+}
+
+#[test]
+fn bool_field_update_from_scalar_shortcut() {
+    let u: BoolFieldUpdate = true.into();
+    assert_eq!(u.set, Some(true));
+}
+
+#[test]
+fn int_nullable_field_update_unset_marker() {
+    let u = IntNullableFieldUpdate { unset: Some(true), ..Default::default() };
+    assert_eq!(u.unset, Some(true));
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cargo test -p prax-query --test inputs_update`
+Expected: compile error.
+
+- [ ] **Step 3: Implement the module**
+
+Create `prax-query/src/inputs/scalar_update.rs`:
+
+```rust
+//! Scalar field update wrappers.
+//!
+//! Each `*FieldUpdate` struct carries the atomic operators expressible
+//! against one scalar type. Phase 5 (write macros) consumes these;
+//! phase 1 only defines them so the codegen scaffolding in phase 2
+//! can refer to them.
+
+use serde::{Deserialize, Serialize};
+
+/// Update operators for a non-nullable `Int` (`i32`) column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct IntFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<i64>,
+    /// `SET column = column + value`
+    pub increment: Option<i64>,
+    /// `SET column = column - value`
+    pub decrement: Option<i64>,
+    /// `SET column = column * value`
+    pub multiply: Option<i64>,
+    /// `SET column = column / value`
+    pub divide: Option<i64>,
+}
+
+impl From<i32> for IntFieldUpdate {
+    fn from(v: i32) -> Self { Self { set: Some(v as i64), ..Default::default() } }
+}
+impl From<i64> for IntFieldUpdate {
+    fn from(v: i64) -> Self { Self { set: Some(v), ..Default::default() } }
+}
+
+/// Update operators for a nullable `Int` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct IntNullableFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<i64>,
+    /// `SET column = column + value`
+    pub increment: Option<i64>,
+    /// `SET column = column - value`
+    pub decrement: Option<i64>,
+    /// `SET column = column * value`
+    pub multiply: Option<i64>,
+    /// `SET column = column / value`
+    pub divide: Option<i64>,
+    /// `SET column = NULL`
+    pub unset: Option<bool>,
+}
+
+/// Update operators for a non-nullable `BigInt` (`i64`) column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct BigIntFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<i64>,
+    /// `SET column = column + value`
+    pub increment: Option<i64>,
+    /// `SET column = column - value`
+    pub decrement: Option<i64>,
+    /// `SET column = column * value`
+    pub multiply: Option<i64>,
+    /// `SET column = column / value`
+    pub divide: Option<i64>,
+}
+
+impl From<i64> for BigIntFieldUpdate {
+    fn from(v: i64) -> Self { Self { set: Some(v), ..Default::default() } }
+}
+
+/// Update operators for a nullable `BigInt` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct BigIntNullableFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<i64>,
+    /// `SET column = column + value`
+    pub increment: Option<i64>,
+    /// `SET column = column - value`
+    pub decrement: Option<i64>,
+    /// `SET column = column * value`
+    pub multiply: Option<i64>,
+    /// `SET column = column / value`
+    pub divide: Option<i64>,
+    /// `SET column = NULL`
+    pub unset: Option<bool>,
+}
+
+/// Update operators for a non-nullable `Float` column.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct FloatFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<f64>,
+    /// `SET column = column + value`
+    pub increment: Option<f64>,
+    /// `SET column = column - value`
+    pub decrement: Option<f64>,
+    /// `SET column = column * value`
+    pub multiply: Option<f64>,
+    /// `SET column = column / value`
+    pub divide: Option<f64>,
+}
+
+impl From<f64> for FloatFieldUpdate {
+    fn from(v: f64) -> Self { Self { set: Some(v), ..Default::default() } }
+}
+
+/// Update operators for a nullable `Float` column.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct FloatNullableFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<f64>,
+    /// `SET column = column + value`
+    pub increment: Option<f64>,
+    /// `SET column = column - value`
+    pub decrement: Option<f64>,
+    /// `SET column = column * value`
+    pub multiply: Option<f64>,
+    /// `SET column = column / value`
+    pub divide: Option<f64>,
+    /// `SET column = NULL`
+    pub unset: Option<bool>,
+}
+
+/// Update operators for a non-nullable `Decimal` column (transmitted as string).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct DecimalFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<String>,
+    /// `SET column = column + value`
+    pub increment: Option<String>,
+    /// `SET column = column - value`
+    pub decrement: Option<String>,
+    /// `SET column = column * value`
+    pub multiply: Option<String>,
+    /// `SET column = column / value`
+    pub divide: Option<String>,
+}
+
+/// Update operators for a nullable `Decimal` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct DecimalNullableFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<String>,
+    /// `SET column = column + value`
+    pub increment: Option<String>,
+    /// `SET column = column - value`
+    pub decrement: Option<String>,
+    /// `SET column = column * value`
+    pub multiply: Option<String>,
+    /// `SET column = column / value`
+    pub divide: Option<String>,
+    /// `SET column = NULL`
+    pub unset: Option<bool>,
+}
+
+/// Update operators for a non-nullable `String` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct StringFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<String>,
+}
+
+impl From<&str> for StringFieldUpdate {
+    fn from(v: &str) -> Self { Self { set: Some(v.into()) } }
+}
+impl From<String> for StringFieldUpdate {
+    fn from(v: String) -> Self { Self { set: Some(v) } }
+}
+
+/// Update operators for a nullable `String` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct StringNullableFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<String>,
+    /// `SET column = NULL`
+    pub unset: Option<bool>,
+}
+
+impl From<&str> for StringNullableFieldUpdate {
+    fn from(v: &str) -> Self { Self { set: Some(v.into()), unset: None } }
+}
+impl From<String> for StringNullableFieldUpdate {
+    fn from(v: String) -> Self { Self { set: Some(v), unset: None } }
+}
+
+/// Update operators for a non-nullable `Boolean` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct BoolFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<bool>,
+}
+
+impl From<bool> for BoolFieldUpdate {
+    fn from(v: bool) -> Self { Self { set: Some(v) } }
+}
+
+/// Update operators for a nullable `Boolean` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct BoolNullableFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<bool>,
+    /// `SET column = NULL`
+    pub unset: Option<bool>,
+}
+
+/// Update operators for an enum-typed column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", bound = "E: Serialize + for<'de2> Deserialize<'de2>")]
+pub struct EnumFieldUpdate<E> {
+    /// `SET column = value`
+    pub set: Option<E>,
+}
+
+/// Update operators for a nullable enum-typed column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", bound = "E: Serialize + for<'de2> Deserialize<'de2>")]
+pub struct EnumNullableFieldUpdate<E> {
+    /// `SET column = value`
+    pub set: Option<E>,
+    /// `SET column = NULL`
+    pub unset: Option<bool>,
+}
+
+/// Update operators for a non-nullable `DateTime` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct DateTimeFieldUpdate {
+    /// `SET column = value` (RFC3339-encoded).
+    pub set: Option<String>,
+}
+
+/// Update operators for a nullable `DateTime` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct DateTimeNullableFieldUpdate {
+    /// `SET column = value` (RFC3339-encoded).
+    pub set: Option<String>,
+    /// `SET column = NULL`
+    pub unset: Option<bool>,
+}
+
+/// Update operators for a non-nullable `Bytes` column (base64-encoded).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct BytesFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<String>,
+}
+
+/// Update operators for a nullable `Bytes` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct BytesNullableFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<String>,
+    /// `SET column = NULL`
+    pub unset: Option<bool>,
+}
+
+/// Update operators for a non-nullable `Uuid` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct UuidFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<String>,
+}
+
+/// Update operators for a nullable `Uuid` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct UuidNullableFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<String>,
+    /// `SET column = NULL`
+    pub unset: Option<bool>,
+}
+
+/// Update operators for a non-nullable `Json` column.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct JsonFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<serde_json::Value>,
+}
+
+/// Update operators for a nullable `Json` column.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct JsonNullableFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<serde_json::Value>,
+    /// `SET column = NULL`
+    pub unset: Option<bool>,
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p prax-query --test inputs_update`
+Expected: every test passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add prax-query/src/inputs/scalar_update.rs prax-query/tests/inputs_update.rs
+git commit -m "feat(query): add scalar field update wrappers
+
+One *FieldUpdate per scalar type, plus nullable variants with an
+`unset` flag for SET column = NULL. Numeric variants carry the atomic
+ops (increment/decrement/multiply/divide). Phase 5 (write macros)
+consumes these; phase 1 only defines the shapes and From<scalar>
+ergonomics so the macro DSL's `name: \"Alice\"` shorthand has a
+runtime target."
+```
+
+---
+
+## Task 11: Per-operation `*Args` containers
+
+**Files:**
+- Create: `prax-query/src/inputs/args.rs`
+- Create: `prax-query/tests/inputs_args.rs`
+
+`FindManyArgs<E, M>` etc. are the explicit-struct third interface promised in the spec. They round-trip through the operation builders.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `prax-query/tests/inputs_args.rs`:
+
+```rust
+use prax_query::filter::Filter;
+use prax_query::inputs::{
+    CountArgs, CreateArgs, CreateManyArgs, DeleteArgs, DeleteManyArgs, FindFirstArgs,
+    FindManyArgs, FindUniqueArgs, UpdateArgs, UpdateManyArgs, UpsertArgs,
+};
+use prax_query::traits::Model;
+
+struct TestModel;
+impl Model for TestModel {
+    const MODEL_NAME: &'static str = "TestModel";
+    const TABLE_NAME: &'static str = "test_models";
+    const PRIMARY_KEY: &'static [&'static str] = &["id"];
+    const COLUMNS: &'static [&'static str] = &["id"];
+}
+
+#[test]
+fn find_many_args_default_is_empty() {
+    let a: FindManyArgs<TestModel, Filter, (), ()> = FindManyArgs::default();
+    assert!(a.r#where.is_none());
+    assert!(a.include.is_none());
+    assert!(a.select.is_none());
+    assert!(a.order_by.is_none());
+    assert!(a.cursor.is_none());
+    assert_eq!(a.skip, None);
+    assert_eq!(a.take, None);
+}
+
+#[test]
+fn find_unique_args_carries_unique_filter() {
+    let a: FindUniqueArgs<TestModel, Filter, (), ()> = FindUniqueArgs {
+        r#where: Filter::None,
+        include: None,
+        select: None,
+    };
+    assert!(matches!(a.r#where, Filter::None));
+}
+
+#[test]
+fn create_args_carries_data() {
+    let a: CreateArgs<TestModel, (), (), ()> = CreateArgs { data: (), include: None, select: None };
+    assert_eq!(std::mem::size_of_val(&a.data), 0);
+}
+
+#[test]
+fn upsert_args_round_trip() {
+    let a: UpsertArgs<TestModel, Filter, (), (), (), ()> = UpsertArgs {
+        r#where: Filter::None,
+        create: (),
+        update: (),
+        include: None,
+        select: None,
+    };
+    assert!(matches!(a.r#where, Filter::None));
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cargo test -p prax-query --test inputs_args`
+Expected: compile error.
+
+- [ ] **Step 3: Implement `args.rs`**
+
+Create `prax-query/src/inputs/args.rs`:
+
+```rust
+//! Per-operation argument containers.
+//!
+//! Each struct is the layer-2 "explicit form" of an operation request:
+//! the macro DSL (phase 3+) expands to a `*Args { ... }` literal that
+//! the operation builder consumes via `.with_args(args)`. Direct
+//! construction by hand is fully supported.
+//!
+//! Generic parameters:
+//! - `M` — the model
+//! - `W` — `WhereInput` impl for that model
+//! - `I` — `IncludeInput` impl
+//! - `S` — `SelectInput` impl
+//! - `D` — `CreateInput::Data` / `UpdateInput::Data` payload (operation-specific)
+//! - `O` — `OrderByInput` impl
+//!
+//! Phase 1 keeps the bounds open so hand-construction works even before
+//! codegen lands. Phase 2 narrows them when the per-model types exist.
+
+use core::marker::PhantomData;
+
+/// Args for `find_unique`. `where` must identify at most one row.
+#[derive(Debug, Clone)]
+pub struct FindUniqueArgs<M, W, I, S> {
+    /// Unique WHERE input.
+    pub r#where: W,
+    /// Optional include shape.
+    pub include: Option<I>,
+    /// Optional select shape.
+    pub select: Option<S>,
+    /// Phantom marker for the model type.
+    #[doc(hidden)]
+    pub _model: PhantomData<M>,
+}
+
+impl<M, W: Default, I, S> Default for FindUniqueArgs<M, W, I, S> {
+    fn default() -> Self {
+        Self { r#where: W::default(), include: None, select: None, _model: PhantomData }
+    }
+}
+
+impl<M, W, I, S> FindUniqueArgs<M, W, I, S> {
+    /// Construct with the given unique WHERE.
+    pub fn new(r#where: W) -> Self {
+        Self { r#where, include: None, select: None, _model: PhantomData }
+    }
+}
+
+/// Args for `find_first`.
+#[derive(Debug, Clone, Default)]
+pub struct FindFirstArgs<M, W, I, S, O = (), C = ()> {
+    /// Optional WHERE input.
+    pub r#where: Option<W>,
+    /// Optional include shape.
+    pub include: Option<I>,
+    /// Optional select shape.
+    pub select: Option<S>,
+    /// Optional order-by shape (single or vec).
+    pub order_by: Option<Vec<O>>,
+    /// Optional cursor value.
+    pub cursor: Option<C>,
+    /// Skip N rows.
+    pub skip: Option<u64>,
+    /// Take N rows.
+    pub take: Option<u64>,
+    /// Phantom marker for the model.
+    #[doc(hidden)]
+    pub _model: PhantomData<M>,
+}
+
+/// Args for `find_many`.
+#[derive(Debug, Clone, Default)]
+pub struct FindManyArgs<M, W, I, S, O = (), C = ()> {
+    /// Optional WHERE input.
+    pub r#where: Option<W>,
+    /// Optional include shape.
+    pub include: Option<I>,
+    /// Optional select shape.
+    pub select: Option<S>,
+    /// Optional order-by shape (single or vec).
+    pub order_by: Option<Vec<O>>,
+    /// Optional cursor value.
+    pub cursor: Option<C>,
+    /// Skip N rows.
+    pub skip: Option<u64>,
+    /// Take N rows.
+    pub take: Option<u64>,
+    /// Distinct columns.
+    pub distinct: Option<Vec<String>>,
+    /// Phantom marker for the model.
+    #[doc(hidden)]
+    pub _model: PhantomData<M>,
+}
+
+/// Args for `create`.
+#[derive(Debug, Clone)]
+pub struct CreateArgs<M, D, I, S> {
+    /// Create-data payload.
+    pub data: D,
+    /// Optional include shape on the returning row.
+    pub include: Option<I>,
+    /// Optional select shape on the returning row.
+    pub select: Option<S>,
+    /// Phantom marker for the model.
+    #[doc(hidden)]
+    pub _model: PhantomData<M>,
+}
+
+impl<M, D: Default, I, S> Default for CreateArgs<M, D, I, S> {
+    fn default() -> Self {
+        Self { data: D::default(), include: None, select: None, _model: PhantomData }
+    }
+}
+
+/// Args for `create_many`.
+#[derive(Debug, Clone)]
+pub struct CreateManyArgs<M, D> {
+    /// Create-data payloads.
+    pub data: Vec<D>,
+    /// Skip rows that would violate a unique constraint (instead of erroring).
+    pub skip_duplicates: Option<bool>,
+    /// Phantom marker for the model.
+    #[doc(hidden)]
+    pub _model: PhantomData<M>,
+}
+
+impl<M, D> Default for CreateManyArgs<M, D> {
+    fn default() -> Self { Self { data: Vec::new(), skip_duplicates: None, _model: PhantomData } }
+}
+
+/// Args for `update`.
+#[derive(Debug, Clone)]
+pub struct UpdateArgs<M, W, U, I, S> {
+    /// Unique WHERE input.
+    pub r#where: W,
+    /// Update-data payload.
+    pub data: U,
+    /// Optional include shape.
+    pub include: Option<I>,
+    /// Optional select shape.
+    pub select: Option<S>,
+    /// Phantom marker for the model.
+    #[doc(hidden)]
+    pub _model: PhantomData<M>,
+}
+
+/// Args for `update_many`.
+#[derive(Debug, Clone, Default)]
+pub struct UpdateManyArgs<M, W, U> {
+    /// Optional WHERE input.
+    pub r#where: Option<W>,
+    /// Update-data payload.
+    pub data: U,
+    /// Phantom marker for the model.
+    #[doc(hidden)]
+    pub _model: PhantomData<M>,
+}
+
+/// Args for `upsert`.
+#[derive(Debug, Clone)]
+pub struct UpsertArgs<M, W, C, U, I, S> {
+    /// Unique WHERE input.
+    pub r#where: W,
+    /// Create-data payload (used if no row matched).
+    pub create: C,
+    /// Update-data payload (used if a row matched).
+    pub update: U,
+    /// Optional include shape on the returning row.
+    pub include: Option<I>,
+    /// Optional select shape on the returning row.
+    pub select: Option<S>,
+    /// Phantom marker for the model.
+    #[doc(hidden)]
+    pub _model: PhantomData<M>,
+}
+
+/// Args for `delete`.
+#[derive(Debug, Clone)]
+pub struct DeleteArgs<M, W, I, S> {
+    /// Unique WHERE input.
+    pub r#where: W,
+    /// Optional include shape on the returning row.
+    pub include: Option<I>,
+    /// Optional select shape on the returning row.
+    pub select: Option<S>,
+    /// Phantom marker for the model.
+    #[doc(hidden)]
+    pub _model: PhantomData<M>,
+}
+
+/// Args for `delete_many`.
+#[derive(Debug, Clone, Default)]
+pub struct DeleteManyArgs<M, W> {
+    /// Optional WHERE input.
+    pub r#where: Option<W>,
+    /// Phantom marker for the model.
+    #[doc(hidden)]
+    pub _model: PhantomData<M>,
+}
+
+/// Args for `count`.
+#[derive(Debug, Clone, Default)]
+pub struct CountArgs<M, W, O = (), C = ()> {
+    /// Optional WHERE input.
+    pub r#where: Option<W>,
+    /// Optional order-by.
+    pub order_by: Option<Vec<O>>,
+    /// Optional cursor.
+    pub cursor: Option<C>,
+    /// Skip N rows.
+    pub skip: Option<u64>,
+    /// Take N rows.
+    pub take: Option<u64>,
+    /// Phantom marker for the model.
+    #[doc(hidden)]
+    pub _model: PhantomData<M>,
+}
+
+/// Args for `aggregate`. The aggregate spec parameter is filled in by phase 6.
+#[derive(Debug, Clone, Default)]
+pub struct AggregateArgs<M, W, A, O = (), C = ()> {
+    /// Optional WHERE input.
+    pub r#where: Option<W>,
+    /// Aggregate spec (`_count` / `_avg` / `_sum` / `_min` / `_max`).
+    pub aggregate: Option<A>,
+    /// Optional order-by.
+    pub order_by: Option<Vec<O>>,
+    /// Optional cursor.
+    pub cursor: Option<C>,
+    /// Skip N rows.
+    pub skip: Option<u64>,
+    /// Take N rows.
+    pub take: Option<u64>,
+    /// Phantom marker for the model.
+    #[doc(hidden)]
+    pub _model: PhantomData<M>,
+}
+
+/// Args for `group_by`. The grouping spec parameter is filled in by phase 6.
+#[derive(Debug, Clone, Default)]
+pub struct GroupByArgs<M, W, A, G, H = (), O = ()> {
+    /// Group by these field names.
+    pub by: Vec<G>,
+    /// Optional WHERE input.
+    pub r#where: Option<W>,
+    /// Optional HAVING input.
+    pub having: Option<H>,
+    /// Aggregate spec.
+    pub aggregate: Option<A>,
+    /// Optional order-by.
+    pub order_by: Option<Vec<O>>,
+    /// Skip N rows.
+    pub skip: Option<u64>,
+    /// Take N rows.
+    pub take: Option<u64>,
+    /// Phantom marker for the model.
+    #[doc(hidden)]
+    pub _model: PhantomData<M>,
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p prax-query --test inputs_args`
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add prax-query/src/inputs/args.rs prax-query/tests/inputs_args.rs
+git commit -m "feat(query): add per-operation Args containers
+
+FindUniqueArgs / FindFirstArgs / FindManyArgs / CreateArgs /
+CreateManyArgs / UpdateArgs / UpdateManyArgs / UpsertArgs /
+DeleteArgs / DeleteManyArgs / CountArgs / AggregateArgs /
+GroupByArgs are the explicit-struct third interface for the DSL.
+The macro DSL (phase 3+) expands to these structs; users may
+construct them by hand. Generic params are left open at phase 1
+and narrowed by codegen (phase 2)."
+```
+
+---
+
+## Task 12: Extension methods on read operations
+
+**Files:**
+- Modify: `prax-query/src/operations/find_many.rs`
+- Modify: `prax-query/src/operations/find_unique.rs`
+- Modify: `prax-query/src/operations/find_first.rs`
+- Create: `prax-query/tests/operation_ext_methods.rs`
+
+Each read operation gets `with_where_input` / `with_include_input` / `with_select_input` (+ `with_order_by_input`/`with_cursor_input` where applicable). They thread the input through `into_ir()` and AND-combine on top of any existing fluent state.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `prax-query/tests/operation_ext_methods.rs`:
+
+```rust
+use prax_query::filter::{Filter, FilterValue};
+use prax_query::inputs::{StringFilter, WhereInput};
+use prax_query::operations::{FindFirstOperation, FindManyOperation, FindUniqueOperation};
+use prax_query::traits::{BoxFuture, Model, QueryEngine};
+
+struct U;
+impl Model for U {
+    const MODEL_NAME: &'static str = "U";
+    const TABLE_NAME: &'static str = "users";
+    const PRIMARY_KEY: &'static [&'static str] = &["id"];
+    const COLUMNS: &'static [&'static str] = &["id", "email"];
+}
+impl prax_query::row::FromRow for U {
+    fn from_row(_row: &impl prax_query::row::RowRef) -> Result<Self, prax_query::row::RowError> {
+        Ok(U)
+    }
+}
+
+#[derive(Clone)]
+struct NoopEngine;
+impl QueryEngine for NoopEngine {
+    fn query_many<T: Model + prax_query::row::FromRow + Send + 'static>(&self, _: &str, _: Vec<FilterValue>) -> BoxFuture<'_, prax_query::error::QueryResult<Vec<T>>> {
+        Box::pin(async { Ok(Vec::new()) })
+    }
+    fn query_one<T: Model + prax_query::row::FromRow + Send + 'static>(&self, _: &str, _: Vec<FilterValue>) -> BoxFuture<'_, prax_query::error::QueryResult<T>> {
+        Box::pin(async { Err(prax_query::error::QueryError::not_found("t")) })
+    }
+    fn query_optional<T: Model + prax_query::row::FromRow + Send + 'static>(&self, _: &str, _: Vec<FilterValue>) -> BoxFuture<'_, prax_query::error::QueryResult<Option<T>>> {
+        Box::pin(async { Ok(None) })
+    }
+    fn execute_insert<T: Model + prax_query::row::FromRow + Send + 'static>(&self, _: &str, _: Vec<FilterValue>) -> BoxFuture<'_, prax_query::error::QueryResult<T>> {
+        Box::pin(async { Err(prax_query::error::QueryError::not_found("t")) })
+    }
+    fn execute_update<T: Model + prax_query::row::FromRow + Send + 'static>(&self, _: &str, _: Vec<FilterValue>) -> BoxFuture<'_, prax_query::error::QueryResult<Vec<T>>> {
+        Box::pin(async { Ok(Vec::new()) })
+    }
+    fn execute_delete(&self, _: &str, _: Vec<FilterValue>) -> BoxFuture<'_, prax_query::error::QueryResult<u64>> {
+        Box::pin(async { Ok(0) })
+    }
+    fn execute_raw(&self, _: &str, _: Vec<FilterValue>) -> BoxFuture<'_, prax_query::error::QueryResult<u64>> {
+        Box::pin(async { Ok(0) })
+    }
+    fn count(&self, _: &str, _: Vec<FilterValue>) -> BoxFuture<'_, prax_query::error::QueryResult<u64>> {
+        Box::pin(async { Ok(0) })
+    }
+}
+
+#[derive(Default, Clone)]
+struct UWhereInput {
+    pub email: Option<StringFilter>,
+}
+impl WhereInput for UWhereInput {
+    type Model = U;
+    fn into_ir(self) -> Filter {
+        use prax_query::inputs::ScalarFilter;
+        match self.email {
+            Some(f) => f.into_filter("email"),
+            None => Filter::None,
+        }
+    }
+}
+
+#[test]
+fn find_many_with_where_input_replaces_filter_when_first() {
+    let op = FindManyOperation::<NoopEngine, U>::new(NoopEngine)
+        .with_where_input(UWhereInput { email: Some(StringFilter::contains("@x.com")) });
+    assert!(!matches!(op.filter_for_test(), Filter::None));
+}
+
+#[test]
+fn find_many_with_where_input_ands_with_existing() {
+    let op = FindManyOperation::<NoopEngine, U>::new(NoopEngine)
+        .r#where(Filter::Equals("id".into(), FilterValue::Int(1)))
+        .with_where_input(UWhereInput { email: Some(StringFilter::contains("@x.com")) });
+    match op.filter_for_test() {
+        Filter::And(parts) => assert_eq!(parts.len(), 2),
+        other => panic!("expected Filter::And, got {:?}", other),
+    }
+}
+
+#[test]
+fn find_unique_with_where_input_overwrites_filter() {
+    let op = FindUniqueOperation::<NoopEngine, U>::new(NoopEngine)
+        .with_where_input(UWhereInput { email: Some(StringFilter::equals("x@y.com")) });
+    assert!(!matches!(op.filter_for_test(), Filter::None));
+}
+
+#[test]
+fn find_first_with_where_input_ands_with_existing() {
+    let op = FindFirstOperation::<NoopEngine, U>::new(NoopEngine)
+        .r#where(Filter::Equals("id".into(), FilterValue::Int(1)))
+        .with_where_input(UWhereInput { email: Some(StringFilter::contains("@x.com")) });
+    match op.filter_for_test() {
+        Filter::And(parts) => assert_eq!(parts.len(), 2),
+        other => panic!("expected Filter::And, got {:?}", other),
+    }
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cargo test -p prax-query --test operation_ext_methods`
+Expected: compile error — `with_where_input` and `filter_for_test` don't exist.
+
+- [ ] **Step 3: Add the methods to `FindManyOperation`**
+
+Open `prax-query/src/operations/find_many.rs`. Inside the `impl<E: QueryEngine, M: Model + crate::row::FromRow> FindManyOperation<E, M>` block (after the `distinct` method), append:
+
+```rust
+    /// Apply a typed `WhereInput`. AND-composes with any previously set
+    /// filter — same semantics as calling `.r#where(...)` again.
+    pub fn with_where_input<W: crate::inputs::WhereInput<Model = M>>(mut self, w: W) -> Self {
+        let f = w.into_ir();
+        self.filter = self.filter.and_then(f);
+        self
+    }
+
+    /// Apply a typed `IncludeInput`. Merges into any previously set
+    /// includes (later wins on conflicting relation names).
+    pub fn with_include_input<I: crate::inputs::IncludeInput<Model = M>>(mut self, i: I) -> Self {
+        let inc = i.into_ir();
+        for spec in inc.specs() {
+            self.includes.push(spec.clone());
+        }
+        self
+    }
+
+    /// Apply a typed `SelectInput`.
+    pub fn with_select_input<S: crate::inputs::SelectInput<Model = M>>(mut self, s: S) -> Self {
+        self.select = s.into_ir();
+        self
+    }
+
+    /// Apply a typed `OrderByInput` (single).
+    pub fn with_order_by_input<O: crate::inputs::OrderByInput<Model = M>>(mut self, o: O) -> Self {
+        self.order_by = o.into_ir();
+        self
+    }
+
+    /// Apply a typed `OrderByInput` collection (later items take lower precedence).
+    pub fn with_order_by_inputs<O: crate::inputs::OrderByInput<Model = M>>(
+        mut self,
+        items: impl IntoIterator<Item = O>,
+    ) -> Self {
+        let mut combined = self.order_by;
+        for o in items {
+            combined = combined.then(o.into_ir());
+        }
+        self.order_by = combined;
+        self
+    }
+
+    /// Test-only accessor for the current filter — needed for unit tests
+    /// that don't have a running engine to issue queries against.
+    #[cfg(test)]
+    pub fn filter_for_test(&self) -> &Filter {
+        &self.filter
+    }
+}
+```
+
+(If the existing `impl` block already closes before `distinct`, place the new methods inside the same `impl` block — adjust the closing `}` as needed.)
+
+If `OrderBy` does not have a `.then(other) -> Self` method, define a local fallback at the top of the file:
+
+```rust
+fn merge_order(left: OrderBy, right: OrderBy) -> OrderBy {
+    // Conservative fallback: keep right if non-empty; else left.
+    if right.is_empty() { left } else { right }
+}
+```
+
+and use that instead of `combined.then(...)`. Verify with `grep -n "fn then\|fn is_empty" prax-query/src/types.rs` what is available.
+
+- [ ] **Step 4: Also expose `filter_for_test` for use by integration test**
+
+The test file uses `cfg(test)` accessors. Integration tests count as `cfg(test)` for the crate they live in, but **not** for `prax-query` itself. Replace `#[cfg(test)]` with `#[doc(hidden)]` on the helper methods so integration tests can call them:
+
+```rust
+    #[doc(hidden)]
+    pub fn filter_for_test(&self) -> &Filter {
+        &self.filter
+    }
+```
+
+- [ ] **Step 5: Add the same methods to `FindUniqueOperation`**
+
+Open `prax-query/src/operations/find_unique.rs`. After the existing setter methods, append:
+
+```rust
+    /// Apply a typed `WhereUniqueInput`. Overwrites the existing filter
+    /// (a unique input is a complete predicate, not a constraint to AND-compose).
+    pub fn with_where_input<W: crate::inputs::WhereUniqueInput<Model = M>>(mut self, w: W) -> Self {
+        self.filter = w.into_ir();
+        self
+    }
+
+    /// Apply a typed `IncludeInput`.
+    pub fn with_include_input<I: crate::inputs::IncludeInput<Model = M>>(mut self, i: I) -> Self {
+        let inc = i.into_ir();
+        for spec in inc.specs() {
+            self.includes.push(spec.clone());
+        }
+        self
+    }
+
+    /// Apply a typed `SelectInput`.
+    pub fn with_select_input<S: crate::inputs::SelectInput<Model = M>>(mut self, s: S) -> Self {
+        self.select = s.into_ir();
+        self
+    }
+
+    #[doc(hidden)]
+    pub fn filter_for_test(&self) -> &Filter {
+        &self.filter
+    }
+```
+
+If `FindUniqueOperation` does not currently carry `select` or `includes` fields, inspect the struct definition at the top of the file and only emit the methods whose backing fields exist; leave others for phase 2 codegen.
+
+- [ ] **Step 6: Add the methods to `FindFirstOperation`**
+
+Open `prax-query/src/operations/find_first.rs`. Mirror the `FindManyOperation` additions exactly (same five methods + `filter_for_test`). The `OrderBy` handling is identical.
+
+- [ ] **Step 7: Run all tests**
+
+Run: `cargo test -p prax-query --test operation_ext_methods`
+Expected: pass.
+Run: `cargo test -p prax-query --lib`
+Expected: pass (no regression).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add prax-query/src/operations/find_many.rs prax-query/src/operations/find_unique.rs prax-query/src/operations/find_first.rs prax-query/tests/operation_ext_methods.rs
+git commit -m "feat(query): add with_*_input extension methods on read operations
+
+FindManyOperation, FindUniqueOperation, FindFirstOperation gain
+with_where_input / with_include_input / with_select_input
+(+ with_order_by_input on find_many and find_first). The methods
+thread inputs through into_ir() and AND-compose on top of any
+existing fluent state, matching the spec's coexistence guarantee.
+filter_for_test is a doc-hidden accessor used by unit tests."
+```
+
+---
+
+## Task 13: Extension methods on write operations
+
+**Files:**
+- Modify: `prax-query/src/operations/create.rs`
+- Modify: `prax-query/src/operations/update.rs`
+- Modify: `prax-query/src/operations/delete.rs`
+- Modify: `prax-query/src/operations/upsert.rs`
+- Modify: `prax-query/tests/operation_ext_methods.rs`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `prax-query/tests/operation_ext_methods.rs`:
+
+```rust
+use prax_query::operations::{CreateOperation, DeleteOperation, UpdateOperation};
+
+#[test]
+fn create_op_accepts_with_include_input() {
+    // Use the existing CreateData::Data path. Phase 5 wires nested writes.
+    // For phase 1 we only assert the method compiles and is callable.
+    fn _compiles<E: QueryEngine, M: Model + prax_query::row::FromRow>(
+        op: CreateOperation<E, M>,
+    ) -> CreateOperation<E, M>
+    where
+        M: prax_query::traits::CreateData,
+    {
+        struct NoopInclude<M>(core::marker::PhantomData<M>);
+        impl<M: Model> prax_query::inputs::IncludeInput for NoopInclude<M> {
+            type Model = M;
+            fn into_ir(self) -> prax_query::relations::Include {
+                prax_query::relations::Include::new()
+            }
+        }
+        op.with_include_input(NoopInclude::<M>(core::marker::PhantomData))
+    }
+    let _ = _compiles::<NoopEngine, U>;
+}
+
+#[test]
+fn update_op_with_where_input_ands_with_existing() {
+    let op = UpdateOperation::<NoopEngine, U>::new(NoopEngine)
+        .r#where(Filter::Equals("id".into(), FilterValue::Int(1)))
+        .with_where_input(UWhereInput { email: Some(StringFilter::contains("@x.com")) });
+    match op.filter_for_test() {
+        Filter::And(parts) => assert_eq!(parts.len(), 2),
+        other => panic!("expected Filter::And, got {:?}", other),
+    }
+}
+
+#[test]
+fn delete_op_with_where_input_overwrites_filter_for_unique() {
+    let op = DeleteOperation::<NoopEngine, U>::new(NoopEngine)
+        .with_where_input(UWhereInput { email: Some(StringFilter::equals("x@y.com")) });
+    assert!(!matches!(op.filter_for_test(), Filter::None));
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cargo test -p prax-query --test operation_ext_methods`
+Expected: compile error.
+
+- [ ] **Step 3: Extend `UpdateOperation`**
+
+Open `prax-query/src/operations/update.rs`. After the existing setter methods, append:
+
+```rust
+    /// Apply a typed `WhereUniqueInput`. AND-composes with any
+    /// previously set filter so callers can combine the unique key
+    /// with side conditions when they need to.
+    pub fn with_where_input<W: crate::inputs::WhereUniqueInput<Model = M>>(mut self, w: W) -> Self {
+        let f = w.into_ir();
+        self.filter = self.filter.and_then(f);
+        self
+    }
+
+    /// Apply a typed `UpdateInput`. Replaces the current update payload.
+    pub fn with_data_input<U: crate::inputs::UpdateInput<Model = M, Data = M::Data>>(mut self, u: U) -> Self
+    where
+        M: crate::traits::UpdateData,
+    {
+        self.data = u.into_ir();
+        self
+    }
+
+    /// Apply a typed `IncludeInput`.
+    pub fn with_include_input<I: crate::inputs::IncludeInput<Model = M>>(mut self, i: I) -> Self {
+        let inc = i.into_ir();
+        for spec in inc.specs() {
+            self.includes.push(spec.clone());
+        }
+        self
+    }
+
+    /// Apply a typed `SelectInput`.
+    pub fn with_select_input<S: crate::inputs::SelectInput<Model = M>>(mut self, s: S) -> Self {
+        self.select = s.into_ir();
+        self
+    }
+
+    #[doc(hidden)]
+    pub fn filter_for_test(&self) -> &Filter {
+        &self.filter
+    }
+```
+
+If the `UpdateOperation` struct doesn't have `includes` / `select` fields, skip the corresponding methods — phase 2 codegen wires them up.
+
+- [ ] **Step 4: Extend `DeleteOperation`**
+
+Open `prax-query/src/operations/delete.rs`. Append the same pattern (omit `with_data_input`):
+
+```rust
+    /// Apply a typed `WhereUniqueInput`. Overwrites any previously set
+    /// filter — delete operations are intentionally precise.
+    pub fn with_where_input<W: crate::inputs::WhereUniqueInput<Model = M>>(mut self, w: W) -> Self {
+        self.filter = w.into_ir();
+        self
+    }
+
+    /// Apply a typed `IncludeInput`.
+    pub fn with_include_input<I: crate::inputs::IncludeInput<Model = M>>(mut self, i: I) -> Self {
+        let inc = i.into_ir();
+        for spec in inc.specs() {
+            self.includes.push(spec.clone());
+        }
+        self
+    }
+
+    /// Apply a typed `SelectInput`.
+    pub fn with_select_input<S: crate::inputs::SelectInput<Model = M>>(mut self, s: S) -> Self {
+        self.select = s.into_ir();
+        self
+    }
+
+    #[doc(hidden)]
+    pub fn filter_for_test(&self) -> &Filter {
+        &self.filter
+    }
+```
+
+- [ ] **Step 5: Extend `CreateOperation`**
+
+Open `prax-query/src/operations/create.rs`. Append:
+
+```rust
+    /// Apply a typed `CreateInput`. Replaces the current create payload.
+    pub fn with_data_input<C: crate::inputs::CreateInput<Model = M, Data = M::Data>>(mut self, c: C) -> Self
+    where
+        M: crate::traits::CreateData,
+    {
+        self.data = c.into_ir();
+        self
+    }
+
+    /// Apply a typed `IncludeInput`.
+    pub fn with_include_input<I: crate::inputs::IncludeInput<Model = M>>(mut self, i: I) -> Self {
+        let inc = i.into_ir();
+        for spec in inc.specs() {
+            self.includes.push(spec.clone());
+        }
+        self
+    }
+
+    /// Apply a typed `SelectInput`.
+    pub fn with_select_input<S: crate::inputs::SelectInput<Model = M>>(mut self, s: S) -> Self {
+        self.select = s.into_ir();
+        self
+    }
+```
+
+Same caveat: if `CreateOperation` lacks `includes`/`select`, skip those methods.
+
+- [ ] **Step 6: Extend `UpsertOperation`**
+
+Open `prax-query/src/operations/upsert.rs`. Append:
+
+```rust
+    /// Apply a typed `WhereUniqueInput`. Overwrites the existing filter.
+    pub fn with_where_input<W: crate::inputs::WhereUniqueInput<Model = M>>(mut self, w: W) -> Self {
+        self.filter = w.into_ir();
+        self
+    }
+
+    /// Apply a typed `CreateInput` for the create branch.
+    pub fn with_create_input<C: crate::inputs::CreateInput<Model = M, Data = <M as crate::traits::CreateData>::Data>>(mut self, c: C) -> Self
+    where
+        M: crate::traits::CreateData,
+    {
+        self.create_data = c.into_ir();
+        self
+    }
+
+    /// Apply a typed `UpdateInput` for the update branch.
+    pub fn with_update_input<U: crate::inputs::UpdateInput<Model = M, Data = <M as crate::traits::UpdateData>::Data>>(mut self, u: U) -> Self
+    where
+        M: crate::traits::UpdateData,
+    {
+        self.update_data = u.into_ir();
+        self
+    }
+
+    /// Apply a typed `IncludeInput`.
+    pub fn with_include_input<I: crate::inputs::IncludeInput<Model = M>>(mut self, i: I) -> Self {
+        let inc = i.into_ir();
+        for spec in inc.specs() {
+            self.includes.push(spec.clone());
+        }
+        self
+    }
+
+    /// Apply a typed `SelectInput`.
+    pub fn with_select_input<S: crate::inputs::SelectInput<Model = M>>(mut self, s: S) -> Self {
+        self.select = s.into_ir();
+        self
+    }
+```
+
+Adjust field names (`create_data`/`update_data`) to match what's already in `UpsertOperation` (use `grep -n "pub create\|pub update\|create_data\|update_data" prax-query/src/operations/upsert.rs`).
+
+- [ ] **Step 7: Run tests**
+
+Run: `cargo test -p prax-query --test operation_ext_methods`
+Expected: every test passes.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add prax-query/src/operations/create.rs prax-query/src/operations/update.rs prax-query/src/operations/delete.rs prax-query/src/operations/upsert.rs prax-query/tests/operation_ext_methods.rs
+git commit -m "feat(query): add with_*_input extension methods on write operations
+
+CreateOperation, UpdateOperation, DeleteOperation, UpsertOperation
+gain methods that consume the corresponding typed inputs. UpdateOp
+AND-composes WHERE (allows side conditions); DeleteOp / UpsertOp
+overwrite WHERE because the unique filter is the whole point of
+those operations. Create/Update data inputs replace the runtime
+payload through CreateInput::Data / UpdateInput::Data."
+```
+
+---
+
+## Task 14: Extension methods on count + aggregate
+
+**Files:**
+- Modify: `prax-query/src/operations/count.rs`
+- Modify: `prax-query/src/operations/aggregate.rs`
+- Modify: `prax-query/tests/operation_ext_methods.rs`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `prax-query/tests/operation_ext_methods.rs`:
+
+```rust
+use prax_query::operations::CountOperation;
+
+#[test]
+fn count_op_with_where_input_ands() {
+    let op = CountOperation::<NoopEngine, U>::new(NoopEngine)
+        .r#where(Filter::Equals("active".into(), FilterValue::Bool(true)))
+        .with_where_input(UWhereInput { email: Some(StringFilter::contains("@x.com")) });
+    match op.filter_for_test() {
+        Filter::And(parts) => assert_eq!(parts.len(), 2),
+        other => panic!("expected Filter::And, got {:?}", other),
+    }
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cargo test -p prax-query --test operation_ext_methods`
+Expected: compile error.
+
+- [ ] **Step 3: Extend `CountOperation`**
+
+Open `prax-query/src/operations/count.rs`. Append:
+
+```rust
+    /// Apply a typed `WhereInput`. AND-composes with any previously set filter.
+    pub fn with_where_input<W: crate::inputs::WhereInput<Model = M>>(mut self, w: W) -> Self {
+        let f = w.into_ir();
+        self.filter = self.filter.and_then(f);
+        self
+    }
+
+    /// Apply a typed `OrderByInput`.
+    pub fn with_order_by_input<O: crate::inputs::OrderByInput<Model = M>>(mut self, o: O) -> Self {
+        self.order_by = o.into_ir();
+        self
+    }
+
+    #[doc(hidden)]
+    pub fn filter_for_test(&self) -> &Filter {
+        &self.filter
+    }
+```
+
+If `CountOperation` doesn't have an `order_by` field, drop `with_order_by_input` here — phase 6 adds it alongside the aggregate macros.
+
+- [ ] **Step 4: Extend `AggregateOperation`**
+
+Open `prax-query/src/operations/aggregate.rs`. Append the same `with_where_input` method:
+
+```rust
+    /// Apply a typed `WhereInput`. AND-composes with any previously set filter.
+    pub fn with_where_input<W: crate::inputs::WhereInput<Model = M>>(mut self, w: W) -> Self {
+        let f = w.into_ir();
+        self.filter = self.filter.and_then(f);
+        self
+    }
+```
+
+`with_aggregate_input` lives in phase 6 — leave it for now.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test -p prax-query --test operation_ext_methods`
+Expected: every test passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add prax-query/src/operations/count.rs prax-query/src/operations/aggregate.rs prax-query/tests/operation_ext_methods.rs
+git commit -m "feat(query): add with_*_input on CountOperation and AggregateOperation
+
+Count gets with_where_input + (where supported) with_order_by_input.
+Aggregate gets with_where_input only; the aggregate-spec input lands
+in phase 6 with the aggregate macros."
+```
+
+---
+
+## Task 15: Re-export at the crate root
+
+**Files:**
+- Modify: `prax-query/src/lib.rs`
+
+- [ ] **Step 1: Re-export the public surface**
+
+In `prax-query/src/lib.rs`, locate the existing crate-root re-exports (search for `pub use`). After them, add:
+
+```rust
+// Typed input shapes (phase 1 of the typed-query-traits work).
+pub use crate::capabilities::{
+    SupportsArrayOps, SupportsCaseInsensitiveMode, SupportsCorrelatedSubquery,
+    SupportsFullTextSearch, SupportsGeneratedColumns, SupportsJsonPath, SupportsNestedWrites,
+    SupportsRelationFilter, SupportsScalarSubqueryInSelect,
+};
+pub use crate::inputs::{
+    // Containers.
+    AggregateArgs, CountArgs, CreateArgs, CreateManyArgs, DeleteArgs, DeleteManyArgs,
+    FindFirstArgs, FindManyArgs, FindUniqueArgs, GroupByArgs, UpdateArgs, UpdateManyArgs,
+    UpsertArgs,
+    // Scalar filters.
+    BigIntFilter, BigIntNullableFilter, BoolFilter, BoolNullableFilter, BytesFilter,
+    BytesNullableFilter, DateFilter, DateNullableFilter, DateTimeFilter, DateTimeNullableFilter,
+    DecimalFilter, DecimalNullableFilter, EnumFilter, EnumNullableFilter, FloatFilter,
+    FloatNullableFilter, IntFilter, IntNullableFilter, JsonFilter, JsonNullableFilter,
+    QueryMode, ScalarFilter, StringFilter, StringNullableFilter, TimeFilter,
+    TimeNullableFilter, UuidFilter, UuidNullableFilter,
+    // Update wrappers.
+    BigIntFieldUpdate, BigIntNullableFieldUpdate, BoolFieldUpdate, BoolNullableFieldUpdate,
+    BytesFieldUpdate, BytesNullableFieldUpdate, DateTimeFieldUpdate,
+    DateTimeNullableFieldUpdate, DecimalFieldUpdate, DecimalNullableFieldUpdate,
+    EnumFieldUpdate, EnumNullableFieldUpdate, FloatFieldUpdate, FloatNullableFieldUpdate,
+    IntFieldUpdate, IntNullableFieldUpdate, JsonFieldUpdate, JsonNullableFieldUpdate,
+    StringFieldUpdate, StringNullableFieldUpdate, UuidFieldUpdate, UuidNullableFieldUpdate,
+    // Relation filters + meta.
+    relation::{ListRelationFilter, LowerRelationFilter, RelationMeta, SingleRelationFilter},
+    // Traits.
+    AggregateInput, CountSelect, CreateInput, GroupByInput, IncludeInput, OrderByInput,
+    PaginationInput, SelectInput, UpdateInput, WhereInput, WhereUniqueInput,
+};
+```
+
+- [ ] **Step 2: Verify docs build**
+
+Run: `cargo doc -p prax-query --no-deps --all-features`
+Expected: clean — no broken intra-doc links.
+
+- [ ] **Step 3: Run full prax-query test suite**
+
+Run: `cargo test -p prax-query`
+Expected: every test passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add prax-query/src/lib.rs
+git commit -m "feat(query): re-export typed input surface at crate root
+
+Capability marker traits, scalar/relation filter wrappers, scalar
+update wrappers, per-operation Args containers, and the 10 input
+traits are now reachable via prax_query::*."
+```
+
+---
+
+## Task 16: Final workspace verification
+
+**Files:**
+- None (verification only)
+
+- [ ] **Step 1: Format check**
+
+Run: `cargo fmt --all -- --check`
+Expected: no diff. If diff, run `cargo fmt --all` and commit the result with `style: format`.
+
+- [ ] **Step 2: Clippy across the workspace**
+
+Run: `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+Expected: zero warnings or errors.
+
+- [ ] **Step 3: Full workspace test suite (libs only)**
+
+Run: `cargo test --workspace --lib`
+Expected: every test passes.
+
+- [ ] **Step 4: Run the new integration tests**
+
+Run: `cargo test -p prax-query --test inputs_scalar --test inputs_relation --test inputs_update --test inputs_args --test operation_ext_methods`
+Expected: every test passes.
+
+- [ ] **Step 5: Confirm docs still build**
+
+Run: `cargo doc --workspace --no-deps --all-features`
+Expected: clean.
+
+- [ ] **Step 6: Phase complete — no commit needed here**
+
+The branch is ready for PR. Phase 2 (codegen of per-model input types in `prax-codegen`) opens its own worktree off `develop` once this branch merges.
+
+---
+
+## Acceptance criteria
+
+- [ ] `Filter::ScalarSubquery` lands behind `#[non_exhaustive]` with `to_sql` lowering and tests.
+- [ ] `QueryEngine::in_transaction` defaults to `false` with a test.
+- [ ] `prax-query/src/capabilities.rs` exposes 9 marker traits with `#[diagnostic::on_unimplemented]` messages.
+- [ ] `prax-query/src/inputs/` is structured into `traits.rs`, `scalar.rs`, `scalar_update.rs`, `relation.rs`, `args.rs`, `mod.rs`.
+- [ ] Every scalar type listed in the spec has a non-nullable + nullable filter wrapper with `into_filter(column)` lowering.
+- [ ] `ListRelationFilter` and `SingleRelationFilter` lower to `Filter::ScalarSubquery` EXISTS / NOT EXISTS fragments via `RelationMeta`.
+- [ ] Every scalar type has a `*FieldUpdate` wrapper with `From<scalar>` shortcut.
+- [ ] 13 `*Args` containers exist with the field shape promised by section 3 of the spec.
+- [ ] Every read/write/count/aggregate operation has `with_*_input` extension methods that consume the typed inputs, AND-composing where appropriate.
+- [ ] The full public surface re-exports at the `prax-query` crate root.
+- [ ] `cargo fmt`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `cargo test --workspace --lib` all pass.
+
+---
+
+## Self-review notes
+
+- **Spec coverage.** Phase 1 of section 8 in the spec maps to tasks 2 (Filter variant), 3 (in_transaction), 4 (capabilities), 5–11 (input types), 12–14 (ext methods), 15 (re-exports). Computed/virtual fields (spec §9), codegen (§3), macros (§4-5), and docs (§10) are out of scope for this plan and live in phase 2+.
+- **Placeholders.** Every step has either runnable commands or complete Rust source. No "TBD", no "fill in", no "similar to Task N." The `_field` skips on operations where a field doesn't yet exist are explicit, not placeholders.
+- **Type consistency.** `WhereInput::into_ir(self) -> Filter` is used uniformly across tasks 5, 6, 7, 8, 9, 12, 13, 14. `IncludeInput::into_ir(self) -> Include` is used consistently. `RelationMeta` constants are named identically across tasks 9, 10, 12. The `Args` field name `r#where` is consistent across tasks 11, 12, 13.
+- **YAGNI.** No phase-2+ work is preemptively wired up. The `mode: QueryMode` field is parsed but ignored at the IR level (phase 2 dialect layer consumes it). Computed/virtual field SQL emission relies on `Filter::ScalarSubquery` but the variant has no producers in this plan.
+- **TDD.** Every code-emitting task follows write-test → confirm-fail → implement → confirm-pass → commit.
+

--- a/docs/superpowers/specs/2026-05-18-typed-query-traits-design.md
+++ b/docs/superpowers/specs/2026-05-18-typed-query-traits-design.md
@@ -1,0 +1,754 @@
+# Typed Query Trait System and Prisma-Style Macro DSL
+
+- **Status**: Draft
+- **Date**: 2026-05-18
+- **Author**: Joseph R. Quinn (with Claude)
+- **Affects**: `prax-query`, `prax-codegen`, every engine crate, `prax-migrate`, `prax-schema`, the docs Angular site
+- **Builds on**: existing `Filter` / `IncludeSpec` / `CreateData` / `UpdateData` / `QueryEngine` (unchanged)
+
+## 1. Goals and non-goals
+
+### Goals
+
+- A declarative, Prisma-like macro DSL for the full operation surface of `prax-query` (`find_*`, `create`, `update`, `delete`, `upsert`, `count`, `aggregate`, `group_by`).
+- A typed trait system that codegen emits per model so the macro is a thin layer on top of inspectable, documentable structs rather than ad-hoc proc-macro output.
+- Compile-time validation of field names, operators, relation cardinality, and engine capability.
+- Composition: spread (`..base`) and conditional (`#[if(...)]`) field syntax for building queries from runtime values.
+- Full coexistence with the existing fluent builder API. Nothing breaks; nothing is deprecated in this design.
+- First-class support for computed and virtual fields (DB-generated columns and relation aggregates).
+
+### Non-goals
+
+- Generic result types parameterized by `include` shape (defer; relations stay `Option<Vec<T>>` on the model).
+- Polymorphic relations or single-table inheritance.
+- Custom raw SQL fragments inside the DSL — `raw_query!` covers that.
+- Pure-Rust computed accessors woven into WHERE clauses — out of scope; use `@generated` columns or `@aggregate` virtuals.
+- CQL (ScyllaDB / Cassandra) nested writes — explicitly compile-time blocked.
+- MongoDB-specific operators (`$exists`, `$type`, geo queries).
+- MongoDB `$lookup` lowering for aggregate virtuals — follow-up plan.
+
+## 2. Architecture — three layers
+
+### Layer 1: Runtime IR (unchanged)
+
+`prax-query`'s `Filter`, `FilterValue`, `IncludeSpec`, `OrderBy`, `Pagination`, `CreateData`, `UpdateData`, `QueryEngine`, and every operation in `prax_query::operations` stay exactly as they are. They are the canonical runtime IR consumed by the dialect/SQL builders. **Query execution does not change.**
+
+One additive change to the IR: a new `Filter::ScalarSubquery { sql: Cow<'static, str>, params: Vec<FilterValue> }` variant to support relation-aggregate virtual fields (see §9). SQL builders splice the embedded SQL into the surrounding WHERE/SELECT. Marked `#[non_exhaustive]` so future additions remain non-breaking.
+
+### Layer 2: Per-model typed inputs (new, codegen-emitted)
+
+Codegen emits a per-model `inputs` submodule containing the following types and trait impls. For a model `User`:
+
+| Generated type                | New trait                                | Lowers to (runtime IR)                |
+|-------------------------------|------------------------------------------|---------------------------------------|
+| `UserWhereInput`              | `WhereInput<Model = User>`               | `Filter`                              |
+| `UserWhereUniqueInput`        | `WhereUniqueInput<Model = User>`         | `Filter` (unique-only invariant)      |
+| `UserInclude`                 | `IncludeInput<Model = User>`             | `Include` (set of `IncludeSpec`)      |
+| `UserSelect`                  | `SelectInput<Model = User>`              | `SelectionSet`                        |
+| `UserOrderBy`                 | `OrderByInput<Model = User>`             | `OrderBy`                             |
+| `UserCreateInput`             | `CreateInput<Model = User>`              | `NestedWritePlan`                     |
+| `UserUpdateInput`             | `UpdateInput<Model = User>`              | `NestedWritePlan`                     |
+| `UserCountSelect`             | `CountSelect<Model = User>`              | `_count` aggregate spec               |
+| `UserAggregateInput`          | `AggregateInput<Model = User>`           | aggregate spec                        |
+| `UserGroupByInput`            | `GroupByInput<Model = User>`             | group-by spec                         |
+
+Each trait has the form:
+
+```rust
+pub trait WhereInput {
+    type Model: crate::traits::Model;
+    fn into_ir(self) -> Filter;
+}
+```
+
+— one method, plus an associated `Model` type so bounds remain tight.
+
+Shared scalar filter wrappers in `prax_query::inputs`:
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct StringFilter {
+    pub equals:      Option<String>,
+    pub not:         Option<Box<StringFilter>>,
+    pub in_list:     Option<Vec<String>>,
+    pub not_in:      Option<Vec<String>>,
+    pub lt:          Option<String>,
+    pub lte:         Option<String>,
+    pub gt:          Option<String>,
+    pub gte:         Option<String>,
+    pub contains:    Option<String>,
+    pub starts_with: Option<String>,
+    pub ends_with:   Option<String>,
+    pub mode:        Option<QueryMode>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct StringNullableFilter {
+    // every StringFilter field, plus:
+    pub is_null: Option<bool>,
+}
+
+// Plus: IntFilter, BigIntFilter, FloatFilter, DecimalFilter, BoolFilter,
+//       BytesFilter, DateTimeFilter, DateFilter, TimeFilter, UuidFilter,
+//       JsonFilter, EnumFilter<E>, and nullable variants.
+
+#[derive(Debug, Clone, Default)]
+pub struct ListRelationFilter<W> { pub some: Option<W>, pub every: Option<W>, pub none: Option<W> }
+
+#[derive(Debug, Clone, Default)]
+pub struct SingleRelationFilter<W> { pub is: Option<W>, pub is_not: Option<W> }
+```
+
+Each scalar filter has helper constructors (`StringFilter::contains("...")`, `IntFilter::gt(18)`) and `From<scalar>` impls so the macro can accept `email: "a@b.com"` as shorthand for `email: { equals: "a@b.com" }`.
+
+Scalar field updates use dedicated wrappers for atomic operations:
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct IntFieldUpdate {
+    pub set:       Option<i64>,
+    pub increment: Option<i64>,
+    pub decrement: Option<i64>,
+    pub multiply:  Option<i64>,
+    pub divide:    Option<i64>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct StringNullableFieldUpdate {
+    pub set:   Option<String>,
+    pub unset: Option<bool>,
+}
+
+impl From<i64>    for IntFieldUpdate              { /* { set: Some(v), .. } */ }
+impl From<String> for StringNullableFieldUpdate   { /* { set: Some(v), .. } */ }
+```
+
+### Layer 3: Macros and capability gates (new)
+
+One proc-macro per operation in `prax-codegen`:
+
+```
+prax::find_unique!   prax::find_first!     prax::find_many!
+prax::create!        prax::create_many!
+prax::update!        prax::update_many!
+prax::delete!        prax::delete_many!
+prax::upsert!
+prax::count!         prax::aggregate!      prax::group_by!
+```
+
+Plus shape macros for composition:
+
+```
+prax::where!         prax::include!        prax::select!
+prax::order_by!      prax::data!
+```
+
+All macros are schema-aware proc-macros that load the schema once per compile and emit token streams that construct the layer-2 input types.
+
+Capability marker traits in `prax_query::capabilities`:
+
+- `SupportsRelationFilter` — `some`/`every`/`none`/`is`/`is_not` available.
+- `SupportsCorrelatedSubquery` — superset for nested EXISTS.
+- `SupportsJsonPath` — JSON-path filter operators.
+- `SupportsCaseInsensitiveMode` — Postgres ILIKE; others fall back to `LOWER(...)` and skip the gate.
+- `SupportsFullTextSearch`, `SupportsArrayOps` — extensible.
+- `SupportsGeneratedColumns` — DDL for `GENERATED ALWAYS AS (...)`.
+- `SupportsScalarSubqueryInSelect` — relation-aggregate virtuals.
+- `SupportsNestedWrites` — Prisma-style nested create/connect/disconnect.
+
+Engine crates impl the marker traits they satisfy. Methods on input types and macro expansions that produce capability-dependent fragments carry `where E: SupportsX` bounds, so misuse fails at compile time with a `#[diagnostic::on_unimplemented]` message.
+
+## 3. Generated input types — concrete shapes
+
+For the example schema:
+
+```text
+model User {
+    id        Int      @id @auto
+    email     String   @unique
+    name      String?
+    age       Int?
+    active    Boolean  @default(true)
+    role      Role
+    posts     Post[]
+    profile   Profile?
+    createdAt DateTime @default(now())
+}
+```
+
+codegen emits, in module `inputs::user`:
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct UserWhereInput {
+    pub id:         Option<IntFilter>,
+    pub email:      Option<StringFilter>,
+    pub name:       Option<StringNullableFilter>,
+    pub age:        Option<IntNullableFilter>,
+    pub active:     Option<BoolFilter>,
+    pub role:       Option<EnumFilter<Role>>,
+    pub created_at: Option<DateTimeFilter>,
+
+    // Relation filters — only emitted when the engine impls SupportsRelationFilter.
+    pub posts:   Option<ListRelationFilter<PostWhereInput>>,
+    pub profile: Option<SingleRelationFilter<ProfileWhereInput>>,
+
+    // Logical combinators.
+    pub and: Option<Vec<UserWhereInput>>,
+    pub or:  Option<Vec<UserWhereInput>>,
+    pub not: Option<Box<UserWhereInput>>,
+}
+
+#[derive(Debug, Clone)]
+pub enum UserWhereUniqueInput {
+    Id(i64),
+    Email(String),
+    // Composite uniques generated as named variants.
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct UserInclude {
+    pub posts:   Option<PostsIncludeArgs>,
+    pub profile: Option<ProfileIncludeArgs>,
+    pub _count:  Option<UserCountSelect>,
+}
+// Codegen emits `#[allow(non_snake_case)]` on UserInclude/UserSelect so the
+// `_count` ident doesn't trigger lints in user crates. The leading underscore
+// follows the Prisma convention and disambiguates from any user-defined `count`
+// field on a model.
+
+#[derive(Debug, Clone, Default)]
+pub struct PostsIncludeArgs {
+    pub r#where:  Option<PostWhereInput>,
+    pub order_by: Option<Vec<PostOrderBy>>,
+    pub skip:     Option<u64>,
+    pub take:     Option<u64>,
+    pub cursor:   Option<PostWhereUniqueInput>,
+    pub include:  Option<PostInclude>,
+    pub select:   Option<PostSelect>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct UserSelect {
+    pub id:         Option<bool>,
+    pub email:      Option<bool>,
+    pub name:       Option<bool>,
+    pub age:        Option<bool>,
+    pub active:     Option<bool>,
+    pub role:       Option<bool>,
+    pub created_at: Option<bool>,
+    pub posts:      Option<PostsSelectArgs>,
+    pub profile:    Option<ProfileSelectArgs>,
+    pub _count:     Option<UserCountSelect>,
+}
+
+#[derive(Debug, Clone)]
+pub enum UserOrderBy {
+    Id(SortOrder),
+    Email(SortOrder),
+    Name(NullableSortOrder),
+    Age(NullableSortOrder),
+    CreatedAt(SortOrder),
+    Posts(PostsOrderByRelationAggregate),  // _count, _avg, _sum on the relation
+    Profile(ProfileOrderBy),
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct UserCreateInput {
+    pub email:   String,                          // required
+    pub name:    Option<String>,
+    pub age:     Option<i32>,
+    pub active:  Option<bool>,
+    pub role:    Role,
+    pub posts:   Option<PostsCreateNestedInput>,
+    pub profile: Option<ProfileCreateNestedInput>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct UserUpdateInput {
+    pub email:   Option<StringFieldUpdate>,
+    pub name:    Option<StringNullableFieldUpdate>,
+    pub age:     Option<IntFieldUpdate>,
+    pub active:  Option<BoolFieldUpdate>,
+    pub role:    Option<EnumFieldUpdate<Role>>,
+    pub posts:   Option<PostsUpdateNestedInput>,
+    pub profile: Option<ProfileUpdateNestedInput>,
+}
+```
+
+Notes:
+
+- `Option<T>` for every field is what makes `..Default::default()` work and lets the macro spread/merge cleanly. Required `CreateInput` fields stay bare (no `Option`).
+- `From<scalar>` impls on filters/updates allow `email: "x"` → `{ equals: "x" }` and `name: "Alice"` → `{ set: "Alice" }`.
+- `NullableSortOrder` (Prisma's `{ sort: asc, nulls: first }`) is in scope: emitted on `UserOrderBy` variants for nullable fields.
+- `_count` lives in `UserSelect` / `UserInclude` only (not as a top-level `_count` key on findMany).
+
+## 4. Macro grammar and expansion
+
+### Forms
+
+```rust
+// Form 1: accessor + brace block (recommended).
+prax::find_many!(client.user, { where: { email: { contains: "@x.com" } }, take: 10 });
+
+// Form 2: typed-accessor path (generic code).
+prax::find_many!(User on &engine, { where: { ... } });
+
+// Form 3: explicit `for` annotation (when accessor can't be resolved automatically).
+prax::find_many!(get_client().user(), for User, { where: { ... } });
+```
+
+The grammar reflects all three forms:
+
+```
+operation_macro_args := accessor_expr ("," "for" model_ident)? "," operation_input
+accessor_expr        := expr | model_ident "on" expr
+```
+
+The macro produces an unexec'd operation (`FindManyOperation<E, User>`). The caller invokes `.exec().await?` themselves. That preserves composition with transactions, middleware, tenant context, etc.
+
+### Grammar (EBNF-ish)
+
+```
+operation_input  := "{" field_list "}"
+field_list       := (field ",")* field?
+field            := ident ":" value
+                  | ".." expr                                  // spread
+                  | "..move" expr                              // move-spread (no clone)
+                  | "#[if(" expr ")]" ident ":" value
+                  | "#[else_if(" expr ")]" ident ":" value
+                  | "#[else]" ident ":" value
+value            := literal | path | expr_in_parens
+                  | "{" field_list "}"                         // nested input shape
+                  | "[" expr_list "]"                          // list (in_list, AND, etc.)
+                  | "true" | "false"                           // include/select shortcuts
+                  | "@(" expr ")"                              // explicit Rust expr escape
+                  | bare_ident                                 // role: Admin → role: { equals: Admin }
+```
+
+### Top-level keys per operation
+
+| Macro              | Allowed top-level keys                                                            |
+|--------------------|-----------------------------------------------------------------------------------|
+| `find_unique!`     | `where` (must be unique), `include` xor `select`                                  |
+| `find_first!`      | `where`, `order_by`, `cursor`, `skip`, `take`, `include` xor `select`             |
+| `find_many!`       | `where`, `order_by`, `cursor`, `skip`, `take`, `distinct`, `include` xor `select` |
+| `create!`          | `data`, `include` xor `select`                                                    |
+| `create_many!`     | `data`, `skip_duplicates`                                                         |
+| `update!`          | `where` (unique), `data`, `include` xor `select`                                  |
+| `update_many!`     | `where`, `data`                                                                   |
+| `upsert!`          | `where` (unique), `create`, `update`, `include` xor `select`                      |
+| `delete!`          | `where` (unique), `include` xor `select`                                          |
+| `delete_many!`     | `where`                                                                           |
+| `count!`           | `where`, `order_by`, `cursor`, `skip`, `take`, `select`                           |
+| `aggregate!`       | `where`, `order_by`, `cursor`, `skip`, `take`, `_count`, `_avg`, `_sum`, `_min`, `_max` |
+| `group_by!`        | `by`, `where`, `having`, `order_by`, `skip`, `take`, `_count`, `_avg`, `_sum`, `_min`, `_max` |
+
+Unknown keys at any level produce a "did you mean" diagnostic computed against the actual model.
+
+### Operator naming
+
+Snake_case Rust idiom: `gt`, `gte`, `lt`, `lte`, `equals`, `not`, `in_list`, `not_in`, `contains`, `starts_with`, `ends_with`, `mode: insensitive`, `some`, `every`, `none`, `is`, `is_not`, `is_null`, `set`, `increment`, `decrement`, `multiply`, `divide`, `unset`.
+
+### Spread and conditional semantics
+
+- `..expr` clones `expr` (which must be the same input type) and any subsequent `field: value` entries overwrite. Later wins, matching Rust struct-update syntax. The macro inserts `Clone::clone(&expr)` so the spread doesn't consume.
+- `..move expr` is the same but moves (no clone) — opt-in for hot paths.
+- `#[if(cond)] field: value` lowers to a `let __tmp = …; if cond { __w.field = Some(__tmp); }` block. Pairs with `#[else_if]` and `#[else]`.
+- Bare identifiers as values (`role: Admin`) are resolved against the schema; if the field is an enum, becomes `EnumFilter::equals(Path::Admin)`.
+- `@(expr)` escapes DSL parsing — treat the contents as a Rust expression.
+- `order_by: { field: dir }` auto-wraps to `vec![{ field: dir }]`.
+
+### Expansion example
+
+```rust
+prax::find_many!(client.user, {
+    where: {
+        email: { contains: "@x.com", mode: insensitive },
+        age:   { gte: 18 },
+        ..base_filter,
+        posts: { some: { published: true } },
+        or: [
+            { role: Admin },
+            { role: Moderator },
+        ],
+    },
+    include: {
+        posts: {
+            where: { published: true },
+            order_by: { created_at: desc },
+            take: 5,
+        },
+        profile: true,
+    },
+    order_by: [{ created_at: desc }],
+    take: 10,
+});
+```
+
+expands (sketch) to:
+
+```rust
+{
+    let __where = {
+        let mut __w = ::prax::inputs::user::UserWhereInput {
+            email: Some(::prax::inputs::StringFilter {
+                contains: Some(("@x.com").into()),
+                mode:     Some(::prax::inputs::QueryMode::Insensitive),
+                ..::core::default::Default::default()
+            }),
+            age: Some(::prax::inputs::IntNullableFilter::gte(18)),
+            ..::core::clone::Clone::clone(&(base_filter))
+        };
+        __w.posts = Some(::prax::inputs::ListRelationFilter {
+            some: Some(::prax::inputs::post::PostWhereInput {
+                published: Some(true.into()),
+                ..::core::default::Default::default()
+            }),
+            ..::core::default::Default::default()
+        });
+        __w.or = Some(::std::vec![ /* ... */ ]);
+        __w
+    };
+    let __include = ::prax::inputs::user::UserInclude { /* ... */ };
+    ::prax::traits::ModelAccessor::find_many(&client.user())
+        .with_where_input(__where)
+        .with_include_input(__include)
+        .with_order_by_input(::std::vec![/* ... */])
+        .take(10)
+}
+```
+
+The macro never invents new runtime types. `with_*_input` are extension methods on each `Operation` that call `into_ir()` and stash the resulting `Filter`/`Include`/`OrderBy`. The existing `.r#where(filter)` / `.include(spec)` builder methods stay untouched.
+
+## 5. Schema-aware proc-macro implementation
+
+### Schema discovery
+
+```rust
+fn resolve_schema() -> &'static Arc<Schema>;
+```
+
+Resolution order:
+
+1. `PRAX_SCHEMA` env var (absolute or relative to `CARGO_MANIFEST_DIR`). Used directly if set; error if file missing.
+2. Walk up from `CARGO_MANIFEST_DIR` looking for `prax.toml`. Read `[generator.client].schema` (defaults to `prax/schema.prax`). Resolve relative to the `prax.toml` location.
+3. No `prax.toml` found → hard error: *"Could not find a `prax.toml` in any ancestor of $CARGO_MANIFEST_DIR. Set `PRAX_SCHEMA=path/to/schema.prax` or run `prax init`."*
+
+Caching: `OnceLock<Mutex<HashMap<PathBuf, Arc<Schema>>>>` keyed by absolute schema path. First macro call parses; subsequent calls hit cache.
+
+Dependency tracking: prefer `proc_macro::tracked_path::path(absolute_schema)` for re-trigger on schema change. Fallback for older toolchains: emit `const _: &[u8] = include_bytes!(absolute_schema_path);` inside a hidden module of the expansion so rustc's dep graph notices changes.
+
+### Macro flow
+
+```
+parse TokenStream
+  → resolve_schema() — &Schema
+  → resolve model from accessor expr (`client.user` → "User")
+  → parse DSL block into typed AST (WhereInputAst, IncludeAst, …)
+  → validate AST against schema:
+      - unknown field → "did you mean `{closest}`" (strsim::jaro_winkler ≥ 0.85)
+      - wrong operator for scalar type → "field `age` (Int) does not support `contains`"
+      - relation op on non-relation → "field `email` is not a relation"
+      - `some`/`every`/`none` on to-one → "use `is`/`is_not` for to-one"
+      - `where` not unique on find_unique/update/etc.
+      - `select` xor `include`
+  → lower AST → token stream constructing layer-2 input structs
+  → emit
+```
+
+### Accessor resolution
+
+- `client.MODEL` → snake_case the last path segment, match against `schema.models` (PascalCase).
+- `MODEL on EXPR` → take the type-position `MODEL` ident directly.
+- `expr(), for MODEL` → explicit annotation.
+
+Failures here produce a clear error pointing to the accessor token.
+
+### Codegen entry points
+
+1. `prax generate` (CLI) — emits `inputs/` submodule alongside existing client `mod.rs`.
+2. `#[derive(Model)]` — emits `<model_snake>_inputs` sibling module. Requires sibling models defined in the same module for relation-filter codegen to resolve cross-model types (default constraint; documented).
+3. `prax_schema!` macro — same codegen as `prax generate`, inline.
+
+### Compile-time cost budget
+
+Per-model generated input footprint: ~200–400 lines (~10 types). For a 50-model schema with 8 fields average, ~16 kLOC generated — comparable to a moderately large `serde::Deserialize` derive footprint. Schema parse: ~5–10 ms once per crate per compile; subsequent macro calls in the same compile are <100 µs.
+
+Feature-gated: `prax/inputs` Cargo feature on `prax-codegen` (default-on). Disabling skips input-type codegen for users who prefer the existing fluent API.
+
+## 6. Write operations and nested-write plans
+
+### Principles
+
+1. **Lower to existing operations.** Nested writes compile to a sequence of `Create`/`Update`/`Upsert`/`Delete` runtime operations inside a single transaction. No new SQL.
+2. **Reuse engine transactions.** The macro auto-wraps multi-op plans in `engine.transaction(...)`. Single-op plans skip the wrapper.
+3. **Static dependency ordering.** Codegen knows relation directions; the plan emits ops in topological order. No runtime topo-sort.
+
+### Nested input shapes
+
+For `posts: Post[]` (FK on `Post.authorId`):
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct PostsCreateNestedInput {
+    pub create:            Option<Vec<PostCreateWithoutAuthorInput>>,
+    pub create_many:       Option<PostsCreateManyWithoutAuthorInput>,
+    pub connect:           Option<Vec<PostWhereUniqueInput>>,
+    pub connect_or_create: Option<Vec<PostConnectOrCreateWithoutAuthorInput>>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PostsUpdateNestedInput {
+    pub create:            Option<Vec<PostCreateWithoutAuthorInput>>,
+    pub connect:           Option<Vec<PostWhereUniqueInput>>,
+    pub disconnect:        Option<Vec<PostWhereUniqueInput>>,
+    pub set:               Option<Vec<PostWhereUniqueInput>>,
+    pub update:            Option<Vec<PostUpdateWithWhereUniqueWithoutAuthorInput>>,
+    pub update_many:       Option<Vec<PostUpdateManyWithWhereWithoutAuthorInput>>,
+    pub upsert:            Option<Vec<PostUpsertWithWhereUniqueWithoutAuthorInput>>,
+    pub delete:            Option<Vec<PostWhereUniqueInput>>,
+    pub delete_many:       Option<Vec<PostScalarWhereWithoutAuthorInput>>,
+    pub connect_or_create: Option<Vec<PostConnectOrCreateWithoutAuthorInput>>,
+}
+```
+
+`*WithoutAuthorInput` variants omit the FK fields the parent insert will fill in via `RETURNING`.
+
+For `profile: Profile?` (to-one, FK on child):
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct ProfileCreateNestedInput {
+    pub create:            Option<Box<ProfileCreateWithoutUserInput>>,
+    pub connect:           Option<ProfileWhereUniqueInput>,
+    pub connect_or_create: Option<Box<ProfileConnectOrCreateWithoutUserInput>>,
+}
+```
+
+### `NestedWritePlan`
+
+```rust
+pub enum NestedWriteOp {
+    InsertSelf { columns: Vec<&'static str>, values: Vec<FilterValue>, returning: ReturningSpec },
+    InsertChild { parent_id_slot: SlotId, model: &'static str, columns: Vec<&'static str>, values: Vec<FilterValue> },
+    Connect { parent_id_slot: SlotId, child_pk: WhereUniqueInput, fk_column: &'static str },
+    ConnectOrCreate { /* ... */ },
+    UpsertChild { /* ... */ },
+    UpdateChild { /* ... */ },
+    DeleteChild { /* ... */ },
+    SetRelation { /* ... */ },
+}
+
+pub struct NestedWritePlan {
+    pub ops: Vec<NestedWriteOp>,
+    pub return_root_via: SlotId,
+}
+```
+
+`SlotId` placeholders are substituted with PKs returned from earlier ops. The executor walks the plan in order; `Self` inserts before children; inverse-direction creates run the parent op first.
+
+### `connect_or_create`
+
+Two lowerings:
+
+- **Engines with upsert syntax** (Postgres `ON CONFLICT`, SQLite `ON CONFLICT`, MySQL `INSERT … ON DUPLICATE KEY UPDATE`, MSSQL `MERGE`): single statement.
+- **Other engines**: two-statement `SELECT pk WHERE unique = …; INSERT if missing` inside the surrounding transaction.
+
+### `set: [...]` (full relation replacement)
+
+Diff-based: fetch current children → DELETE those not in the new set → INSERT/CONNECT those that are new. Heavy but consistent. **Enabled by default** to match Prisma. Document the cost.
+
+### Returning typed shape after a nested write
+
+After commit, the executor runs a final find with the requested `include`/`select` against the inserted PK. Adds one roundtrip but reuses the existing find-with-include path.
+
+### Capability gating
+
+- All SQL drivers + MongoDB: full support.
+- CQL (ScyllaDB / Cassandra): `*CreateNestedInput` / `*UpdateNestedInput` types are gated behind `SupportsNestedWrites`. CQL engines don't impl it, so nested writes don't compile.
+
+### `QueryEngine` additions
+
+- `fn in_transaction(&self) -> bool` — additive, default returns `false`. Drivers that support transactions override.
+
+## 7. Error handling
+
+Three categories:
+
+### Compile-time errors
+
+- Unknown field, wrong operator for scalar type, `some` on non-relation, relation cardinality mismatch, `where` not unique where required, `select` and `include` both set, capability-trait not satisfied.
+- Emitted via `syn::Error::to_compile_error` with token-level spans.
+- Capability errors carry `#[diagnostic::on_unimplemented]` messages.
+
+### Runtime errors (additive `QueryError` variants, `#[non_exhaustive]`)
+
+- `QueryError::RelationNotFound { relation, parent_id }`
+- `QueryError::UniqueViolationOnConnectOrCreate { model, unique }`
+- `QueryError::RequiredWhereMissing { operation }`
+- `QueryError::NestedWriteFailed { op, source: Box<QueryError> }`
+
+### Capability mismatches caught early
+
+Marker-trait bounds on input methods plus `with_*_input` extension methods make capability errors compile-time, not runtime.
+
+## 8. Coexistence and migration path
+
+### Coexistence
+
+- Existing `.r#where(filter)` / `.include(spec)` / `CreateData::new().set(…)` API unchanged.
+- New `with_where_input<W: WhereInput<Model = M>>(self, w: W) -> Self` and siblings on every `Operation`.
+- Old and new can be combined; later calls AND-compose with earlier filters.
+- Third interface: explicit struct construction (`FindManyArgs { r#where: Some(UserWhereInput { … }), .. }`) is supported and documented.
+
+### Phasing (non-breaking, each phase ships independently)
+
+| Phase | Crates | Deliverable | Effort |
+|-------|--------|-------------|--------|
+| 1 | `prax-query` | New traits, scalar filter wrappers, `ListRelationFilter`/`SingleRelationFilter`, capability marker traits, `*Args` structs, `with_*_input` ext methods | 3–4 days |
+| 2 | `prax-codegen`, engine crates | `prax generate` / `prax_schema!` / `#[derive(Model)]` emit `inputs/` modules. Engines impl capability marker traits | 4–5 days |
+| 3 | `prax-codegen` | Read operation macros + schema discovery + cache + `trybuild` UI tests | 4–5 days |
+| 4 | `prax-codegen` | Shape macros (`where!`, `include!`, …), spread, conditional, bare-ident enum resolution | 2–3 days |
+| 5 | `prax-codegen`, `prax-query` | Write macros + `NestedWritePlan` executor + `connect_or_create` paths + `SupportsNestedWrites` gating | 5–7 days |
+| 5.5 | `prax-schema`, `prax-codegen`, `prax-migrate`, engine crates | Computed/virtual field support (§9) | 3 days |
+| 6 | `prax-codegen`, `prax-query` | Aggregate macros (`count!`, `aggregate!`, `group_by!`) | 2–3 days |
+| 7 | repo-wide | Examples migrated, docs site updated (§10), cookbook, rustdoc chapter, cross-engine consistency tests | 5–8 days |
+
+**Total: 28–38 feature-days.**
+
+### Compatibility guarantees
+
+- Every public symbol in `prax-query`'s current API remains.
+- New `Filter::ScalarSubquery` variant lands behind `#[non_exhaustive]`.
+- `QueryError` is `#[non_exhaustive]`; new variants are additive.
+- `Model` and `ModelAccessor` traits unchanged.
+
+## 9. Computed and virtual fields
+
+Three classes:
+
+### (1) DB-generated columns
+
+```text
+model User {
+    id        Int    @id @auto
+    firstName String
+    lastName  String
+    fullName  String @generated("first_name || ' ' || last_name") @stored
+    searchKey String @generated("LOWER(email)") @virtual
+}
+```
+
+- New `FieldKind::DbGenerated { expr: String, stored: bool }` variant in the `prax-schema` AST.
+- Real scalar field in the result struct.
+- Included in `WhereInput` and `SelectInput`.
+- Excluded from `CreateInput` and `UpdateInput`.
+- `prax-migrate` SQL generator emits `GENERATED ALWAYS AS (expr) STORED|VIRTUAL` DDL; CQL dialect rejects with clear error.
+- Capability gate: `SupportsGeneratedColumns` — PG/MySQL/SQLite/MSSQL/DuckDB.
+
+### (2) Relation aggregate virtuals
+
+```text
+model User {
+    id         Int    @id @auto
+    posts      Post[]
+    postCount  Int    @count(posts)
+    totalViews Int    @sum(posts.views)
+    lastPostAt DateTime? @max(posts.created_at)
+}
+```
+
+- New `FieldKind::Aggregate { kind, relation, field }` variant.
+- Scalar field on result struct; no underlying column.
+- Included in `WhereInput` and `SelectInput`; excluded from `CreateInput`/`UpdateInput`.
+- `WhereInput::into_ir` produces `Filter::ScalarSubquery { sql, params }` (new IR variant).
+- SELECT lowering: scalar subquery `(SELECT COUNT(*) FROM posts p WHERE p.author_id = u.id) AS post_count`. Lateral-join is an optimization, not baseline.
+- `_count` accessor in `select` / `include` reuses the same machinery — `select: { _count: { posts: true } }` and a schema-level `@count(posts)` field produce the same lowering.
+- Capability gate: `SupportsScalarSubqueryInSelect`. Implemented at phase 5.5 by every SQL engine (PG / MySQL / SQLite / MSSQL / DuckDB) via scalar subqueries. **Not** implemented by `prax-mongodb` until the follow-up `$lookup`-lowering plan ships; until then, MongoDB code that uses relation-aggregate virtuals fails to compile with a clear capability-trait diagnostic. CQL engines never implement this gate.
+
+### (3) Pure-Rust computed methods
+
+Regular `impl User { fn display_name(&self) -> String { … } }`. No DSL involvement. Documented as "for derived values that depend only on already-loaded fields and never need to be filtered on."
+
+## 10. Documentation site updates (Angular `docs/` workspace)
+
+### New pages and routes
+
+| Route | Page module | Content |
+|-------|-------------|---------|
+| `/queries/input-types` | `queries-input-types.page` | Reference for the trait family and per-model generated structs |
+| `/queries/macros` | `queries-macros.page` | Full grammar reference for every operation macro and shape macro; spread + conditional syntax; capability-trait error messages |
+| `/queries/relation-filters` | `queries-relation-filters.page` | `some`/`every`/`none`/`is`/`is_not` — examples, generated SQL per dialect, cross-engine support matrix |
+| `/queries/nested-writes` | `queries-nested-writes.page` | Nested `connect` / `create` / `connect_or_create` / `disconnect` / `set` / `update` / `upsert` / `delete` / `delete_many`; transaction semantics; CQL unsupported note |
+| `/queries/computed-fields` | `queries-computed-fields.page` | `@generated` columns and `@count` / `@sum` / `@avg` / `@min` / `@max` virtuals |
+| `/migration/from-fluent-builder` | `migration-from-fluent.page` | Side-by-side fluent → macro cookbook |
+| `/migration/prisma-to-prax` | `migration-prisma-to-prax.page` | Prisma TS → Prax cheat sheet (snake_case operator names, Rust syntax differences) |
+
+### Existing pages requiring substantive updates
+
+Each gets a new "Macro DSL" or "Input types" section. The fluent-builder example moves under a "Dynamic composition" sub-heading.
+
+- `queries-crud.page` — primary CRUD examples switch to macros.
+- `queries-filtering.page` — refactor around `WhereInput` and scalar filters.
+- `queries-pagination.page` — `skip`/`take`/`cursor` inside macros.
+- `queries-aggregations.page` — `aggregate!`, `group_by!`, `count!`, `_count` virtual.
+- `queries-upsert.page` — `upsert!` macro.
+- `queries-json.page` — JSON-field filters; capability gating per engine.
+- `queries-search.page` — `mode: insensitive` and per-engine behavior.
+- `schema-relations.page` — include/select/relation-filter shapes; relation cardinality drives `ListRelationFilter` vs `SingleRelationFilter`.
+- `schema-overview.page` — link to new generated-types reference.
+- `schema-fields.page` — `@generated`, `@stored`, `@virtual`, `@count` / `@sum` / `@avg` / `@min` / `@max` attributes.
+- `schema-attributes.page` — same attribute reference detail.
+- `home.page`, `quickstart.page` — landing examples switch to macro form.
+- `advanced-errors.page` — new `QueryError` variants and error mapping.
+- `examples.page` — every example rewritten in the new style.
+- `database-{postgresql,mysql,sqlite,mssql,duckdb,mongodb}.page` — capability matrix table noting which marker traits each engine implements. New pages to add: `database-scylladb.page` and `database-cassandra.page` (route + module + html) — these don't exist on the docs site today and the new feature surface is a natural moment to introduce them.
+
+### Navigation / IA changes
+
+- New "Macro DSL" sidebar group: `/queries/macros`, `/queries/input-types`, `/queries/relation-filters`, `/queries/nested-writes`, `/queries/computed-fields`.
+- New "Migration" sidebar group with the two migration pages.
+- Existing "Queries" group reordered so `queries/crud` and `queries/filtering` lead with macro examples and link out to the new Macro DSL group.
+
+### Cross-link audit
+
+- Every `prax::*!` macro reference on any page links to `/queries/macros#<macro>`.
+- Every `WhereInput` / `IncludeInput` / capability-trait mention links to `/queries/input-types#<anchor>`.
+
+### Build verification
+
+- `pnpm --filter docs build`, `pnpm --filter docs lint`, `pnpm --filter docs test` must pass before phase 7 closes.
+- If a docs CI job exists, extend it to cover the new pages; otherwise add one that triggers on `docs/**` changes.
+
+## 11. Testing strategy
+
+| Layer | Location | What it catches |
+|-------|----------|-----------------|
+| Unit: `into_ir` lowerings | `prax-query/tests/inputs/` | Hand-built `UserWhereInput` lowers to expected `Filter`. Pure data, no engine. |
+| Macro UI tests | `prax-codegen/tests/ui/` | DSL parsing, diagnostics, "did you mean", capability-trait errors. `trybuild` with `.stderr` snapshots. Schema-aware diagnostics pinned via committed `tests/fixtures/schema.prax`, found via `PRAX_SCHEMA`. |
+| Per-engine integration | `prax-postgres/tests/inputs_dsl.rs` (and siblings) | Macros against real engines, assert rows. Reuses existing test containers. |
+| Cross-engine consistency | `prax-query/tests/cross_engine_dsl/` | Same macro call against PG/MySQL/SQLite/MSSQL/DuckDB; results agree. |
+| `compile_fail.rs` | `prax-query/tests/` | Capability gates: `prax::find_many!(scylla_client.user, { where: { posts: { some: ... } } })` fails to compile. |
+
+Test schema (`tests/fixtures/schema.prax`) covers: one-to-one, one-to-many, many-to-many (implicit join), self-relation, composite PK, nullable-FK, enum field, JSON field, `@generated` columns, `@count` / `@sum` virtuals.
+
+Shared test schemas live in a new private workspace member `prax-test-schema` so all engine crates pull from one fixture set.
+
+## 12. Risks and mitigations
+
+| Risk | Probability | Mitigation |
+|------|-------------|------------|
+| `proc_macro::tracked_path` not on MSRV | Medium | `include_bytes!`-inside-hidden-module fallback; build.rs / env-var hash as final fallback |
+| Compile-time bloat from generated input types | Medium | Feature-gate `inputs` codegen behind `prax/inputs` (default-on); ~16 kLOC per 50-model schema is acceptable |
+| Diagnostic span quality on macro errors | Medium | Use `syn::Error::to_compile_error` with per-token spans; `trybuild` snapshots gate regressions |
+| `connect_or_create` race semantics | Medium | One concrete path per engine; document the per-engine atomicity guarantees |
+| Many-to-many through implicit join tables in nested writes | Medium | Codegen reads the schema's join table; phase 5 covers implicit-join only; explicit-join-model M2M deferred |
+| Capability-trait proliferation | Low | Cap at the nine traits in §2; finer-grained gates become runtime errors |
+
+## 13. Open follow-ups (post-design)
+
+- MongoDB `$lookup` lowering for relation-aggregate virtuals (separate plan after phase 6).
+- Generic result types parameterized by include shape (a future research design — not promised).
+- Explicit-join-model M2M in nested writes (separate plan).
+- Migration helpers for translating Prisma schemas to Prax schemas (could live in `prax-import`).

--- a/prax-cli/src/commands/import.rs
+++ b/prax-cli/src/commands/import.rs
@@ -185,10 +185,10 @@ fn format_schema(schema: &prax_schema::Schema) -> String {
             // dimension in `ScalarType::Vector(Option<u32>)` etc. The schema
             // parser expects the dimension as a separate `@dim(N)` attribute
             // rather than inline `Vector(N)` syntax, so emit it explicitly.
-            if let prax_schema::FieldType::Scalar(scalar) = &field.field_type {
-                if let Some(dim) = scalar.dimension() {
-                    output.push_str(&format!(" @dim({})", dim));
-                }
+            if let prax_schema::FieldType::Scalar(scalar) = &field.field_type
+                && let Some(dim) = scalar.dimension()
+            {
+                output.push_str(&format!(" @dim({})", dim));
             }
 
             // Add attributes

--- a/prax-query/Cargo.toml
+++ b/prax-query/Cargo.toml
@@ -45,6 +45,7 @@ parking_lot = { workspace = true }
 num_cpus = "1.16"
 chrono = { workspace = true }
 rust_decimal = { workspace = true }
+base64 = { workspace = true }
 
 # Logging
 tracing = { workspace = true }

--- a/prax-query/src/capabilities.rs
+++ b/prax-query/src/capabilities.rs
@@ -1,0 +1,164 @@
+//! Engine capability marker traits.
+//!
+//! Each trait in this module marks a capability that some `QueryEngine`
+//! impls satisfy and others don't. The macro DSL (phase 3+) and the
+//! generated input types (phase 2) carry `where E: SupportsX` bounds on
+//! the methods that produce capability-dependent SQL. Using such a
+//! method against an engine that doesn't impl the trait fails to compile
+//! with a clear diagnostic.
+//!
+//! Engine crates (`prax-postgres`, `prax-mysql`, ...) impl the traits
+//! they satisfy on their concrete engine types. Phase 1 only defines
+//! the traits; engine impls land in phase 2.
+
+use crate::traits::QueryEngine;
+
+/// Engine supports relation filters (`some`/`every`/`none`/`is`/`is_not`)
+/// that lower to correlated EXISTS / NOT EXISTS subqueries (or the
+/// equivalent in non-SQL engines).
+#[diagnostic::on_unimplemented(
+    message = "the engine `{Self}` does not support relation filters (`some` / `every` / `none` / `is` / `is_not`)",
+    note = "ScyllaDB / Cassandra do not support correlated subqueries. Consider flattening the join or restructuring the model."
+)]
+pub trait SupportsRelationFilter: QueryEngine {}
+
+/// Engine supports correlated subqueries in WHERE clauses.
+///
+/// Superset of `SupportsRelationFilter` — used by features that need
+/// arbitrary subqueries (e.g. computed-field WHERE lowering in phase 5.5).
+#[diagnostic::on_unimplemented(
+    message = "the engine `{Self}` does not support correlated subqueries in WHERE clauses"
+)]
+pub trait SupportsCorrelatedSubquery: QueryEngine {}
+
+/// Engine supports JSON-path filter operators (`path_eq`, `path_gt`, etc.).
+#[diagnostic::on_unimplemented(
+    message = "the engine `{Self}` does not support JSON path operators",
+    note = "Postgres / MySQL >= 5.7 / SQLite + JSON1 / MSSQL support JSON paths."
+)]
+pub trait SupportsJsonPath: QueryEngine {}
+
+/// Engine has native case-insensitive comparison (`ILIKE`, `COLLATE NOCASE`,
+/// equivalent). Engines without it fall back to `LOWER(...)` comparisons and
+/// **do not** need to impl this trait.
+#[diagnostic::on_unimplemented(
+    message = "the engine `{Self}` does not advertise native case-insensitive comparison"
+)]
+pub trait SupportsCaseInsensitiveMode: QueryEngine {}
+
+/// Engine supports full-text search predicates.
+#[diagnostic::on_unimplemented(message = "the engine `{Self}` does not support full-text search")]
+pub trait SupportsFullTextSearch: QueryEngine {}
+
+/// Engine supports native array column operators (`contains`, `overlaps`, ...).
+#[diagnostic::on_unimplemented(message = "the engine `{Self}` does not support array operators")]
+pub trait SupportsArrayOps: QueryEngine {}
+
+/// Engine supports DDL for `GENERATED ALWAYS AS (expr) STORED|VIRTUAL`
+/// computed columns.
+#[diagnostic::on_unimplemented(
+    message = "the engine `{Self}` does not support generated columns",
+    note = "Postgres / MySQL / SQLite / MSSQL / DuckDB support GENERATED ALWAYS AS."
+)]
+pub trait SupportsGeneratedColumns: QueryEngine {}
+
+/// Engine supports scalar subqueries in the SELECT list.
+///
+/// Required for relation-aggregate virtual fields (`@count`, `@sum`,
+/// `@avg`, `@min`, `@max`) and Prisma-style `_count`.
+#[diagnostic::on_unimplemented(
+    message = "the engine `{Self}` does not support scalar subqueries in SELECT",
+    note = "All SQL engines satisfy this. MongoDB requires the $lookup-lowering follow-up plan."
+)]
+pub trait SupportsScalarSubqueryInSelect: QueryEngine {}
+
+/// Engine supports Prisma-style nested writes
+/// (`create` / `connect` / `connect_or_create` / `disconnect` / `set`
+/// / `update` / `upsert` / `delete` / `delete_many` inside `data`).
+///
+/// CQL engines (`prax-scylladb`, `prax-cassandra`) deliberately do not
+/// impl this trait — phase 5's `*CreateNestedInput` / `*UpdateNestedInput`
+/// types carry `where E: SupportsNestedWrites` bounds so misuse fails
+/// to compile.
+#[diagnostic::on_unimplemented(
+    message = "the engine `{Self}` does not support nested writes",
+    note = "ScyllaDB / Cassandra batch semantics don't map onto Prisma-style nested writes. Use the engine-native BATCH API or restructure."
+)]
+pub trait SupportsNestedWrites: QueryEngine {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A tiny stub engine for trait-impl smoke tests.
+    #[derive(Clone)]
+    struct StubEngine;
+
+    impl QueryEngine for StubEngine {
+        fn query_many<T: crate::traits::Model + crate::row::FromRow + Send + 'static>(
+            &self,
+            _sql: &str,
+            _params: Vec<crate::filter::FilterValue>,
+        ) -> crate::traits::BoxFuture<'_, crate::error::QueryResult<Vec<T>>> {
+            Box::pin(async { Ok(Vec::new()) })
+        }
+        fn query_one<T: crate::traits::Model + crate::row::FromRow + Send + 'static>(
+            &self,
+            _sql: &str,
+            _params: Vec<crate::filter::FilterValue>,
+        ) -> crate::traits::BoxFuture<'_, crate::error::QueryResult<T>> {
+            Box::pin(async { Err(crate::error::QueryError::not_found("t")) })
+        }
+        fn query_optional<T: crate::traits::Model + crate::row::FromRow + Send + 'static>(
+            &self,
+            _sql: &str,
+            _params: Vec<crate::filter::FilterValue>,
+        ) -> crate::traits::BoxFuture<'_, crate::error::QueryResult<Option<T>>> {
+            Box::pin(async { Ok(None) })
+        }
+        fn execute_insert<T: crate::traits::Model + crate::row::FromRow + Send + 'static>(
+            &self,
+            _sql: &str,
+            _params: Vec<crate::filter::FilterValue>,
+        ) -> crate::traits::BoxFuture<'_, crate::error::QueryResult<T>> {
+            Box::pin(async { Err(crate::error::QueryError::not_found("t")) })
+        }
+        fn execute_update<T: crate::traits::Model + crate::row::FromRow + Send + 'static>(
+            &self,
+            _sql: &str,
+            _params: Vec<crate::filter::FilterValue>,
+        ) -> crate::traits::BoxFuture<'_, crate::error::QueryResult<Vec<T>>> {
+            Box::pin(async { Ok(Vec::new()) })
+        }
+        fn execute_delete(
+            &self,
+            _sql: &str,
+            _params: Vec<crate::filter::FilterValue>,
+        ) -> crate::traits::BoxFuture<'_, crate::error::QueryResult<u64>> {
+            Box::pin(async { Ok(0) })
+        }
+        fn execute_raw(
+            &self,
+            _sql: &str,
+            _params: Vec<crate::filter::FilterValue>,
+        ) -> crate::traits::BoxFuture<'_, crate::error::QueryResult<u64>> {
+            Box::pin(async { Ok(0) })
+        }
+        fn count(
+            &self,
+            _sql: &str,
+            _params: Vec<crate::filter::FilterValue>,
+        ) -> crate::traits::BoxFuture<'_, crate::error::QueryResult<u64>> {
+            Box::pin(async { Ok(0) })
+        }
+    }
+
+    impl SupportsRelationFilter for StubEngine {}
+
+    fn needs_relation_filter<E: SupportsRelationFilter>() {}
+
+    #[test]
+    fn marker_trait_dispatch_compiles() {
+        needs_relation_filter::<StubEngine>();
+    }
+}

--- a/prax-query/src/filter.rs
+++ b/prax-query/src/filter.rs
@@ -551,6 +551,7 @@ impl<T: Into<FilterValue>> ScalarFilter<T> {
 #[derive(Debug, Clone, PartialEq)]
 #[repr(C)] // Ensure predictable memory layout
 #[derive(Default)]
+#[non_exhaustive]
 pub enum Filter {
     /// No filter (always true).
     #[default]
@@ -599,6 +600,22 @@ pub enum Filter {
     Or(Box<[Filter]>),
     /// Logical NOT of a filter.
     Not(Box<Filter>),
+
+    /// A pre-built scalar subquery fragment.
+    ///
+    /// Used by relation-aggregate virtual fields and nested-write child
+    /// lookups (phase 5 / 5.5). The `sql` string contains portable `{N}`
+    /// placeholders that are substituted with dialect-specific placeholders
+    /// at SQL build time; `N` is the zero-based index into `params`.
+    ///
+    /// Phase 1 introduces the variant for forward compatibility; nothing
+    /// in the workspace constructs it yet.
+    ScalarSubquery {
+        /// SQL fragment with `{N}` placeholders.
+        sql: std::borrow::Cow<'static, str>,
+        /// Parameter values referenced by the `{N}` placeholders.
+        params: Vec<FilterValue>,
+    },
 }
 
 impl Filter {
@@ -1111,6 +1128,51 @@ impl Filter {
             Self::Not(filter) => {
                 let inner = filter.to_sql_with_params(param_idx, params, dialect);
                 format!("NOT ({})", inner)
+            }
+
+            Self::ScalarSubquery {
+                sql,
+                params: inner_params,
+            } => {
+                // `param_idx` already encodes the next available 1-based global slot:
+                // the And/Or arms forward `outer_param_idx + params.len()` as the
+                // child's param_idx, so we must NOT add params.len() again here.
+                // {N} in the SQL maps to global slot (param_idx + N + 1).
+                let base = param_idx;
+                let mut out = String::with_capacity(sql.len() + inner_params.len() * 4);
+                let mut chars = sql.chars().peekable();
+                while let Some(ch) = chars.next() {
+                    if ch == '{' {
+                        // Read the integer index up to '}'.
+                        let mut digits = String::new();
+                        while let Some(&c) = chars.peek() {
+                            if c == '}' {
+                                chars.next();
+                                break;
+                            }
+                            digits.push(c);
+                            chars.next();
+                        }
+                        let n: usize = digits.parse().unwrap_or_else(|_| {
+                            panic!(
+                                "Filter::ScalarSubquery: invalid placeholder index `{{{}}}`",
+                                digits
+                            )
+                        });
+                        let value = inner_params.get(n).unwrap_or_else(|| {
+                            panic!(
+                                "Filter::ScalarSubquery: placeholder {{{}}} out of range (have {} params)",
+                                n,
+                                inner_params.len()
+                            )
+                        });
+                        params.push(value.clone());
+                        out.push_str(&dialect.placeholder(base + n + 1));
+                    } else {
+                        out.push(ch);
+                    }
+                }
+                format!("({})", out)
             }
         }
     }
@@ -2741,5 +2803,43 @@ mod tests {
     #[test]
     fn to_filter_value_bool_is_bool() {
         assert_eq!(true.to_filter_value(), FilterValue::Bool(true));
+    }
+
+    #[test]
+    fn scalar_subquery_lowers_to_inline_sql_with_dialect_placeholders() {
+        use crate::dialect::Postgres;
+        let f = Filter::ScalarSubquery {
+            sql: std::borrow::Cow::Borrowed(
+                "(SELECT COUNT(*) FROM posts p WHERE p.author_id = users.id AND p.published = {0}) > {1}",
+            ),
+            params: vec![FilterValue::Bool(true), FilterValue::Int(5)],
+        };
+        let (sql, params) = f.to_sql(0, &Postgres);
+        assert_eq!(
+            sql,
+            "((SELECT COUNT(*) FROM posts p WHERE p.author_id = users.id AND p.published = $1) > $2)"
+        );
+        assert_eq!(params, vec![FilterValue::Bool(true), FilterValue::Int(5)]);
+    }
+
+    #[test]
+    fn scalar_subquery_offsets_placeholders_inside_and() {
+        use crate::dialect::Postgres;
+        let f = Filter::and([
+            Filter::Equals("active".into(), FilterValue::Bool(true)),
+            Filter::ScalarSubquery {
+                sql: std::borrow::Cow::Borrowed(
+                    "(SELECT COUNT(*) FROM posts p WHERE p.author_id = users.id) >= {0}",
+                ),
+                params: vec![FilterValue::Int(1)],
+            },
+        ]);
+        let (sql, params) = f.to_sql(0, &Postgres);
+        // First filter takes $1, the scalar subquery's {0} maps to $2.
+        assert!(sql.contains("$1"));
+        assert!(sql.contains("$2"));
+        assert_eq!(params.len(), 2);
+        assert_eq!(params[0], FilterValue::Bool(true));
+        assert_eq!(params[1], FilterValue::Int(1));
     }
 }

--- a/prax-query/src/filter.rs
+++ b/prax-query/src/filter.rs
@@ -612,7 +612,10 @@ pub enum Filter {
     /// in the workspace constructs it yet.
     ScalarSubquery {
         /// SQL fragment with `{N}` placeholders.
-        sql: std::borrow::Cow<'static, str>,
+        ///
+        /// Placeholders may appear in any textual order and may repeat; each
+        /// `{N}` always resolves to the dialect placeholder for `inner_params[N]`.
+        sql: Cow<'static, str>,
         /// Parameter values referenced by the `{N}` placeholders.
         params: Vec<FilterValue>,
     },
@@ -1139,6 +1142,12 @@ impl Filter {
                 // child's param_idx, so we must NOT add params.len() again here.
                 // {N} in the SQL maps to global slot (param_idx + N + 1).
                 let base = param_idx;
+                // Reserve placeholder slots up front in inner_params index order so
+                // each `{N}` always emits the correct dialect placeholder regardless
+                // of textual order or repeats.
+                for v in inner_params.iter() {
+                    params.push(v.clone());
+                }
                 let mut out = String::with_capacity(sql.len() + inner_params.len() * 4);
                 let mut chars = sql.chars().peekable();
                 while let Some(ch) = chars.next() {
@@ -1159,14 +1168,13 @@ impl Filter {
                                 digits
                             )
                         });
-                        let value = inner_params.get(n).unwrap_or_else(|| {
+                        if n >= inner_params.len() {
                             panic!(
                                 "Filter::ScalarSubquery: placeholder {{{}}} out of range (have {} params)",
                                 n,
                                 inner_params.len()
-                            )
-                        });
-                        params.push(value.clone());
+                            );
+                        }
                         out.push_str(&dialect.placeholder(base + n + 1));
                     } else {
                         out.push(ch);
@@ -2809,7 +2817,7 @@ mod tests {
     fn scalar_subquery_lowers_to_inline_sql_with_dialect_placeholders() {
         use crate::dialect::Postgres;
         let f = Filter::ScalarSubquery {
-            sql: std::borrow::Cow::Borrowed(
+            sql: Cow::Borrowed(
                 "(SELECT COUNT(*) FROM posts p WHERE p.author_id = users.id AND p.published = {0}) > {1}",
             ),
             params: vec![FilterValue::Bool(true), FilterValue::Int(5)],
@@ -2828,7 +2836,7 @@ mod tests {
         let f = Filter::and([
             Filter::Equals("active".into(), FilterValue::Bool(true)),
             Filter::ScalarSubquery {
-                sql: std::borrow::Cow::Borrowed(
+                sql: Cow::Borrowed(
                     "(SELECT COUNT(*) FROM posts p WHERE p.author_id = users.id) >= {0}",
                 ),
                 params: vec![FilterValue::Int(1)],
@@ -2841,5 +2849,19 @@ mod tests {
         assert_eq!(params.len(), 2);
         assert_eq!(params[0], FilterValue::Bool(true));
         assert_eq!(params[1], FilterValue::Int(1));
+    }
+
+    #[test]
+    fn scalar_subquery_handles_out_of_order_and_repeated_placeholders() {
+        use crate::dialect::Postgres;
+        let f = Filter::ScalarSubquery {
+            sql: Cow::Borrowed("{1} = {0} AND {1} > {0}"),
+            params: vec![FilterValue::Int(1), FilterValue::Int(2)],
+        };
+        let (sql, params) = f.to_sql(0, &Postgres);
+        // {0} → $1 (binds Int(1)), {1} → $2 (binds Int(2)), regardless of
+        // textual order or repeats.
+        assert_eq!(sql, "($2 = $1 AND $2 > $1)");
+        assert_eq!(params, vec![FilterValue::Int(1), FilterValue::Int(2)]);
     }
 }

--- a/prax-query/src/inputs/args.rs
+++ b/prax-query/src/inputs/args.rs
@@ -1,1 +1,320 @@
-//! Per-operation Args containers — populated by Task 11.
+//! Per-operation argument containers.
+//!
+//! Each struct is the layer-2 "explicit form" of an operation request:
+//! the macro DSL (phase 3+) expands to a `*Args { ... }` literal that
+//! the operation builder consumes via `.with_args(args)`. Direct
+//! construction by hand is fully supported.
+//!
+//! Generic parameters:
+//! - `M` — the model
+//! - `W` — `WhereInput` impl for that model
+//! - `I` — `IncludeInput` impl
+//! - `S` — `SelectInput` impl
+//! - `D` — `CreateInput::Data` / `UpdateInput::Data` payload (operation-specific)
+//! - `O` — `OrderByInput` impl
+//!
+//! Phase 1 keeps the bounds open so hand-construction works even before
+//! codegen lands. Phase 2 narrows them when the per-model types exist.
+
+use core::marker::PhantomData;
+
+/// Args for `find_unique`. `where` must identify at most one row.
+#[derive(Debug, Clone)]
+pub struct FindUniqueArgs<M, W, I, S> {
+    /// Unique WHERE input.
+    pub r#where: W,
+    /// Optional include shape.
+    pub include: Option<I>,
+    /// Optional select shape.
+    pub select: Option<S>,
+    /// Phantom marker for the model type.
+    #[doc(hidden)]
+    pub _model: PhantomData<M>,
+}
+
+impl<M, W: Default, I, S> Default for FindUniqueArgs<M, W, I, S> {
+    fn default() -> Self {
+        Self {
+            r#where: W::default(),
+            include: None,
+            select: None,
+            _model: PhantomData,
+        }
+    }
+}
+
+impl<M, W, I, S> FindUniqueArgs<M, W, I, S> {
+    /// Construct with the given unique WHERE.
+    pub fn new(r#where: W) -> Self {
+        Self {
+            r#where,
+            include: None,
+            select: None,
+            _model: PhantomData,
+        }
+    }
+}
+
+/// Args for `find_first`.
+#[derive(Debug, Clone)]
+pub struct FindFirstArgs<M, W, I, S, O = (), C = ()> {
+    /// Optional WHERE input.
+    pub r#where: Option<W>,
+    /// Optional include shape.
+    pub include: Option<I>,
+    /// Optional select shape.
+    pub select: Option<S>,
+    /// Optional order-by shape (single or vec).
+    pub order_by: Option<Vec<O>>,
+    /// Optional cursor value.
+    pub cursor: Option<C>,
+    /// Skip N rows.
+    pub skip: Option<u64>,
+    /// Take N rows.
+    pub take: Option<u64>,
+    /// Phantom marker for the model.
+    #[doc(hidden)]
+    pub _model: PhantomData<M>,
+}
+
+impl<M, W, I, S, O, C> Default for FindFirstArgs<M, W, I, S, O, C> {
+    fn default() -> Self {
+        Self {
+            r#where: None,
+            include: None,
+            select: None,
+            order_by: None,
+            cursor: None,
+            skip: None,
+            take: None,
+            _model: PhantomData,
+        }
+    }
+}
+
+/// Args for `find_many`.
+#[derive(Debug, Clone)]
+pub struct FindManyArgs<M, W, I, S, O = (), C = ()> {
+    /// Optional WHERE input.
+    pub r#where: Option<W>,
+    /// Optional include shape.
+    pub include: Option<I>,
+    /// Optional select shape.
+    pub select: Option<S>,
+    /// Optional order-by shape (single or vec).
+    pub order_by: Option<Vec<O>>,
+    /// Optional cursor value.
+    pub cursor: Option<C>,
+    /// Skip N rows.
+    pub skip: Option<u64>,
+    /// Take N rows.
+    pub take: Option<u64>,
+    /// Distinct columns.
+    pub distinct: Option<Vec<String>>,
+    /// Phantom marker for the model.
+    #[doc(hidden)]
+    pub _model: PhantomData<M>,
+}
+
+impl<M, W, I, S, O, C> Default for FindManyArgs<M, W, I, S, O, C> {
+    fn default() -> Self {
+        Self {
+            r#where: None,
+            include: None,
+            select: None,
+            order_by: None,
+            cursor: None,
+            skip: None,
+            take: None,
+            distinct: None,
+            _model: PhantomData,
+        }
+    }
+}
+
+/// Args for `create`.
+#[derive(Debug, Clone)]
+pub struct CreateArgs<M, D, I, S> {
+    /// Create-data payload.
+    pub data: D,
+    /// Optional include shape on the returning row.
+    pub include: Option<I>,
+    /// Optional select shape on the returning row.
+    pub select: Option<S>,
+    /// Phantom marker for the model.
+    #[doc(hidden)]
+    pub _model: PhantomData<M>,
+}
+
+impl<M, D: Default, I, S> Default for CreateArgs<M, D, I, S> {
+    fn default() -> Self {
+        Self {
+            data: D::default(),
+            include: None,
+            select: None,
+            _model: PhantomData,
+        }
+    }
+}
+
+/// Args for `create_many`.
+#[derive(Debug, Clone)]
+pub struct CreateManyArgs<M, D> {
+    /// Create-data payloads.
+    pub data: Vec<D>,
+    /// Skip rows that would violate a unique constraint (instead of erroring).
+    pub skip_duplicates: Option<bool>,
+    /// Phantom marker for the model.
+    #[doc(hidden)]
+    pub _model: PhantomData<M>,
+}
+
+impl<M, D> Default for CreateManyArgs<M, D> {
+    fn default() -> Self {
+        Self {
+            data: Vec::new(),
+            skip_duplicates: None,
+            _model: PhantomData,
+        }
+    }
+}
+
+/// Args for `update`.
+#[derive(Debug, Clone)]
+pub struct UpdateArgs<M, W, U, I, S> {
+    /// Unique WHERE input.
+    pub r#where: W,
+    /// Update-data payload.
+    pub data: U,
+    /// Optional include shape.
+    pub include: Option<I>,
+    /// Optional select shape.
+    pub select: Option<S>,
+    /// Phantom marker for the model.
+    #[doc(hidden)]
+    pub _model: PhantomData<M>,
+}
+
+/// Args for `update_many`.
+#[derive(Debug, Clone)]
+pub struct UpdateManyArgs<M, W, U> {
+    /// Optional WHERE input.
+    pub r#where: Option<W>,
+    /// Update-data payload.
+    pub data: U,
+    /// Phantom marker for the model.
+    #[doc(hidden)]
+    pub _model: PhantomData<M>,
+}
+
+impl<M, W, U: Default> Default for UpdateManyArgs<M, W, U> {
+    fn default() -> Self {
+        Self {
+            r#where: None,
+            data: U::default(),
+            _model: PhantomData,
+        }
+    }
+}
+
+/// Args for `upsert`.
+#[derive(Debug, Clone)]
+pub struct UpsertArgs<M, W, C, U, I, S> {
+    /// Unique WHERE input.
+    pub r#where: W,
+    /// Create-data payload (used if no row matched).
+    pub create: C,
+    /// Update-data payload (used if a row matched).
+    pub update: U,
+    /// Optional include shape on the returning row.
+    pub include: Option<I>,
+    /// Optional select shape on the returning row.
+    pub select: Option<S>,
+    /// Phantom marker for the model.
+    #[doc(hidden)]
+    pub _model: PhantomData<M>,
+}
+
+/// Args for `delete`.
+#[derive(Debug, Clone)]
+pub struct DeleteArgs<M, W, I, S> {
+    /// Unique WHERE input.
+    pub r#where: W,
+    /// Optional include shape on the returning row.
+    pub include: Option<I>,
+    /// Optional select shape on the returning row.
+    pub select: Option<S>,
+    /// Phantom marker for the model.
+    #[doc(hidden)]
+    pub _model: PhantomData<M>,
+}
+
+/// Args for `delete_many`.
+#[derive(Debug, Clone, Default)]
+pub struct DeleteManyArgs<M, W> {
+    /// Optional WHERE input.
+    pub r#where: Option<W>,
+    /// Phantom marker for the model.
+    #[doc(hidden)]
+    pub _model: PhantomData<M>,
+}
+
+/// Args for `count`.
+#[derive(Debug, Clone, Default)]
+pub struct CountArgs<M, W, O = (), C = ()> {
+    /// Optional WHERE input.
+    pub r#where: Option<W>,
+    /// Optional order-by.
+    pub order_by: Option<Vec<O>>,
+    /// Optional cursor.
+    pub cursor: Option<C>,
+    /// Skip N rows.
+    pub skip: Option<u64>,
+    /// Take N rows.
+    pub take: Option<u64>,
+    /// Phantom marker for the model.
+    #[doc(hidden)]
+    pub _model: PhantomData<M>,
+}
+
+/// Args for `aggregate`. The aggregate spec parameter is filled in by phase 6.
+#[derive(Debug, Clone, Default)]
+pub struct AggregateArgs<M, W, A, O = (), C = ()> {
+    /// Optional WHERE input.
+    pub r#where: Option<W>,
+    /// Aggregate spec (`_count` / `_avg` / `_sum` / `_min` / `_max`).
+    pub aggregate: Option<A>,
+    /// Optional order-by.
+    pub order_by: Option<Vec<O>>,
+    /// Optional cursor.
+    pub cursor: Option<C>,
+    /// Skip N rows.
+    pub skip: Option<u64>,
+    /// Take N rows.
+    pub take: Option<u64>,
+    /// Phantom marker for the model.
+    #[doc(hidden)]
+    pub _model: PhantomData<M>,
+}
+
+/// Args for `group_by`. The grouping spec parameter is filled in by phase 6.
+#[derive(Debug, Clone, Default)]
+pub struct GroupByArgs<M, W, A, G, H = (), O = ()> {
+    /// Group by these field names.
+    pub by: Vec<G>,
+    /// Optional WHERE input.
+    pub r#where: Option<W>,
+    /// Optional HAVING input.
+    pub having: Option<H>,
+    /// Aggregate spec.
+    pub aggregate: Option<A>,
+    /// Optional order-by.
+    pub order_by: Option<Vec<O>>,
+    /// Skip N rows.
+    pub skip: Option<u64>,
+    /// Take N rows.
+    pub take: Option<u64>,
+    /// Phantom marker for the model.
+    #[doc(hidden)]
+    pub _model: PhantomData<M>,
+}

--- a/prax-query/src/inputs/args.rs
+++ b/prax-query/src/inputs/args.rs
@@ -1,0 +1,1 @@
+//! Per-operation Args containers — populated by Task 11.

--- a/prax-query/src/inputs/mod.rs
+++ b/prax-query/src/inputs/mod.rs
@@ -26,7 +26,6 @@ pub mod traits;
 // resolve to concrete items once tasks 6-11 populate them.
 #[allow(unused_imports)]
 pub use args::*;
-#[allow(unused_imports)]
 pub use relation::*;
 pub use scalar::*;
 #[allow(unused_imports)]

--- a/prax-query/src/inputs/mod.rs
+++ b/prax-query/src/inputs/mod.rs
@@ -28,7 +28,6 @@ pub mod traits;
 pub use args::*;
 #[allow(unused_imports)]
 pub use relation::*;
-#[allow(unused_imports)]
 pub use scalar::*;
 #[allow(unused_imports)]
 pub use scalar_update::*;

--- a/prax-query/src/inputs/mod.rs
+++ b/prax-query/src/inputs/mod.rs
@@ -22,9 +22,6 @@ pub mod scalar;
 pub mod scalar_update;
 pub mod traits;
 
-// The four sibling modules are stubs in phase 1; their pub-use lines will
-// resolve to concrete items once tasks 6-11 populate them.
-#[allow(unused_imports)]
 pub use args::*;
 pub use relation::*;
 pub use scalar::*;

--- a/prax-query/src/inputs/mod.rs
+++ b/prax-query/src/inputs/mod.rs
@@ -1,0 +1,35 @@
+//! Typed input shapes for the Prisma-style DSL.
+//!
+//! This module holds the trait spine (`WhereInput`, `IncludeInput`, …),
+//! the reusable scalar filter wrappers (`StringFilter`, `IntFilter`, …),
+//! the relation filter wrappers (`ListRelationFilter`,
+//! `SingleRelationFilter`), the scalar update wrappers
+//! (`IntFieldUpdate`, `StringFieldUpdate`, …), and the per-operation
+//! containers (`FindManyArgs`, `CreateArgs`, …).
+//!
+//! Codegen (phase 2) emits per-model concrete structs that implement
+//! these traits and use these wrappers. The operation macros (phase 3+)
+//! emit token streams that construct these inputs and feed them to
+//! existing `*Operation` builders via `with_*_input` extension methods.
+//!
+//! Layer-1 callers can also build these inputs by hand — they form the
+//! "third interface" alongside the macro DSL and the existing fluent
+//! builder.
+
+pub mod args;
+pub mod relation;
+pub mod scalar;
+pub mod scalar_update;
+pub mod traits;
+
+// The four sibling modules are stubs in phase 1; their pub-use lines will
+// resolve to concrete items once tasks 6-11 populate them.
+#[allow(unused_imports)]
+pub use args::*;
+#[allow(unused_imports)]
+pub use relation::*;
+#[allow(unused_imports)]
+pub use scalar::*;
+#[allow(unused_imports)]
+pub use scalar_update::*;
+pub use traits::*;

--- a/prax-query/src/inputs/mod.rs
+++ b/prax-query/src/inputs/mod.rs
@@ -28,6 +28,5 @@ pub mod traits;
 pub use args::*;
 pub use relation::*;
 pub use scalar::*;
-#[allow(unused_imports)]
 pub use scalar_update::*;
 pub use traits::*;

--- a/prax-query/src/inputs/relation.rs
+++ b/prax-query/src/inputs/relation.rs
@@ -1,1 +1,312 @@
-//! Relation filter wrappers — populated by Task 9.
+//! Relation-aware filter wrappers.
+//!
+//! `ListRelationFilter<W>` and `SingleRelationFilter<W>` carry the
+//! Prisma operator shape (`some`/`every`/`none` for to-many;
+//! `is`/`is_not` for to-one). They lower to [`Filter::ScalarSubquery`]
+//! fragments via a per-relation [`RelationMeta`] adapter that codegen
+//! emits (phase 2) but tests / hand-built users can supply directly.
+
+use crate::filter::{Filter, FilterValue};
+use crate::inputs::traits::WhereInput;
+
+/// Static metadata for one parent→child relation.
+///
+/// Phase 2 codegen emits one impl per relation declared in the schema.
+/// Hand-rolled callers can implement this trait themselves.
+pub trait RelationMeta {
+    /// Parent SQL table name.
+    const PARENT_TABLE: &'static str;
+    /// Parent primary-key column name.
+    const PARENT_PK: &'static str;
+    /// Child SQL table name.
+    const CHILD_TABLE: &'static str;
+    /// Child foreign-key column name pointing back at the parent.
+    const CHILD_FK: &'static str;
+}
+
+/// Filter operators for a to-many relation.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[serde(bound = "W: serde::Serialize + for<'de2> serde::Deserialize<'de2>")]
+pub struct ListRelationFilter<W> {
+    /// At least one child matches `W`.
+    pub some: Option<W>,
+    /// Every existing child matches `W`.
+    pub every: Option<W>,
+    /// No child matches `W`.
+    pub none: Option<W>,
+}
+
+/// Filter operators for a to-one relation.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[serde(bound = "W: serde::Serialize + for<'de2> serde::Deserialize<'de2>")]
+pub struct SingleRelationFilter<W> {
+    /// The related row matches `W`.
+    pub is: Option<W>,
+    /// The related row does NOT match `W` (or doesn't exist).
+    pub is_not: Option<W>,
+}
+
+/// Lowering helper: produces `Filter::ScalarSubquery` from a relation
+/// filter + `RelationMeta`.
+///
+/// Implemented for any `W: WhereInput` so neither the codegen nor the
+/// macro layer needs to manually thread metadata.
+pub trait LowerRelationFilter {
+    /// Lower this relation filter to a runtime [`Filter`] using the
+    /// supplied metadata.
+    fn lower<M: RelationMeta>(self) -> Filter;
+}
+
+/// Walk a `Filter` tree and produce inline SQL with `{N}` placeholders.
+///
+/// Phase 1 supports the operators that the scalar filters emit.
+/// `ScalarSubquery` nesting is not expected at phase 1 and panics.
+fn render_inline_filter(inner: Filter) -> (String, Vec<FilterValue>) {
+    let mut sql = String::new();
+    let mut params = Vec::<FilterValue>::new();
+    write_filter(&inner, &mut sql, &mut params);
+    (sql, params)
+}
+
+fn write_filter(f: &Filter, sql: &mut String, params: &mut Vec<FilterValue>) {
+    match f {
+        Filter::None => sql.push_str("TRUE"),
+        Filter::Equals(c, v) => {
+            if matches!(v, FilterValue::Null) {
+                sql.push_str(&format!("{} IS NULL", c));
+            } else {
+                let idx = params.len();
+                params.push(v.clone());
+                sql.push_str(&format!("{} = {{{}}}", c, idx));
+            }
+        }
+        Filter::NotEquals(c, v) => {
+            if matches!(v, FilterValue::Null) {
+                sql.push_str(&format!("{} IS NOT NULL", c));
+            } else {
+                let idx = params.len();
+                params.push(v.clone());
+                sql.push_str(&format!("{} <> {{{}}}", c, idx));
+            }
+        }
+        Filter::Lt(c, v) => {
+            let i = params.len();
+            params.push(v.clone());
+            sql.push_str(&format!("{} < {{{}}}", c, i));
+        }
+        Filter::Lte(c, v) => {
+            let i = params.len();
+            params.push(v.clone());
+            sql.push_str(&format!("{} <= {{{}}}", c, i));
+        }
+        Filter::Gt(c, v) => {
+            let i = params.len();
+            params.push(v.clone());
+            sql.push_str(&format!("{} > {{{}}}", c, i));
+        }
+        Filter::Gte(c, v) => {
+            let i = params.len();
+            params.push(v.clone());
+            sql.push_str(&format!("{} >= {{{}}}", c, i));
+        }
+        Filter::IsNull(c) => sql.push_str(&format!("{} IS NULL", c)),
+        Filter::IsNotNull(c) => sql.push_str(&format!("{} IS NOT NULL", c)),
+        Filter::Contains(c, FilterValue::String(s)) => {
+            let i = params.len();
+            params.push(FilterValue::String(format!("%{}%", s)));
+            sql.push_str(&format!("{} LIKE {{{}}}", c, i));
+        }
+        Filter::StartsWith(c, FilterValue::String(s)) => {
+            let i = params.len();
+            params.push(FilterValue::String(format!("{}%", s)));
+            sql.push_str(&format!("{} LIKE {{{}}}", c, i));
+        }
+        Filter::EndsWith(c, FilterValue::String(s)) => {
+            let i = params.len();
+            params.push(FilterValue::String(format!("%{}", s)));
+            sql.push_str(&format!("{} LIKE {{{}}}", c, i));
+        }
+        Filter::Contains(_, _) | Filter::StartsWith(_, _) | Filter::EndsWith(_, _) => {
+            panic!("phase 1 inline lowering supports only String LIKE values");
+        }
+        Filter::In(c, values) => {
+            if values.is_empty() {
+                sql.push_str("FALSE");
+                return;
+            }
+            sql.push_str(&format!("{} IN (", c));
+            for (n, v) in values.iter().enumerate() {
+                if n > 0 {
+                    sql.push_str(", ");
+                }
+                let i = params.len();
+                params.push(v.clone());
+                sql.push_str(&format!("{{{}}}", i));
+            }
+            sql.push(')');
+        }
+        Filter::NotIn(c, values) => {
+            if values.is_empty() {
+                sql.push_str("TRUE");
+                return;
+            }
+            sql.push_str(&format!("{} NOT IN (", c));
+            for (n, v) in values.iter().enumerate() {
+                if n > 0 {
+                    sql.push_str(", ");
+                }
+                let i = params.len();
+                params.push(v.clone());
+                sql.push_str(&format!("{{{}}}", i));
+            }
+            sql.push(')');
+        }
+        Filter::And(parts) => {
+            if parts.is_empty() {
+                sql.push_str("TRUE");
+                return;
+            }
+            sql.push('(');
+            for (n, p) in parts.iter().enumerate() {
+                if n > 0 {
+                    sql.push_str(" AND ");
+                }
+                write_filter(p, sql, params);
+            }
+            sql.push(')');
+        }
+        Filter::Or(parts) => {
+            if parts.is_empty() {
+                sql.push_str("FALSE");
+                return;
+            }
+            sql.push('(');
+            for (n, p) in parts.iter().enumerate() {
+                if n > 0 {
+                    sql.push_str(" OR ");
+                }
+                write_filter(p, sql, params);
+            }
+            sql.push(')');
+        }
+        Filter::Not(inner) => {
+            sql.push_str("NOT (");
+            write_filter(inner, sql, params);
+            sql.push(')');
+        }
+        Filter::ScalarSubquery { .. } => {
+            panic!("phase 1 does not support nesting ScalarSubquery inside relation filters");
+        }
+    }
+}
+
+impl<W: WhereInput> LowerRelationFilter for ListRelationFilter<W> {
+    fn lower<M: RelationMeta>(self) -> Filter {
+        let mut clauses: Vec<Filter> = Vec::new();
+
+        if let Some(w) = self.some {
+            let (body, params) = render_inline_filter(w.into_ir());
+            let sql = format!(
+                "EXISTS (SELECT 1 FROM {} WHERE {}.{} = {}.{} AND {})",
+                M::CHILD_TABLE,
+                M::CHILD_TABLE,
+                M::CHILD_FK,
+                M::PARENT_TABLE,
+                M::PARENT_PK,
+                body,
+            );
+            clauses.push(Filter::ScalarSubquery {
+                sql: sql.into(),
+                params,
+            });
+        }
+
+        if let Some(w) = self.every {
+            let (body, params) = render_inline_filter(w.into_ir());
+            let sql = format!(
+                "NOT EXISTS (SELECT 1 FROM {} WHERE {}.{} = {}.{} AND NOT ({}))",
+                M::CHILD_TABLE,
+                M::CHILD_TABLE,
+                M::CHILD_FK,
+                M::PARENT_TABLE,
+                M::PARENT_PK,
+                body,
+            );
+            clauses.push(Filter::ScalarSubquery {
+                sql: sql.into(),
+                params,
+            });
+        }
+
+        if let Some(w) = self.none {
+            let (body, params) = render_inline_filter(w.into_ir());
+            let sql = format!(
+                "NOT EXISTS (SELECT 1 FROM {} WHERE {}.{} = {}.{} AND {})",
+                M::CHILD_TABLE,
+                M::CHILD_TABLE,
+                M::CHILD_FK,
+                M::PARENT_TABLE,
+                M::PARENT_PK,
+                body,
+            );
+            clauses.push(Filter::ScalarSubquery {
+                sql: sql.into(),
+                params,
+            });
+        }
+
+        match clauses.len() {
+            0 => Filter::None,
+            1 => clauses.into_iter().next().unwrap(),
+            _ => Filter::and(clauses),
+        }
+    }
+}
+
+impl<W: WhereInput> LowerRelationFilter for SingleRelationFilter<W> {
+    fn lower<M: RelationMeta>(self) -> Filter {
+        let mut clauses: Vec<Filter> = Vec::new();
+
+        if let Some(w) = self.is {
+            let (body, params) = render_inline_filter(w.into_ir());
+            let sql = format!(
+                "EXISTS (SELECT 1 FROM {} WHERE {}.{} = {}.{} AND {})",
+                M::CHILD_TABLE,
+                M::CHILD_TABLE,
+                M::CHILD_FK,
+                M::PARENT_TABLE,
+                M::PARENT_PK,
+                body,
+            );
+            clauses.push(Filter::ScalarSubquery {
+                sql: sql.into(),
+                params,
+            });
+        }
+
+        if let Some(w) = self.is_not {
+            let (body, params) = render_inline_filter(w.into_ir());
+            let sql = format!(
+                "NOT EXISTS (SELECT 1 FROM {} WHERE {}.{} = {}.{} AND {})",
+                M::CHILD_TABLE,
+                M::CHILD_TABLE,
+                M::CHILD_FK,
+                M::PARENT_TABLE,
+                M::PARENT_PK,
+                body,
+            );
+            clauses.push(Filter::ScalarSubquery {
+                sql: sql.into(),
+                params,
+            });
+        }
+
+        match clauses.len() {
+            0 => Filter::None,
+            1 => clauses.into_iter().next().unwrap(),
+            _ => Filter::and(clauses),
+        }
+    }
+}

--- a/prax-query/src/inputs/relation.rs
+++ b/prax-query/src/inputs/relation.rs
@@ -3,17 +3,20 @@
 //! `ListRelationFilter<W>` and `SingleRelationFilter<W>` carry the
 //! Prisma operator shape (`some`/`every`/`none` for to-many;
 //! `is`/`is_not` for to-one). They lower to [`Filter::ScalarSubquery`]
-//! fragments via a per-relation [`RelationMeta`] adapter that codegen
+//! fragments via a per-relation [`RelationFilterMeta`] adapter that codegen
 //! emits (phase 2) but tests / hand-built users can supply directly.
 
 use crate::filter::{Filter, FilterValue};
 use crate::inputs::traits::WhereInput;
 
-/// Static metadata for one parent→child relation.
+/// Static metadata for one parent→child relation, used when lowering
+/// relation filters to EXISTS / NOT EXISTS subqueries.
 ///
 /// Phase 2 codegen emits one impl per relation declared in the schema.
 /// Hand-rolled callers can implement this trait themselves.
-pub trait RelationMeta {
+///
+/// Distinct from `crate::relations::RelationMeta`, which carries runtime-loader metadata.
+pub trait RelationFilterMeta {
     /// Parent SQL table name.
     const PARENT_TABLE: &'static str;
     /// Parent primary-key column name.
@@ -49,14 +52,14 @@ pub struct SingleRelationFilter<W> {
 }
 
 /// Lowering helper: produces `Filter::ScalarSubquery` from a relation
-/// filter + `RelationMeta`.
+/// filter + [`RelationFilterMeta`].
 ///
 /// Implemented for any `W: WhereInput` so neither the codegen nor the
 /// macro layer needs to manually thread metadata.
 pub trait LowerRelationFilter {
     /// Lower this relation filter to a runtime [`Filter`] using the
     /// supplied metadata.
-    fn lower<M: RelationMeta>(self) -> Filter;
+    fn lower<M: RelationFilterMeta>(self) -> Filter;
 }
 
 /// Walk a `Filter` tree and produce inline SQL with `{N}` placeholders.
@@ -203,7 +206,7 @@ fn write_filter(f: &Filter, sql: &mut String, params: &mut Vec<FilterValue>) {
 }
 
 impl<W: WhereInput> LowerRelationFilter for ListRelationFilter<W> {
-    fn lower<M: RelationMeta>(self) -> Filter {
+    fn lower<M: RelationFilterMeta>(self) -> Filter {
         let mut clauses: Vec<Filter> = Vec::new();
 
         if let Some(w) = self.some {
@@ -266,7 +269,7 @@ impl<W: WhereInput> LowerRelationFilter for ListRelationFilter<W> {
 }
 
 impl<W: WhereInput> LowerRelationFilter for SingleRelationFilter<W> {
-    fn lower<M: RelationMeta>(self) -> Filter {
+    fn lower<M: RelationFilterMeta>(self) -> Filter {
         let mut clauses: Vec<Filter> = Vec::new();
 
         if let Some(w) = self.is {

--- a/prax-query/src/inputs/relation.rs
+++ b/prax-query/src/inputs/relation.rs
@@ -7,6 +7,7 @@
 //! emits (phase 2) but tests / hand-built users can supply directly.
 
 use crate::filter::{Filter, FilterValue};
+use crate::inputs::scalar::combine_filters;
 use crate::inputs::traits::WhereInput;
 
 /// Static metadata for one parent→child relation, used when lowering
@@ -65,7 +66,8 @@ pub trait LowerRelationFilter {
 /// Walk a `Filter` tree and produce inline SQL with `{N}` placeholders.
 ///
 /// Phase 1 supports the operators that the scalar filters emit.
-/// `ScalarSubquery` nesting is not expected at phase 1 and panics.
+/// `ScalarSubquery` nesting is not supported here and panics — the outer
+/// `Filter::to_sql_with_params` is the only place that splices subquery SQL.
 fn render_inline_filter(inner: Filter) -> (String, Vec<FilterValue>) {
     let mut sql = String::new();
     let mut params = Vec::<FilterValue>::new();
@@ -132,7 +134,10 @@ fn write_filter(f: &Filter, sql: &mut String, params: &mut Vec<FilterValue>) {
             sql.push_str(&format!("{} LIKE {{{}}}", c, i));
         }
         Filter::Contains(_, _) | Filter::StartsWith(_, _) | Filter::EndsWith(_, _) => {
-            panic!("phase 1 inline lowering supports only String LIKE values");
+            panic!(
+                "inline relation-filter lowering requires String values for Contains / StartsWith / EndsWith \
+                 (other FilterValue variants must be expressed via Equals / In)"
+            );
         }
         Filter::In(c, values) => {
             if values.is_empty() {
@@ -200,7 +205,10 @@ fn write_filter(f: &Filter, sql: &mut String, params: &mut Vec<FilterValue>) {
             sql.push(')');
         }
         Filter::ScalarSubquery { .. } => {
-            panic!("phase 1 does not support nesting ScalarSubquery inside relation filters");
+            panic!(
+                "inline relation-filter lowering does not support nested ScalarSubquery \
+                 (the outer to_sql_with_params handles ScalarSubquery; relation bodies must lower to leaf filters first)"
+            );
         }
     }
 }
@@ -260,11 +268,7 @@ impl<W: WhereInput> LowerRelationFilter for ListRelationFilter<W> {
             });
         }
 
-        match clauses.len() {
-            0 => Filter::None,
-            1 => clauses.into_iter().next().unwrap(),
-            _ => Filter::and(clauses),
-        }
+        combine_filters(clauses)
     }
 }
 
@@ -306,10 +310,6 @@ impl<W: WhereInput> LowerRelationFilter for SingleRelationFilter<W> {
             });
         }
 
-        match clauses.len() {
-            0 => Filter::None,
-            1 => clauses.into_iter().next().unwrap(),
-            _ => Filter::and(clauses),
-        }
+        combine_filters(clauses)
     }
 }

--- a/prax-query/src/inputs/relation.rs
+++ b/prax-query/src/inputs/relation.rs
@@ -1,0 +1,1 @@
+//! Relation filter wrappers — populated by Task 9.

--- a/prax-query/src/inputs/scalar.rs
+++ b/prax-query/src/inputs/scalar.rs
@@ -1,0 +1,1 @@
+//! Scalar filter wrappers — populated by Tasks 6, 7, 8.

--- a/prax-query/src/inputs/scalar.rs
+++ b/prax-query/src/inputs/scalar.rs
@@ -1,1 +1,263 @@
-//! Scalar filter wrappers — populated by Tasks 6, 7, 8.
+//! Reusable scalar filter wrappers shared by every generated `*WhereInput`.
+//!
+//! Each wrapper is a struct of `Option`-fields, one per operator. Empty
+//! wrappers (all fields `None`) lower to `Filter::None`. Multiple set
+//! fields AND-combine. `From<scalar>` impls support the macro shorthand
+//! `email: "alice@x.com"` => `StringFilter { equals: Some("..."), .. }`.
+//!
+//! Every wrapper implements [`ScalarFilter`], whose `into_filter`
+//! method takes the column name (which the parent `WhereInput` knows)
+//! and produces a runtime [`Filter`].
+
+use crate::filter::{Filter, FilterValue};
+use serde::{Deserialize, Serialize};
+
+/// Helper trait implemented by every scalar filter wrapper.
+///
+/// The wrapper itself doesn't know its column name — the parent
+/// `WhereInput::into_ir` impl threads the column in when lowering.
+pub trait ScalarFilter {
+    /// Lower this scalar filter to a runtime [`Filter`] keyed by
+    /// the given column name.
+    fn into_filter(self, column: &str) -> Filter;
+}
+
+/// Comparison mode for string filters.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum QueryMode {
+    /// Default (case-sensitive) comparison.
+    #[default]
+    Default,
+    /// Case-insensitive comparison. Requires `SupportsCaseInsensitiveMode`
+    /// for engines that don't fall back to `LOWER(...)`.
+    Insensitive,
+}
+
+/// Filter operators for a non-nullable `String` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct StringFilter {
+    /// `column = value`
+    pub equals: Option<String>,
+    /// Negation of the inner filter.
+    pub not: Option<Box<StringFilter>>,
+    /// `column IN (...)`
+    pub in_list: Option<Vec<String>>,
+    /// `column NOT IN (...)`
+    pub not_in: Option<Vec<String>>,
+    /// `column < value`
+    pub lt: Option<String>,
+    /// `column <= value`
+    pub lte: Option<String>,
+    /// `column > value`
+    pub gt: Option<String>,
+    /// `column >= value`
+    pub gte: Option<String>,
+    /// `column LIKE %value%`
+    pub contains: Option<String>,
+    /// `column LIKE value%`
+    pub starts_with: Option<String>,
+    /// `column LIKE %value`
+    pub ends_with: Option<String>,
+    /// Comparison mode (case sensitivity).
+    pub mode: Option<QueryMode>,
+}
+
+impl StringFilter {
+    /// `equals: Some(value)`.
+    pub fn equals(v: impl Into<String>) -> Self {
+        Self {
+            equals: Some(v.into()),
+            ..Default::default()
+        }
+    }
+    /// `contains: Some(value)`.
+    pub fn contains(v: impl Into<String>) -> Self {
+        Self {
+            contains: Some(v.into()),
+            ..Default::default()
+        }
+    }
+    /// `starts_with: Some(value)`.
+    pub fn starts_with(v: impl Into<String>) -> Self {
+        Self {
+            starts_with: Some(v.into()),
+            ..Default::default()
+        }
+    }
+    /// `ends_with: Some(value)`.
+    pub fn ends_with(v: impl Into<String>) -> Self {
+        Self {
+            ends_with: Some(v.into()),
+            ..Default::default()
+        }
+    }
+}
+
+impl From<&str> for StringFilter {
+    fn from(v: &str) -> Self {
+        Self::equals(v)
+    }
+}
+impl From<String> for StringFilter {
+    fn from(v: String) -> Self {
+        Self::equals(v)
+    }
+}
+
+impl ScalarFilter for StringFilter {
+    fn into_filter(self, column: &str) -> Filter {
+        let mut parts: Vec<Filter> = Vec::new();
+        let col = column.to_string();
+        if let Some(v) = self.equals {
+            parts.push(Filter::Equals(col.clone().into(), FilterValue::String(v)));
+        }
+        if let Some(boxed) = self.not {
+            let inner = boxed.into_filter(column);
+            parts.push(Filter::Not(Box::new(inner)));
+        }
+        if let Some(values) = self.in_list {
+            let vs: Vec<FilterValue> = values.into_iter().map(FilterValue::String).collect();
+            parts.push(Filter::In(col.clone().into(), vs));
+        }
+        if let Some(values) = self.not_in {
+            let vs: Vec<FilterValue> = values.into_iter().map(FilterValue::String).collect();
+            parts.push(Filter::NotIn(col.clone().into(), vs));
+        }
+        if let Some(v) = self.lt {
+            parts.push(Filter::Lt(col.clone().into(), FilterValue::String(v)));
+        }
+        if let Some(v) = self.lte {
+            parts.push(Filter::Lte(col.clone().into(), FilterValue::String(v)));
+        }
+        if let Some(v) = self.gt {
+            parts.push(Filter::Gt(col.clone().into(), FilterValue::String(v)));
+        }
+        if let Some(v) = self.gte {
+            parts.push(Filter::Gte(col.clone().into(), FilterValue::String(v)));
+        }
+        if let Some(v) = self.contains {
+            parts.push(Filter::Contains(col.clone().into(), FilterValue::String(v)));
+        }
+        if let Some(v) = self.starts_with {
+            parts.push(Filter::StartsWith(
+                col.clone().into(),
+                FilterValue::String(v),
+            ));
+        }
+        if let Some(v) = self.ends_with {
+            parts.push(Filter::EndsWith(col.clone().into(), FilterValue::String(v)));
+        }
+        // `mode` is honored by the dialect layer in phase 2+; phase 1 ignores
+        // it here. The field is kept so downstream phases don't need a
+        // breaking-shape change.
+        let _ = self.mode;
+        match parts.len() {
+            0 => Filter::None,
+            1 => parts.into_iter().next().unwrap(),
+            _ => Filter::and(parts),
+        }
+    }
+}
+
+/// Filter operators for a nullable `String` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct StringNullableFilter {
+    /// `column = value`
+    pub equals: Option<String>,
+    /// Negation of the inner filter.
+    pub not: Option<Box<StringNullableFilter>>,
+    /// `column IN (...)`
+    pub in_list: Option<Vec<String>>,
+    /// `column NOT IN (...)`
+    pub not_in: Option<Vec<String>>,
+    /// `column < value`
+    pub lt: Option<String>,
+    /// `column <= value`
+    pub lte: Option<String>,
+    /// `column > value`
+    pub gt: Option<String>,
+    /// `column >= value`
+    pub gte: Option<String>,
+    /// `column LIKE %value%`
+    pub contains: Option<String>,
+    /// `column LIKE value%`
+    pub starts_with: Option<String>,
+    /// `column LIKE %value`
+    pub ends_with: Option<String>,
+    /// Comparison mode.
+    pub mode: Option<QueryMode>,
+    /// `is_null: Some(true)` => `IS NULL`; `Some(false)` => `IS NOT NULL`.
+    pub is_null: Option<bool>,
+}
+
+impl From<&str> for StringNullableFilter {
+    fn from(v: &str) -> Self {
+        Self {
+            equals: Some(v.into()),
+            ..Default::default()
+        }
+    }
+}
+impl From<String> for StringNullableFilter {
+    fn from(v: String) -> Self {
+        Self {
+            equals: Some(v),
+            ..Default::default()
+        }
+    }
+}
+
+impl ScalarFilter for StringNullableFilter {
+    fn into_filter(self, column: &str) -> Filter {
+        let mut parts: Vec<Filter> = Vec::new();
+        let col = column.to_string();
+        if let Some(b) = self.is_null {
+            parts.push(if b {
+                Filter::IsNull(col.clone().into())
+            } else {
+                Filter::IsNotNull(col.clone().into())
+            });
+        }
+        // Reuse StringFilter's lowering for the remaining ops.
+        let inner = StringFilter {
+            equals: self.equals,
+            not: self.not.map(|b| {
+                Box::new(StringFilter {
+                    equals: b.equals,
+                    in_list: b.in_list,
+                    not_in: b.not_in,
+                    lt: b.lt,
+                    lte: b.lte,
+                    gt: b.gt,
+                    gte: b.gte,
+                    contains: b.contains,
+                    starts_with: b.starts_with,
+                    ends_with: b.ends_with,
+                    mode: b.mode,
+                    not: None,
+                })
+            }),
+            in_list: self.in_list,
+            not_in: self.not_in,
+            lt: self.lt,
+            lte: self.lte,
+            gt: self.gt,
+            gte: self.gte,
+            contains: self.contains,
+            starts_with: self.starts_with,
+            ends_with: self.ends_with,
+            mode: self.mode,
+        };
+        let inner_filter = inner.into_filter(column);
+        if !matches!(inner_filter, Filter::None) {
+            parts.push(inner_filter);
+        }
+        match parts.len() {
+            0 => Filter::None,
+            1 => parts.into_iter().next().unwrap(),
+            _ => Filter::and(parts),
+        }
+    }
+}

--- a/prax-query/src/inputs/scalar.rs
+++ b/prax-query/src/inputs/scalar.rs
@@ -549,6 +549,154 @@ impl ScalarFilter for BoolNullableFilter {
     }
 }
 
+scalar_filter!(
+    /// Filter for non-nullable `DateTime` columns (encoded RFC3339).
+    DateTimeFilter<chrono::DateTime<chrono::Utc>> => |v: chrono::DateTime<chrono::Utc>| {
+        FilterValue::String(v.to_rfc3339())
+    } as FilterValue::String,
+    /// Filter for nullable `DateTime` columns.
+    nullable DateTimeNullableFilter
+);
+
+scalar_filter!(
+    /// Filter for non-nullable `Date` columns (encoded YYYY-MM-DD).
+    DateFilter<chrono::NaiveDate> => |v: chrono::NaiveDate| {
+        FilterValue::String(v.to_string())
+    } as FilterValue::String,
+    /// Filter for nullable `Date` columns.
+    nullable DateNullableFilter
+);
+
+scalar_filter!(
+    /// Filter for non-nullable `Time` columns (encoded HH:MM:SS).
+    TimeFilter<chrono::NaiveTime> => |v: chrono::NaiveTime| {
+        FilterValue::String(v.format("%H:%M:%S").to_string())
+    } as FilterValue::String,
+    /// Filter for nullable `Time` columns.
+    nullable TimeNullableFilter
+);
+
+/// Filter operators for an enum-typed column.
+///
+/// `E` is the user-defined enum. Codegen emits `impl ToString for Role` so
+/// the macro's bare-ident shorthand (`role: Admin`) flows through.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    rename_all = "snake_case",
+    bound = "E: Serialize + for<'de2> Deserialize<'de2>"
+)]
+pub struct EnumFilter<E> {
+    /// `column = value`
+    pub equals: Option<E>,
+    /// Negation.
+    pub not: Option<Box<EnumFilter<E>>>,
+    /// `column IN (...)`
+    pub in_list: Option<Vec<E>>,
+    /// `column NOT IN (...)`
+    pub not_in: Option<Vec<E>>,
+}
+
+impl<E> EnumFilter<E> {
+    /// `equals: Some(value)`.
+    pub fn equals(v: E) -> Self {
+        Self {
+            equals: Some(v),
+            not: None,
+            in_list: None,
+            not_in: None,
+        }
+    }
+}
+
+impl<E: ToString> ScalarFilter for EnumFilter<E> {
+    fn into_filter(self, column: &str) -> Filter {
+        let col: crate::filter::FieldName = column.to_string().into();
+        let mut parts: Vec<Filter> = Vec::new();
+        if let Some(v) = self.equals {
+            parts.push(Filter::Equals(
+                col.clone(),
+                FilterValue::String(v.to_string()),
+            ));
+        }
+        if let Some(boxed) = self.not {
+            parts.push(Filter::Not(Box::new(boxed.into_filter(column))));
+        }
+        if let Some(values) = self.in_list {
+            let vs: Vec<FilterValue> = values
+                .into_iter()
+                .map(|v| FilterValue::String(v.to_string()))
+                .collect();
+            parts.push(Filter::In(col.clone(), vs));
+        }
+        if let Some(values) = self.not_in {
+            let vs: Vec<FilterValue> = values
+                .into_iter()
+                .map(|v| FilterValue::String(v.to_string()))
+                .collect();
+            parts.push(Filter::NotIn(col, vs));
+        }
+        match parts.len() {
+            0 => Filter::None,
+            1 => parts.into_iter().next().unwrap(),
+            _ => Filter::and(parts),
+        }
+    }
+}
+
+/// Filter operators for a nullable enum-typed column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    rename_all = "snake_case",
+    bound = "E: Serialize + for<'de2> Deserialize<'de2>"
+)]
+pub struct EnumNullableFilter<E> {
+    /// `column = value`
+    pub equals: Option<E>,
+    /// Negation.
+    pub not: Option<Box<EnumNullableFilter<E>>>,
+    /// `column IN (...)`
+    pub in_list: Option<Vec<E>>,
+    /// `column NOT IN (...)`
+    pub not_in: Option<Vec<E>>,
+    /// IS NULL / IS NOT NULL.
+    pub is_null: Option<bool>,
+}
+
+impl<E: ToString> ScalarFilter for EnumNullableFilter<E> {
+    fn into_filter(self, column: &str) -> Filter {
+        let mut parts: Vec<Filter> = Vec::new();
+        if let Some(b) = self.is_null {
+            parts.push(if b {
+                Filter::IsNull(column.to_string().into())
+            } else {
+                Filter::IsNotNull(column.to_string().into())
+            });
+        }
+        let inner = EnumFilter::<E> {
+            equals: self.equals,
+            not: self.not.map(|b| {
+                Box::new(EnumFilter {
+                    equals: b.equals,
+                    in_list: b.in_list,
+                    not_in: b.not_in,
+                    not: None,
+                })
+            }),
+            in_list: self.in_list,
+            not_in: self.not_in,
+        };
+        let f = inner.into_filter(column);
+        if !matches!(f, Filter::None) {
+            parts.push(f);
+        }
+        match parts.len() {
+            0 => Filter::None,
+            1 => parts.into_iter().next().unwrap(),
+            _ => Filter::and(parts),
+        }
+    }
+}
+
 /// Filter operators for a non-nullable `Json` column.
 ///
 /// Phase 1 supports `equals`/`not`. JSON-path operators land behind

--- a/prax-query/src/inputs/scalar.rs
+++ b/prax-query/src/inputs/scalar.rs
@@ -22,6 +22,22 @@ pub trait ScalarFilter {
     fn into_filter(self, column: &str) -> Filter;
 }
 
+/// Collapse a list of operator filters into a single [`Filter`].
+///
+/// Every `ScalarFilter::into_filter` impl accumulates one entry per
+/// active operator and then needs to reduce that list to a `Filter`.
+/// The reduction is identical across all of them:
+/// - empty → `Filter::None`
+/// - single → that filter unwrapped
+/// - multiple → `Filter::and(parts)`.
+pub(crate) fn combine_filters(parts: Vec<Filter>) -> Filter {
+    match parts.len() {
+        0 => Filter::None,
+        1 => parts.into_iter().next().unwrap(),
+        _ => Filter::and(parts),
+    }
+}
+
 /// Comparison mode for string filters.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum QueryMode {
@@ -152,11 +168,7 @@ impl ScalarFilter for StringFilter {
         // it here. The field is kept so downstream phases don't need a
         // breaking-shape change.
         let _ = self.mode;
-        match parts.len() {
-            0 => Filter::None,
-            1 => parts.into_iter().next().unwrap(),
-            _ => Filter::and(parts),
-        }
+        combine_filters(parts)
     }
 }
 
@@ -254,11 +266,7 @@ impl ScalarFilter for StringNullableFilter {
         if !matches!(inner_filter, Filter::None) {
             parts.push(inner_filter);
         }
-        match parts.len() {
-            0 => Filter::None,
-            1 => parts.into_iter().next().unwrap(),
-            _ => Filter::and(parts),
-        }
+        combine_filters(parts)
     }
 }
 
@@ -269,7 +277,7 @@ impl ScalarFilter for StringNullableFilter {
 macro_rules! scalar_filter {
     (
         $(#[$nn_meta:meta])*
-        $name:ident<$rust:ty> => |$conv_v:ident: $rust2:ty| $conv:block as $fv:expr,
+        $name:ident<$rust:ty> => |$conv_v:ident| $conv:block,
         $(#[$null_meta:meta])*
         nullable $null:ident
     ) => {
@@ -320,7 +328,7 @@ macro_rules! scalar_filter {
 
         impl ScalarFilter for $name {
             fn into_filter(self, column: &str) -> Filter {
-                fn to_fv($conv_v: $rust2) -> FilterValue $conv
+                fn to_fv($conv_v: $rust) -> FilterValue $conv
                 let col: crate::filter::FieldName = column.to_string().into();
                 let mut parts: Vec<Filter> = Vec::new();
                 if let Some(v) = self.equals {
@@ -342,12 +350,7 @@ macro_rules! scalar_filter {
                 if let Some(v) = self.lte { parts.push(Filter::Lte(col.clone(), to_fv(v))); }
                 if let Some(v) = self.gt { parts.push(Filter::Gt(col.clone(), to_fv(v))); }
                 if let Some(v) = self.gte { parts.push(Filter::Gte(col, to_fv(v))); }
-                let _ = $fv;
-                match parts.len() {
-                    0 => Filter::None,
-                    1 => parts.into_iter().next().unwrap(),
-                    _ => Filter::and(parts),
-                }
+                combine_filters(parts)
             }
         }
 
@@ -400,11 +403,7 @@ macro_rules! scalar_filter {
                 };
                 let f = inner.into_filter(column);
                 if !matches!(f, Filter::None) { parts.push(f); }
-                match parts.len() {
-                    0 => Filter::None,
-                    1 => parts.into_iter().next().unwrap(),
-                    _ => Filter::and(parts),
-                }
+                combine_filters(parts)
             }
         }
     };
@@ -412,21 +411,21 @@ macro_rules! scalar_filter {
 
 scalar_filter!(
     /// Filter for non-nullable `Int` (`i32`) columns.
-    IntFilter<i32> => |v: i32| { FilterValue::Int(v as i64) } as FilterValue::Int,
+    IntFilter<i32> => |v| { FilterValue::Int(v as i64) },
     /// Filter for nullable `Int` columns.
     nullable IntNullableFilter
 );
 
 scalar_filter!(
     /// Filter for non-nullable `BigInt` (`i64`) columns.
-    BigIntFilter<i64> => |v: i64| { FilterValue::Int(v) } as FilterValue::Int,
+    BigIntFilter<i64> => |v| { FilterValue::Int(v) },
     /// Filter for nullable `BigInt` columns.
     nullable BigIntNullableFilter
 );
 
 scalar_filter!(
     /// Filter for non-nullable `Float` (`f64`) columns.
-    FloatFilter<f64> => |v: f64| { FilterValue::Float(v) } as FilterValue::Float,
+    FloatFilter<f64> => |v| { FilterValue::Float(v) },
     /// Filter for nullable `Float` columns.
     nullable FloatNullableFilter
 );
@@ -437,14 +436,14 @@ scalar_filter!(
     /// Lowered as `FilterValue::String` because the runtime IR does not
     /// have a dedicated `Decimal` variant; the driver layer parses it on
     /// the wire.
-    DecimalFilter<rust_decimal::Decimal> => |v: rust_decimal::Decimal| { FilterValue::String(v.to_string()) } as FilterValue::String,
+    DecimalFilter<rust_decimal::Decimal> => |v| { FilterValue::String(v.to_string()) },
     /// Filter for nullable `Decimal` columns.
     nullable DecimalNullableFilter
 );
 
 scalar_filter!(
     /// Filter for non-nullable `Uuid` columns.
-    UuidFilter<uuid::Uuid> => |v: uuid::Uuid| { FilterValue::String(v.to_string()) } as FilterValue::String,
+    UuidFilter<uuid::Uuid> => |v| { FilterValue::String(v.to_string()) },
     /// Filter for nullable `Uuid` columns.
     nullable UuidNullableFilter
 );
@@ -454,10 +453,10 @@ scalar_filter!(
     ///
     /// Encoded as a base64-of-bytes string in FilterValue::String. The
     /// driver layer decodes back to bytes on the wire.
-    BytesFilter<Vec<u8>> => |v: Vec<u8>| {
+    BytesFilter<Vec<u8>> => |v| {
         use base64::Engine as _;
         FilterValue::String(base64::engine::general_purpose::STANDARD.encode(&v))
-    } as FilterValue::String,
+    },
     /// Filter for nullable `Bytes` columns.
     nullable BytesNullableFilter
 );
@@ -498,11 +497,7 @@ impl ScalarFilter for BoolFilter {
         if let Some(boxed) = self.not {
             parts.push(Filter::Not(Box::new(boxed.into_filter(column))));
         }
-        match parts.len() {
-            0 => Filter::None,
-            1 => parts.into_iter().next().unwrap(),
-            _ => Filter::and(parts),
-        }
+        combine_filters(parts)
     }
 }
 
@@ -541,37 +536,33 @@ impl ScalarFilter for BoolNullableFilter {
         if !matches!(f, Filter::None) {
             parts.push(f);
         }
-        match parts.len() {
-            0 => Filter::None,
-            1 => parts.into_iter().next().unwrap(),
-            _ => Filter::and(parts),
-        }
+        combine_filters(parts)
     }
 }
 
 scalar_filter!(
     /// Filter for non-nullable `DateTime` columns (encoded RFC3339).
-    DateTimeFilter<chrono::DateTime<chrono::Utc>> => |v: chrono::DateTime<chrono::Utc>| {
+    DateTimeFilter<chrono::DateTime<chrono::Utc>> => |v| {
         FilterValue::String(v.to_rfc3339())
-    } as FilterValue::String,
+    },
     /// Filter for nullable `DateTime` columns.
     nullable DateTimeNullableFilter
 );
 
 scalar_filter!(
     /// Filter for non-nullable `Date` columns (encoded YYYY-MM-DD).
-    DateFilter<chrono::NaiveDate> => |v: chrono::NaiveDate| {
+    DateFilter<chrono::NaiveDate> => |v| {
         FilterValue::String(v.to_string())
-    } as FilterValue::String,
+    },
     /// Filter for nullable `Date` columns.
     nullable DateNullableFilter
 );
 
 scalar_filter!(
     /// Filter for non-nullable `Time` columns (encoded HH:MM:SS).
-    TimeFilter<chrono::NaiveTime> => |v: chrono::NaiveTime| {
+    TimeFilter<chrono::NaiveTime> => |v| {
         FilterValue::String(v.format("%H:%M:%S").to_string())
-    } as FilterValue::String,
+    },
     /// Filter for nullable `Time` columns.
     nullable TimeNullableFilter
 );
@@ -635,11 +626,7 @@ impl<E: ToString> ScalarFilter for EnumFilter<E> {
                 .collect();
             parts.push(Filter::NotIn(col, vs));
         }
-        match parts.len() {
-            0 => Filter::None,
-            1 => parts.into_iter().next().unwrap(),
-            _ => Filter::and(parts),
-        }
+        combine_filters(parts)
     }
 }
 
@@ -689,11 +676,7 @@ impl<E: ToString> ScalarFilter for EnumNullableFilter<E> {
         if !matches!(f, Filter::None) {
             parts.push(f);
         }
-        match parts.len() {
-            0 => Filter::None,
-            1 => parts.into_iter().next().unwrap(),
-            _ => Filter::and(parts),
-        }
+        combine_filters(parts)
     }
 }
 
@@ -720,11 +703,7 @@ impl ScalarFilter for JsonFilter {
         if let Some(boxed) = self.not {
             parts.push(Filter::Not(Box::new(boxed.into_filter(column))));
         }
-        match parts.len() {
-            0 => Filter::None,
-            1 => parts.into_iter().next().unwrap(),
-            _ => Filter::and(parts),
-        }
+        combine_filters(parts)
     }
 }
 
@@ -763,10 +742,6 @@ impl ScalarFilter for JsonNullableFilter {
         if !matches!(f, Filter::None) {
             parts.push(f);
         }
-        match parts.len() {
-            0 => Filter::None,
-            1 => parts.into_iter().next().unwrap(),
-            _ => Filter::and(parts),
-        }
+        combine_filters(parts)
     }
 }

--- a/prax-query/src/inputs/scalar.rs
+++ b/prax-query/src/inputs/scalar.rs
@@ -261,3 +261,364 @@ impl ScalarFilter for StringNullableFilter {
         }
     }
 }
+
+/// Macro to emit a scalar filter wrapper + nullable counterpart that
+/// lowers to a `FilterValue::$variant`. Keeps the table of integer /
+/// floating / temporal / blob types DRY without sacrificing rustdoc
+/// per-type.
+macro_rules! scalar_filter {
+    (
+        $(#[$nn_meta:meta])*
+        $name:ident<$rust:ty> => |$conv_v:ident: $rust2:ty| $conv:block as $fv:expr,
+        $(#[$null_meta:meta])*
+        nullable $null:ident
+    ) => {
+        $(#[$nn_meta])*
+        #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+        #[serde(rename_all = "snake_case")]
+        pub struct $name {
+            /// `column = value`
+            pub equals: Option<$rust>,
+            /// Negation.
+            pub not: Option<Box<$name>>,
+            /// `column IN (...)`
+            pub in_list: Option<Vec<$rust>>,
+            /// `column NOT IN (...)`
+            pub not_in: Option<Vec<$rust>>,
+            /// `column < value`
+            pub lt: Option<$rust>,
+            /// `column <= value`
+            pub lte: Option<$rust>,
+            /// `column > value`
+            pub gt: Option<$rust>,
+            /// `column >= value`
+            pub gte: Option<$rust>,
+        }
+
+        impl $name {
+            /// `equals: Some(value)`.
+            pub fn equals(v: impl Into<$rust>) -> Self {
+                Self { equals: Some(v.into()), ..Default::default() }
+            }
+            /// `lt: Some(value)`.
+            pub fn lt(v: impl Into<$rust>) -> Self {
+                Self { lt: Some(v.into()), ..Default::default() }
+            }
+            /// `lte: Some(value)`.
+            pub fn lte(v: impl Into<$rust>) -> Self {
+                Self { lte: Some(v.into()), ..Default::default() }
+            }
+            /// `gt: Some(value)`.
+            pub fn gt(v: impl Into<$rust>) -> Self {
+                Self { gt: Some(v.into()), ..Default::default() }
+            }
+            /// `gte: Some(value)`.
+            pub fn gte(v: impl Into<$rust>) -> Self {
+                Self { gte: Some(v.into()), ..Default::default() }
+            }
+        }
+
+        impl ScalarFilter for $name {
+            fn into_filter(self, column: &str) -> Filter {
+                fn to_fv($conv_v: $rust2) -> FilterValue $conv
+                let col: crate::filter::FieldName = column.to_string().into();
+                let mut parts: Vec<Filter> = Vec::new();
+                if let Some(v) = self.equals {
+                    parts.push(Filter::Equals(col.clone(), to_fv(v)));
+                }
+                if let Some(boxed) = self.not {
+                    let inner = boxed.into_filter(column);
+                    parts.push(Filter::Not(Box::new(inner)));
+                }
+                if let Some(values) = self.in_list {
+                    let vs: Vec<FilterValue> = values.into_iter().map(to_fv).collect();
+                    parts.push(Filter::In(col.clone(), vs));
+                }
+                if let Some(values) = self.not_in {
+                    let vs: Vec<FilterValue> = values.into_iter().map(to_fv).collect();
+                    parts.push(Filter::NotIn(col.clone(), vs));
+                }
+                if let Some(v) = self.lt { parts.push(Filter::Lt(col.clone(), to_fv(v))); }
+                if let Some(v) = self.lte { parts.push(Filter::Lte(col.clone(), to_fv(v))); }
+                if let Some(v) = self.gt { parts.push(Filter::Gt(col.clone(), to_fv(v))); }
+                if let Some(v) = self.gte { parts.push(Filter::Gte(col, to_fv(v))); }
+                let _ = $fv;
+                match parts.len() {
+                    0 => Filter::None,
+                    1 => parts.into_iter().next().unwrap(),
+                    _ => Filter::and(parts),
+                }
+            }
+        }
+
+        $(#[$null_meta])*
+        #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+        #[serde(rename_all = "snake_case")]
+        pub struct $null {
+            /// `column = value`
+            pub equals: Option<$rust>,
+            /// Negation.
+            pub not: Option<Box<$null>>,
+            /// `column IN (...)`
+            pub in_list: Option<Vec<$rust>>,
+            /// `column NOT IN (...)`
+            pub not_in: Option<Vec<$rust>>,
+            /// `column < value`
+            pub lt: Option<$rust>,
+            /// `column <= value`
+            pub lte: Option<$rust>,
+            /// `column > value`
+            pub gt: Option<$rust>,
+            /// `column >= value`
+            pub gte: Option<$rust>,
+            /// IS NULL / IS NOT NULL.
+            pub is_null: Option<bool>,
+        }
+
+        impl ScalarFilter for $null {
+            fn into_filter(self, column: &str) -> Filter {
+                let mut parts: Vec<Filter> = Vec::new();
+                if let Some(b) = self.is_null {
+                    parts.push(if b {
+                        Filter::IsNull(column.to_string().into())
+                    } else {
+                        Filter::IsNotNull(column.to_string().into())
+                    });
+                }
+                let inner = $name {
+                    equals: self.equals,
+                    not: self.not.map(|b| Box::new($name {
+                        equals: b.equals,
+                        in_list: b.in_list,
+                        not_in: b.not_in,
+                        lt: b.lt, lte: b.lte, gt: b.gt, gte: b.gte,
+                        not: None,
+                    })),
+                    in_list: self.in_list,
+                    not_in: self.not_in,
+                    lt: self.lt, lte: self.lte, gt: self.gt, gte: self.gte,
+                };
+                let f = inner.into_filter(column);
+                if !matches!(f, Filter::None) { parts.push(f); }
+                match parts.len() {
+                    0 => Filter::None,
+                    1 => parts.into_iter().next().unwrap(),
+                    _ => Filter::and(parts),
+                }
+            }
+        }
+    };
+}
+
+scalar_filter!(
+    /// Filter for non-nullable `Int` (`i32`) columns.
+    IntFilter<i32> => |v: i32| { FilterValue::Int(v as i64) } as FilterValue::Int,
+    /// Filter for nullable `Int` columns.
+    nullable IntNullableFilter
+);
+
+scalar_filter!(
+    /// Filter for non-nullable `BigInt` (`i64`) columns.
+    BigIntFilter<i64> => |v: i64| { FilterValue::Int(v) } as FilterValue::Int,
+    /// Filter for nullable `BigInt` columns.
+    nullable BigIntNullableFilter
+);
+
+scalar_filter!(
+    /// Filter for non-nullable `Float` (`f64`) columns.
+    FloatFilter<f64> => |v: f64| { FilterValue::Float(v) } as FilterValue::Float,
+    /// Filter for nullable `Float` columns.
+    nullable FloatNullableFilter
+);
+
+scalar_filter!(
+    /// Filter for non-nullable `Decimal` (`rust_decimal::Decimal`) columns.
+    ///
+    /// Lowered as `FilterValue::String` because the runtime IR does not
+    /// have a dedicated `Decimal` variant; the driver layer parses it on
+    /// the wire.
+    DecimalFilter<rust_decimal::Decimal> => |v: rust_decimal::Decimal| { FilterValue::String(v.to_string()) } as FilterValue::String,
+    /// Filter for nullable `Decimal` columns.
+    nullable DecimalNullableFilter
+);
+
+scalar_filter!(
+    /// Filter for non-nullable `Uuid` columns.
+    UuidFilter<uuid::Uuid> => |v: uuid::Uuid| { FilterValue::String(v.to_string()) } as FilterValue::String,
+    /// Filter for nullable `Uuid` columns.
+    nullable UuidNullableFilter
+);
+
+scalar_filter!(
+    /// Filter for non-nullable `Bytes` (`Vec<u8>`) columns.
+    ///
+    /// Encoded as a base64-of-bytes string in FilterValue::String. The
+    /// driver layer decodes back to bytes on the wire.
+    BytesFilter<Vec<u8>> => |v: Vec<u8>| {
+        use base64::Engine as _;
+        FilterValue::String(base64::engine::general_purpose::STANDARD.encode(&v))
+    } as FilterValue::String,
+    /// Filter for nullable `Bytes` columns.
+    nullable BytesNullableFilter
+);
+
+/// Filter operators for a non-nullable `Boolean` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct BoolFilter {
+    /// `column = value`
+    pub equals: Option<bool>,
+    /// Negation of the inner filter.
+    pub not: Option<Box<BoolFilter>>,
+}
+
+impl BoolFilter {
+    /// `equals: Some(value)`.
+    pub fn equals(v: bool) -> Self {
+        Self {
+            equals: Some(v),
+            ..Default::default()
+        }
+    }
+}
+
+impl From<bool> for BoolFilter {
+    fn from(v: bool) -> Self {
+        Self::equals(v)
+    }
+}
+
+impl ScalarFilter for BoolFilter {
+    fn into_filter(self, column: &str) -> Filter {
+        let col: crate::filter::FieldName = column.to_string().into();
+        let mut parts: Vec<Filter> = Vec::new();
+        if let Some(v) = self.equals {
+            parts.push(Filter::Equals(col.clone(), FilterValue::Bool(v)));
+        }
+        if let Some(boxed) = self.not {
+            parts.push(Filter::Not(Box::new(boxed.into_filter(column))));
+        }
+        match parts.len() {
+            0 => Filter::None,
+            1 => parts.into_iter().next().unwrap(),
+            _ => Filter::and(parts),
+        }
+    }
+}
+
+/// Filter operators for a nullable `Boolean` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct BoolNullableFilter {
+    /// `column = value`
+    pub equals: Option<bool>,
+    /// Negation.
+    pub not: Option<Box<BoolNullableFilter>>,
+    /// IS NULL / IS NOT NULL.
+    pub is_null: Option<bool>,
+}
+
+impl ScalarFilter for BoolNullableFilter {
+    fn into_filter(self, column: &str) -> Filter {
+        let mut parts: Vec<Filter> = Vec::new();
+        if let Some(b) = self.is_null {
+            parts.push(if b {
+                Filter::IsNull(column.to_string().into())
+            } else {
+                Filter::IsNotNull(column.to_string().into())
+            });
+        }
+        let inner = BoolFilter {
+            equals: self.equals,
+            not: self.not.map(|b| {
+                Box::new(BoolFilter {
+                    equals: b.equals,
+                    not: None,
+                })
+            }),
+        };
+        let f = inner.into_filter(column);
+        if !matches!(f, Filter::None) {
+            parts.push(f);
+        }
+        match parts.len() {
+            0 => Filter::None,
+            1 => parts.into_iter().next().unwrap(),
+            _ => Filter::and(parts),
+        }
+    }
+}
+
+/// Filter operators for a non-nullable `Json` column.
+///
+/// Phase 1 supports `equals`/`not`. JSON-path operators land behind
+/// `SupportsJsonPath` in a follow-up.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct JsonFilter {
+    /// `column = value`
+    pub equals: Option<serde_json::Value>,
+    /// Negation.
+    pub not: Option<Box<JsonFilter>>,
+}
+
+impl ScalarFilter for JsonFilter {
+    fn into_filter(self, column: &str) -> Filter {
+        let col: crate::filter::FieldName = column.to_string().into();
+        let mut parts: Vec<Filter> = Vec::new();
+        if let Some(v) = self.equals {
+            parts.push(Filter::Equals(col.clone(), FilterValue::Json(v)));
+        }
+        if let Some(boxed) = self.not {
+            parts.push(Filter::Not(Box::new(boxed.into_filter(column))));
+        }
+        match parts.len() {
+            0 => Filter::None,
+            1 => parts.into_iter().next().unwrap(),
+            _ => Filter::and(parts),
+        }
+    }
+}
+
+/// Filter operators for a nullable `Json` column.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct JsonNullableFilter {
+    /// `column = value`
+    pub equals: Option<serde_json::Value>,
+    /// Negation.
+    pub not: Option<Box<JsonNullableFilter>>,
+    /// IS NULL / IS NOT NULL.
+    pub is_null: Option<bool>,
+}
+
+impl ScalarFilter for JsonNullableFilter {
+    fn into_filter(self, column: &str) -> Filter {
+        let mut parts: Vec<Filter> = Vec::new();
+        if let Some(b) = self.is_null {
+            parts.push(if b {
+                Filter::IsNull(column.to_string().into())
+            } else {
+                Filter::IsNotNull(column.to_string().into())
+            });
+        }
+        let inner = JsonFilter {
+            equals: self.equals,
+            not: self.not.map(|b| {
+                Box::new(JsonFilter {
+                    equals: b.equals,
+                    not: None,
+                })
+            }),
+        };
+        let f = inner.into_filter(column);
+        if !matches!(f, Filter::None) {
+            parts.push(f);
+        }
+        match parts.len() {
+            0 => Filter::None,
+            1 => parts.into_iter().next().unwrap(),
+            _ => Filter::and(parts),
+        }
+    }
+}

--- a/prax-query/src/inputs/scalar_update.rs
+++ b/prax-query/src/inputs/scalar_update.rs
@@ -1,0 +1,1 @@
+//! Scalar field update wrappers — populated by Task 10.

--- a/prax-query/src/inputs/scalar_update.rs
+++ b/prax-query/src/inputs/scalar_update.rs
@@ -1,1 +1,347 @@
-//! Scalar field update wrappers — populated by Task 10.
+//! Scalar field update wrappers.
+//!
+//! Each `*FieldUpdate` struct carries the atomic operators expressible
+//! against one scalar type. Phase 5 (write macros) consumes these;
+//! phase 1 only defines them so the codegen scaffolding in phase 2
+//! can refer to them.
+
+use serde::{Deserialize, Serialize};
+
+/// Update operators for a non-nullable `Int` (`i32`) column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct IntFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<i64>,
+    /// `SET column = column + value`
+    pub increment: Option<i64>,
+    /// `SET column = column - value`
+    pub decrement: Option<i64>,
+    /// `SET column = column * value`
+    pub multiply: Option<i64>,
+    /// `SET column = column / value`
+    pub divide: Option<i64>,
+}
+
+impl From<i32> for IntFieldUpdate {
+    fn from(v: i32) -> Self {
+        Self {
+            set: Some(v as i64),
+            ..Default::default()
+        }
+    }
+}
+impl From<i64> for IntFieldUpdate {
+    fn from(v: i64) -> Self {
+        Self {
+            set: Some(v),
+            ..Default::default()
+        }
+    }
+}
+
+/// Update operators for a nullable `Int` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct IntNullableFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<i64>,
+    /// `SET column = column + value`
+    pub increment: Option<i64>,
+    /// `SET column = column - value`
+    pub decrement: Option<i64>,
+    /// `SET column = column * value`
+    pub multiply: Option<i64>,
+    /// `SET column = column / value`
+    pub divide: Option<i64>,
+    /// `SET column = NULL`
+    pub unset: Option<bool>,
+}
+
+/// Update operators for a non-nullable `BigInt` (`i64`) column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct BigIntFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<i64>,
+    /// `SET column = column + value`
+    pub increment: Option<i64>,
+    /// `SET column = column - value`
+    pub decrement: Option<i64>,
+    /// `SET column = column * value`
+    pub multiply: Option<i64>,
+    /// `SET column = column / value`
+    pub divide: Option<i64>,
+}
+
+impl From<i64> for BigIntFieldUpdate {
+    fn from(v: i64) -> Self {
+        Self {
+            set: Some(v),
+            ..Default::default()
+        }
+    }
+}
+
+/// Update operators for a nullable `BigInt` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct BigIntNullableFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<i64>,
+    /// `SET column = column + value`
+    pub increment: Option<i64>,
+    /// `SET column = column - value`
+    pub decrement: Option<i64>,
+    /// `SET column = column * value`
+    pub multiply: Option<i64>,
+    /// `SET column = column / value`
+    pub divide: Option<i64>,
+    /// `SET column = NULL`
+    pub unset: Option<bool>,
+}
+
+/// Update operators for a non-nullable `Float` column.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct FloatFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<f64>,
+    /// `SET column = column + value`
+    pub increment: Option<f64>,
+    /// `SET column = column - value`
+    pub decrement: Option<f64>,
+    /// `SET column = column * value`
+    pub multiply: Option<f64>,
+    /// `SET column = column / value`
+    pub divide: Option<f64>,
+}
+
+impl From<f64> for FloatFieldUpdate {
+    fn from(v: f64) -> Self {
+        Self {
+            set: Some(v),
+            ..Default::default()
+        }
+    }
+}
+
+/// Update operators for a nullable `Float` column.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct FloatNullableFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<f64>,
+    /// `SET column = column + value`
+    pub increment: Option<f64>,
+    /// `SET column = column - value`
+    pub decrement: Option<f64>,
+    /// `SET column = column * value`
+    pub multiply: Option<f64>,
+    /// `SET column = column / value`
+    pub divide: Option<f64>,
+    /// `SET column = NULL`
+    pub unset: Option<bool>,
+}
+
+/// Update operators for a non-nullable `Decimal` column (transmitted as string).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct DecimalFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<String>,
+    /// `SET column = column + value`
+    pub increment: Option<String>,
+    /// `SET column = column - value`
+    pub decrement: Option<String>,
+    /// `SET column = column * value`
+    pub multiply: Option<String>,
+    /// `SET column = column / value`
+    pub divide: Option<String>,
+}
+
+/// Update operators for a nullable `Decimal` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct DecimalNullableFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<String>,
+    /// `SET column = column + value`
+    pub increment: Option<String>,
+    /// `SET column = column - value`
+    pub decrement: Option<String>,
+    /// `SET column = column * value`
+    pub multiply: Option<String>,
+    /// `SET column = column / value`
+    pub divide: Option<String>,
+    /// `SET column = NULL`
+    pub unset: Option<bool>,
+}
+
+/// Update operators for a non-nullable `String` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct StringFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<String>,
+}
+
+impl From<&str> for StringFieldUpdate {
+    fn from(v: &str) -> Self {
+        Self {
+            set: Some(v.into()),
+        }
+    }
+}
+impl From<String> for StringFieldUpdate {
+    fn from(v: String) -> Self {
+        Self { set: Some(v) }
+    }
+}
+
+/// Update operators for a nullable `String` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct StringNullableFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<String>,
+    /// `SET column = NULL`
+    pub unset: Option<bool>,
+}
+
+impl From<&str> for StringNullableFieldUpdate {
+    fn from(v: &str) -> Self {
+        Self {
+            set: Some(v.into()),
+            unset: None,
+        }
+    }
+}
+impl From<String> for StringNullableFieldUpdate {
+    fn from(v: String) -> Self {
+        Self {
+            set: Some(v),
+            unset: None,
+        }
+    }
+}
+
+/// Update operators for a non-nullable `Boolean` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct BoolFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<bool>,
+}
+
+impl From<bool> for BoolFieldUpdate {
+    fn from(v: bool) -> Self {
+        Self { set: Some(v) }
+    }
+}
+
+/// Update operators for a nullable `Boolean` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct BoolNullableFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<bool>,
+    /// `SET column = NULL`
+    pub unset: Option<bool>,
+}
+
+/// Update operators for an enum-typed column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    rename_all = "snake_case",
+    bound = "E: Serialize + for<'de2> Deserialize<'de2>"
+)]
+pub struct EnumFieldUpdate<E> {
+    /// `SET column = value`
+    pub set: Option<E>,
+}
+
+/// Update operators for a nullable enum-typed column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    rename_all = "snake_case",
+    bound = "E: Serialize + for<'de2> Deserialize<'de2>"
+)]
+pub struct EnumNullableFieldUpdate<E> {
+    /// `SET column = value`
+    pub set: Option<E>,
+    /// `SET column = NULL`
+    pub unset: Option<bool>,
+}
+
+/// Update operators for a non-nullable `DateTime` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct DateTimeFieldUpdate {
+    /// `SET column = value` (RFC3339-encoded).
+    pub set: Option<String>,
+}
+
+/// Update operators for a nullable `DateTime` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct DateTimeNullableFieldUpdate {
+    /// `SET column = value` (RFC3339-encoded).
+    pub set: Option<String>,
+    /// `SET column = NULL`
+    pub unset: Option<bool>,
+}
+
+/// Update operators for a non-nullable `Bytes` column (base64-encoded).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct BytesFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<String>,
+}
+
+/// Update operators for a nullable `Bytes` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct BytesNullableFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<String>,
+    /// `SET column = NULL`
+    pub unset: Option<bool>,
+}
+
+/// Update operators for a non-nullable `Uuid` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct UuidFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<String>,
+}
+
+/// Update operators for a nullable `Uuid` column.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct UuidNullableFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<String>,
+    /// `SET column = NULL`
+    pub unset: Option<bool>,
+}
+
+/// Update operators for a non-nullable `Json` column.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct JsonFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<serde_json::Value>,
+}
+
+/// Update operators for a nullable `Json` column.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct JsonNullableFieldUpdate {
+    /// `SET column = value`
+    pub set: Option<serde_json::Value>,
+    /// `SET column = NULL`
+    pub unset: Option<bool>,
+}

--- a/prax-query/src/inputs/traits.rs
+++ b/prax-query/src/inputs/traits.rs
@@ -1,0 +1,172 @@
+//! Traits implemented by per-model generated input types.
+//!
+//! Each trait has one method, `into_ir`, that lowers the input to the
+//! runtime IR that the SQL builders already consume. The associated
+//! `Model` type keeps generic bounds tight: a `FindManyOperation<E, User>`
+//! can only accept a `WhereInput<Model = User>`, never a `PostWhereInput`.
+
+use crate::filter::Filter;
+use crate::pagination::Pagination;
+use crate::relations::Include;
+use crate::traits::Model;
+use crate::types::{OrderBy, Select};
+
+/// A typed shape that lowers to a runtime [`Filter`].
+///
+/// Implemented by per-model `UserWhereInput`, `PostWhereInput`, ...
+pub trait WhereInput {
+    /// The model this WHERE shape applies to.
+    type Model: Model;
+    /// Lower this input to the runtime IR.
+    fn into_ir(self) -> Filter;
+}
+
+/// A WHERE shape constrained to a unique key (PK or `@unique` column).
+///
+/// Used by `find_unique` / `update` / `upsert` / `delete` where the
+/// operation requires the filter to identify at most one row.
+pub trait WhereUniqueInput {
+    /// The model this WHERE shape applies to.
+    type Model: Model;
+    /// Lower this input to the runtime IR.
+    fn into_ir(self) -> Filter;
+}
+
+/// A typed shape that lowers to an [`Include`] specification.
+pub trait IncludeInput {
+    /// The model this include shape applies to.
+    type Model: Model;
+    /// Lower this input to the runtime IR.
+    fn into_ir(self) -> Include;
+}
+
+/// A typed shape that lowers to a [`Select`] specification.
+pub trait SelectInput {
+    /// The model this select shape applies to.
+    type Model: Model;
+    /// Lower this input to the runtime IR.
+    fn into_ir(self) -> Select;
+}
+
+/// A typed shape that lowers to an [`OrderBy`] specification.
+pub trait OrderByInput {
+    /// The model this order shape applies to.
+    type Model: Model;
+    /// Lower this input to the runtime IR.
+    fn into_ir(self) -> OrderBy;
+}
+
+/// A typed shape that lowers to the `Data` payload for a `create`.
+///
+/// The associated `Data` type is the existing `<Model as CreateData>::Data`
+/// from `prax_query::traits::CreateData` — phase 5 will introduce a
+/// `NestedWritePlan` lowering path; phase 1 keeps the lowering simple.
+pub trait CreateInput {
+    /// The model this create input applies to.
+    type Model: Model;
+    /// The runtime payload type.
+    type Data: Send + Sync;
+    /// Lower this input to the runtime payload.
+    fn into_ir(self) -> Self::Data;
+}
+
+/// A typed shape that lowers to the `Data` payload for an `update`.
+pub trait UpdateInput {
+    /// The model this update input applies to.
+    type Model: Model;
+    /// The runtime payload type.
+    type Data: Send + Sync;
+    /// Lower this input to the runtime payload.
+    fn into_ir(self) -> Self::Data;
+}
+
+/// A typed shape that lowers to a `_count` aggregate selection.
+pub trait CountSelect {
+    /// The model this count selection applies to.
+    type Model: Model;
+    /// Concrete representation as a list of relation names to count.
+    fn into_relation_names(self) -> Vec<String>;
+}
+
+/// A typed shape that lowers to an aggregate spec
+/// (`_count` / `_avg` / `_sum` / `_min` / `_max`).
+///
+/// The IR target for this trait is finalized in phase 6 when aggregate
+/// macros are wired up. For phase 1 the trait only carries the `Model`
+/// associated type.
+pub trait AggregateInput {
+    /// The model this aggregate spec applies to.
+    type Model: Model;
+}
+
+/// A typed shape that lowers to a group-by spec.
+///
+/// As with [`AggregateInput`], the IR target is finalized in phase 6.
+pub trait GroupByInput {
+    /// The model this group-by spec applies to.
+    type Model: Model;
+}
+
+/// Pagination fragment shared by every read input.
+///
+/// Phase 1 keeps pagination on the operation itself (matching the
+/// current builder API). This struct exists so phase 3+ macros can
+/// surface `skip`/`take`/`cursor` inside the input AST without having
+/// to construct an entire `*Args`.
+#[derive(Debug, Clone, Default)]
+pub struct PaginationInput {
+    /// Number of rows to skip.
+    pub skip: Option<u64>,
+    /// Number of rows to take.
+    pub take: Option<u64>,
+}
+
+impl From<PaginationInput> for Pagination {
+    fn from(p: PaginationInput) -> Self {
+        let mut out = Pagination::new();
+        if let Some(n) = p.skip {
+            out = out.skip(n);
+        }
+        if let Some(n) = p.take {
+            out = out.take(n);
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestModel;
+    impl Model for TestModel {
+        const MODEL_NAME: &'static str = "TestModel";
+        const TABLE_NAME: &'static str = "test_models";
+        const PRIMARY_KEY: &'static [&'static str] = &["id"];
+        const COLUMNS: &'static [&'static str] = &["id"];
+    }
+
+    struct TestWhere;
+    impl WhereInput for TestWhere {
+        type Model = TestModel;
+        fn into_ir(self) -> Filter {
+            Filter::None
+        }
+    }
+
+    #[test]
+    fn where_input_lowers_to_filter_none() {
+        assert!(matches!(TestWhere.into_ir(), Filter::None));
+    }
+
+    #[test]
+    fn pagination_input_roundtrip() {
+        let p = PaginationInput {
+            skip: Some(5),
+            take: Some(10),
+        };
+        let raw: Pagination = p.into();
+        assert_eq!(raw.skip, Some(5));
+        assert_eq!(raw.take, Some(10));
+    }
+}

--- a/prax-query/src/lib.rs
+++ b/prax-query/src/lib.rs
@@ -176,6 +176,7 @@ pub mod dialect;
 pub mod error;
 pub mod extension;
 pub mod filter;
+pub mod inputs;
 pub mod intern;
 pub mod introspection;
 pub mod json;

--- a/prax-query/src/lib.rs
+++ b/prax-query/src/lib.rs
@@ -471,6 +471,102 @@ pub use profiling::{
 // Re-export smallvec for macros
 pub use smallvec;
 
+// Typed input shapes (phase 1 of the typed-query-traits work).
+pub use crate::capabilities::{
+    SupportsArrayOps, SupportsCaseInsensitiveMode, SupportsCorrelatedSubquery,
+    SupportsFullTextSearch, SupportsGeneratedColumns, SupportsJsonPath, SupportsNestedWrites,
+    SupportsRelationFilter, SupportsScalarSubqueryInSelect,
+};
+pub use crate::inputs::{
+    // Containers.
+    AggregateArgs,
+    // Traits.
+    AggregateInput,
+    // Update wrappers.
+    BigIntFieldUpdate,
+    // Scalar filters.
+    // NOTE: `ScalarFilter` (the trait) conflicts with `filter::ScalarFilter` already at crate
+    // root — re-exported as `InputScalarFilter` to disambiguate.
+    BigIntFilter,
+    BigIntNullableFieldUpdate,
+    BigIntNullableFilter,
+    BoolFieldUpdate,
+    BoolFilter,
+    BoolNullableFieldUpdate,
+    BoolNullableFilter,
+    BytesFieldUpdate,
+    BytesFilter,
+    BytesNullableFieldUpdate,
+    BytesNullableFilter,
+    CountArgs,
+    CountSelect,
+    CreateArgs,
+    CreateInput,
+    CreateManyArgs,
+    DateFilter,
+    DateNullableFilter,
+    DateTimeFieldUpdate,
+    DateTimeFilter,
+    DateTimeNullableFieldUpdate,
+    DateTimeNullableFilter,
+    DecimalFieldUpdate,
+    DecimalFilter,
+    DecimalNullableFieldUpdate,
+    DecimalNullableFilter,
+    DeleteArgs,
+    DeleteManyArgs,
+    EnumFieldUpdate,
+    EnumFilter,
+    EnumNullableFieldUpdate,
+    EnumNullableFilter,
+    FindFirstArgs,
+    FindManyArgs,
+    FindUniqueArgs,
+    FloatFieldUpdate,
+    FloatFilter,
+    FloatNullableFieldUpdate,
+    FloatNullableFilter,
+    GroupByArgs,
+    GroupByInput,
+    IncludeInput,
+    IntFieldUpdate,
+    IntFilter,
+    IntNullableFieldUpdate,
+    IntNullableFilter,
+    JsonFieldUpdate,
+    // NOTE: `JsonFilter` and `JsonNullableFilter` conflict with `json::JsonFilter` already at
+    // crate root — re-exported as `InputJsonFilter` / `InputJsonNullableFilter`.
+    JsonFilter as InputJsonFilter,
+    JsonNullableFieldUpdate,
+    JsonNullableFilter as InputJsonNullableFilter,
+    // Relation filters + meta.
+    ListRelationFilter,
+    LowerRelationFilter,
+    OrderByInput,
+    PaginationInput,
+    QueryMode,
+    RelationFilterMeta,
+    ScalarFilter as InputScalarFilter,
+    SelectInput,
+    SingleRelationFilter,
+    StringFieldUpdate,
+    StringFilter,
+    StringNullableFieldUpdate,
+    StringNullableFilter,
+    TimeFilter,
+    TimeNullableFilter,
+    UpdateArgs,
+    UpdateInput,
+    UpdateManyArgs,
+    UpsertArgs,
+    UuidFieldUpdate,
+    UuidFilter,
+    UuidNullableFieldUpdate,
+    UuidNullableFilter,
+    WhereInput,
+    WhereUniqueInput,
+};
+
 /// Prelude module for convenient imports.
 pub mod prelude {
     pub use crate::advanced::{LateralJoin, Returning, RowLock, TableSample};

--- a/prax-query/src/lib.rs
+++ b/prax-query/src/lib.rs
@@ -165,6 +165,7 @@ pub mod async_optimize;
 pub mod batch;
 pub mod builder;
 pub mod cache;
+pub mod capabilities;
 pub mod connection;
 pub mod cte;
 pub mod data;

--- a/prax-query/src/operations/aggregate.rs
+++ b/prax-query/src/operations/aggregate.rs
@@ -299,6 +299,16 @@ impl<M: Model, E: QueryEngine> AggregateOperation<M, E> {
         self
     }
 
+    /// Apply a typed `WhereInput`. AND-composes with any previously set filter.
+    pub fn with_where_input<W: crate::inputs::WhereInput<Model = M>>(mut self, w: W) -> Self {
+        let f = w.into_ir();
+        self.filter = Some(match self.filter.take() {
+            Some(existing) => existing.and_then(f),
+            None => f,
+        });
+        self
+    }
+
     /// Build the SQL for this operation.
     pub fn build_sql(
         &self,

--- a/prax-query/src/operations/count.rs
+++ b/prax-query/src/operations/count.rs
@@ -82,6 +82,19 @@ impl<E: QueryEngine, M: Model> CountOperation<E, M> {
         (sql, params)
     }
 
+    /// Apply a typed `WhereInput`. AND-composes with any previously set filter.
+    pub fn with_where_input<W: crate::inputs::WhereInput<Model = M>>(mut self, w: W) -> Self {
+        let f = w.into_ir();
+        self.filter = self.filter.and_then(f);
+        self
+    }
+
+    /// Doc-hidden accessor for the current filter.
+    #[doc(hidden)]
+    pub fn filter_for_test(&self) -> &Filter {
+        &self.filter
+    }
+
     /// Execute the count query.
     pub async fn exec(self) -> QueryResult<u64> {
         let dialect = self.engine.dialect();

--- a/prax-query/src/operations/create.rs
+++ b/prax-query/src/operations/create.rs
@@ -72,6 +72,12 @@ impl<E: QueryEngine, M: Model + crate::row::FromRow> CreateOperation<E, M> {
         self
     }
 
+    /// Apply a typed `SelectInput`.
+    pub fn with_select_input<S: crate::inputs::SelectInput<Model = M>>(mut self, s: S) -> Self {
+        self.select = s.into_ir();
+        self
+    }
+
     /// Queue a nested write to run alongside this create.
     ///
     /// The parent `INSERT` and every queued nested op execute inside a

--- a/prax-query/src/operations/delete.rs
+++ b/prax-query/src/operations/delete.rs
@@ -111,6 +111,25 @@ impl<E: QueryEngine, M: Model + crate::row::FromRow> DeleteOperation<E, M> {
         let (sql, params) = self.build_sql_count(dialect);
         self.engine.execute_delete(&sql, params).await
     }
+
+    /// Apply a typed `WhereUniqueInput`. Overwrites any previously set
+    /// filter — delete operations are intentionally precise.
+    pub fn with_where_input<W: crate::inputs::WhereUniqueInput<Model = M>>(mut self, w: W) -> Self {
+        self.filter = w.into_ir();
+        self
+    }
+
+    /// Apply a typed `SelectInput`.
+    pub fn with_select_input<S: crate::inputs::SelectInput<Model = M>>(mut self, s: S) -> Self {
+        self.select = s.into_ir();
+        self
+    }
+
+    /// Doc-hidden accessor for the current filter.
+    #[doc(hidden)]
+    pub fn filter_for_test(&self) -> &Filter {
+        &self.filter
+    }
 }
 
 /// Delete many records at once.

--- a/prax-query/src/operations/find_first.rs
+++ b/prax-query/src/operations/find_first.rs
@@ -73,6 +73,43 @@ impl<E: QueryEngine, M: Model + crate::row::FromRow> FindFirstOperation<E, M> {
         self
     }
 
+    /// Apply a typed `WhereInput`. AND-composes with any previously set
+    /// filter — same semantics as calling `.r#where(...)` again.
+    pub fn with_where_input<W: crate::inputs::WhereInput<Model = M>>(mut self, w: W) -> Self {
+        let f = w.into_ir();
+        self.filter = self.filter.and_then(f);
+        self
+    }
+
+    /// Apply a typed `IncludeInput`. Merges into any previously set
+    /// includes (later wins on conflicting relation names).
+    pub fn with_include_input<I: crate::inputs::IncludeInput<Model = M>>(mut self, i: I) -> Self {
+        let inc = i.into_ir();
+        for spec in inc.specs() {
+            self.includes.push(spec.clone());
+        }
+        self
+    }
+
+    /// Apply a typed `SelectInput`.
+    pub fn with_select_input<S: crate::inputs::SelectInput<Model = M>>(mut self, s: S) -> Self {
+        self.select = s.into_ir();
+        self
+    }
+
+    /// Apply a typed `OrderByInput` (replaces current).
+    pub fn with_order_by_input<O: crate::inputs::OrderByInput<Model = M>>(mut self, o: O) -> Self {
+        self.order_by = o.into_ir();
+        self
+    }
+
+    /// Doc-hidden accessor for the current filter — needed for unit
+    /// tests that don't have a running engine to issue queries against.
+    #[doc(hidden)]
+    pub fn filter_for_test(&self) -> &Filter {
+        &self.filter
+    }
+
     /// Build the SQL query.
     pub fn build_sql(
         &self,

--- a/prax-query/src/operations/find_many.rs
+++ b/prax-query/src/operations/find_many.rs
@@ -107,6 +107,43 @@ impl<E: QueryEngine, M: Model + crate::row::FromRow> FindManyOperation<E, M> {
         self
     }
 
+    /// Apply a typed `WhereInput`. AND-composes with any previously set
+    /// filter — same semantics as calling `.r#where(...)` again.
+    pub fn with_where_input<W: crate::inputs::WhereInput<Model = M>>(mut self, w: W) -> Self {
+        let f = w.into_ir();
+        self.filter = self.filter.and_then(f);
+        self
+    }
+
+    /// Apply a typed `IncludeInput`. Merges into any previously set
+    /// includes (later wins on conflicting relation names).
+    pub fn with_include_input<I: crate::inputs::IncludeInput<Model = M>>(mut self, i: I) -> Self {
+        let inc = i.into_ir();
+        for spec in inc.specs() {
+            self.includes.push(spec.clone());
+        }
+        self
+    }
+
+    /// Apply a typed `SelectInput`.
+    pub fn with_select_input<S: crate::inputs::SelectInput<Model = M>>(mut self, s: S) -> Self {
+        self.select = s.into_ir();
+        self
+    }
+
+    /// Apply a typed `OrderByInput` (replaces current).
+    pub fn with_order_by_input<O: crate::inputs::OrderByInput<Model = M>>(mut self, o: O) -> Self {
+        self.order_by = o.into_ir();
+        self
+    }
+
+    /// Doc-hidden accessor for the current filter — needed for unit
+    /// tests that don't have a running engine to issue queries against.
+    #[doc(hidden)]
+    pub fn filter_for_test(&self) -> &Filter {
+        &self.filter
+    }
+
     /// Build the SQL query.
     pub fn build_sql(
         &self,

--- a/prax-query/src/operations/find_unique.rs
+++ b/prax-query/src/operations/find_unique.rs
@@ -64,6 +64,34 @@ impl<E: QueryEngine, M: Model + crate::row::FromRow> FindUniqueOperation<E, M> {
         self
     }
 
+    /// Apply a typed `WhereUniqueInput`. Overwrites the existing filter
+    /// (a unique input is a complete predicate, not a constraint to AND-compose).
+    pub fn with_where_input<W: crate::inputs::WhereUniqueInput<Model = M>>(mut self, w: W) -> Self {
+        self.filter = w.into_ir();
+        self
+    }
+
+    /// Apply a typed `IncludeInput`.
+    pub fn with_include_input<I: crate::inputs::IncludeInput<Model = M>>(mut self, i: I) -> Self {
+        let inc = i.into_ir();
+        for spec in inc.specs() {
+            self.includes.push(spec.clone());
+        }
+        self
+    }
+
+    /// Apply a typed `SelectInput`.
+    pub fn with_select_input<S: crate::inputs::SelectInput<Model = M>>(mut self, s: S) -> Self {
+        self.select = s.into_ir();
+        self
+    }
+
+    /// Doc-hidden accessor for the current filter.
+    #[doc(hidden)]
+    pub fn filter_for_test(&self) -> &Filter {
+        &self.filter
+    }
+
     /// Build the SQL query.
     pub fn build_sql(
         &self,

--- a/prax-query/src/operations/update.rs
+++ b/prax-query/src/operations/update.rs
@@ -137,6 +137,27 @@ impl<E: QueryEngine, M: Model + crate::row::FromRow> UpdateOperation<E, M> {
         let (sql, params) = self.build_sql(dialect);
         self.engine.query_one::<M>(&sql, params).await
     }
+
+    /// Apply a typed `WhereUniqueInput`. AND-composes with any
+    /// previously set filter so callers can combine the unique key
+    /// with side conditions when they need to.
+    pub fn with_where_input<W: crate::inputs::WhereUniqueInput<Model = M>>(mut self, w: W) -> Self {
+        let f = w.into_ir();
+        self.filter = self.filter.and_then(f);
+        self
+    }
+
+    /// Apply a typed `SelectInput`.
+    pub fn with_select_input<S: crate::inputs::SelectInput<Model = M>>(mut self, s: S) -> Self {
+        self.select = s.into_ir();
+        self
+    }
+
+    /// Doc-hidden accessor for the current filter.
+    #[doc(hidden)]
+    pub fn filter_for_test(&self) -> &Filter {
+        &self.filter
+    }
 }
 
 /// Update many records at once.

--- a/prax-query/src/operations/upsert.rs
+++ b/prax-query/src/operations/upsert.rs
@@ -105,6 +105,18 @@ impl<E: QueryEngine, M: Model + crate::row::FromRow> UpsertOperation<E, M> {
         self
     }
 
+    /// Apply a typed `WhereUniqueInput`. Overwrites the existing filter.
+    pub fn with_where_input<W: crate::inputs::WhereUniqueInput<Model = M>>(mut self, w: W) -> Self {
+        self.filter = w.into_ir();
+        self
+    }
+
+    /// Apply a typed `SelectInput`.
+    pub fn with_select_input<S: crate::inputs::SelectInput<Model = M>>(mut self, s: S) -> Self {
+        self.select = s.into_ir();
+        self
+    }
+
     /// Build the SQL query.
     pub fn build_sql(
         &self,

--- a/prax-query/src/traits.rs
+++ b/prax-query/src/traits.rs
@@ -236,6 +236,19 @@ pub trait QueryEngine: Send + Sync + Clone + 'static {
         })
     }
 
+    /// Whether this engine is currently executing inside an open
+    /// transaction.
+    ///
+    /// The nested-write executor (phase 5) checks this to decide
+    /// whether to issue its own `BEGIN`/`COMMIT` around a write plan
+    /// or inline into a transaction the caller already started.
+    ///
+    /// Default returns `false`. Driver engines that wrap a
+    /// driver-native transaction object override and return `true`.
+    fn in_transaction(&self) -> bool {
+        false
+    }
+
     /// Run the closure inside a transaction.
     ///
     /// Drivers that support real transactions override this to issue
@@ -417,6 +430,74 @@ mod tests {
         let filter = Filter::Equals("id".into(), crate::filter::FilterValue::Int(1));
         let converted = filter.clone().into_filter();
         assert_eq!(converted, filter);
+    }
+
+    #[test]
+    fn default_in_transaction_returns_false() {
+        #[derive(Clone)]
+        struct E;
+
+        impl QueryEngine for E {
+            fn query_many<T: Model + crate::row::FromRow + Send + 'static>(
+                &self,
+                _sql: &str,
+                _params: Vec<crate::filter::FilterValue>,
+            ) -> BoxFuture<'_, QueryResult<Vec<T>>> {
+                Box::pin(async { Ok(Vec::new()) })
+            }
+            fn query_one<T: Model + crate::row::FromRow + Send + 'static>(
+                &self,
+                _sql: &str,
+                _params: Vec<crate::filter::FilterValue>,
+            ) -> BoxFuture<'_, QueryResult<T>> {
+                Box::pin(async { Err(crate::error::QueryError::not_found("t")) })
+            }
+            fn query_optional<T: Model + crate::row::FromRow + Send + 'static>(
+                &self,
+                _sql: &str,
+                _params: Vec<crate::filter::FilterValue>,
+            ) -> BoxFuture<'_, QueryResult<Option<T>>> {
+                Box::pin(async { Ok(None) })
+            }
+            fn execute_insert<T: Model + crate::row::FromRow + Send + 'static>(
+                &self,
+                _sql: &str,
+                _params: Vec<crate::filter::FilterValue>,
+            ) -> BoxFuture<'_, QueryResult<T>> {
+                Box::pin(async { Err(crate::error::QueryError::not_found("t")) })
+            }
+            fn execute_update<T: Model + crate::row::FromRow + Send + 'static>(
+                &self,
+                _sql: &str,
+                _params: Vec<crate::filter::FilterValue>,
+            ) -> BoxFuture<'_, QueryResult<Vec<T>>> {
+                Box::pin(async { Ok(Vec::new()) })
+            }
+            fn execute_delete(
+                &self,
+                _sql: &str,
+                _params: Vec<crate::filter::FilterValue>,
+            ) -> BoxFuture<'_, QueryResult<u64>> {
+                Box::pin(async { Ok(0) })
+            }
+            fn execute_raw(
+                &self,
+                _sql: &str,
+                _params: Vec<crate::filter::FilterValue>,
+            ) -> BoxFuture<'_, QueryResult<u64>> {
+                Box::pin(async { Ok(0) })
+            }
+            fn count(
+                &self,
+                _sql: &str,
+                _params: Vec<crate::filter::FilterValue>,
+            ) -> BoxFuture<'_, QueryResult<u64>> {
+                Box::pin(async { Ok(0) })
+            }
+        }
+
+        let e = E;
+        assert!(!e.in_transaction());
     }
 
     #[test]

--- a/prax-query/tests/inputs_args.rs
+++ b/prax-query/tests/inputs_args.rs
@@ -1,0 +1,58 @@
+use prax_query::filter::Filter;
+use prax_query::inputs::{CreateArgs, FindManyArgs, FindUniqueArgs, UpsertArgs};
+use prax_query::traits::Model;
+
+struct TestModel;
+impl Model for TestModel {
+    const MODEL_NAME: &'static str = "TestModel";
+    const TABLE_NAME: &'static str = "test_models";
+    const PRIMARY_KEY: &'static [&'static str] = &["id"];
+    const COLUMNS: &'static [&'static str] = &["id"];
+}
+
+#[test]
+fn find_many_args_default_is_empty() {
+    let a: FindManyArgs<TestModel, Filter, (), ()> = FindManyArgs::default();
+    assert!(a.r#where.is_none());
+    assert!(a.include.is_none());
+    assert!(a.select.is_none());
+    assert!(a.order_by.is_none());
+    assert!(a.cursor.is_none());
+    assert_eq!(a.skip, None);
+    assert_eq!(a.take, None);
+}
+
+#[test]
+fn find_unique_args_carries_unique_filter() {
+    let a: FindUniqueArgs<TestModel, Filter, (), ()> = FindUniqueArgs {
+        r#where: Filter::None,
+        include: None,
+        select: None,
+        _model: std::marker::PhantomData,
+    };
+    assert!(matches!(a.r#where, Filter::None));
+}
+
+#[test]
+fn create_args_carries_data() {
+    let a: CreateArgs<TestModel, (), (), ()> = CreateArgs {
+        data: (),
+        include: None,
+        select: None,
+        _model: std::marker::PhantomData,
+    };
+    assert_eq!(std::mem::size_of_val(&a.data), 0);
+}
+
+#[test]
+fn upsert_args_round_trip() {
+    let a: UpsertArgs<TestModel, Filter, (), (), (), ()> = UpsertArgs {
+        r#where: Filter::None,
+        create: (),
+        update: (),
+        include: None,
+        select: None,
+        _model: std::marker::PhantomData,
+    };
+    assert!(matches!(a.r#where, Filter::None));
+}

--- a/prax-query/tests/inputs_relation.rs
+++ b/prax-query/tests/inputs_relation.rs
@@ -1,7 +1,7 @@
 use prax_query::filter::{Filter, FilterValue};
 use prax_query::inputs::{
     WhereInput,
-    relation::{ListRelationFilter, LowerRelationFilter, RelationMeta, SingleRelationFilter},
+    relation::{ListRelationFilter, LowerRelationFilter, RelationFilterMeta, SingleRelationFilter},
 };
 use prax_query::traits::Model;
 
@@ -30,7 +30,7 @@ impl WhereInput for PostWhereInput {
 
 // Hand-built relation meta for `User.posts` so we don't need the codegen.
 struct UserPostsMeta;
-impl RelationMeta for UserPostsMeta {
+impl RelationFilterMeta for UserPostsMeta {
     const PARENT_TABLE: &'static str = "users";
     const PARENT_PK: &'static str = "id";
     const CHILD_TABLE: &'static str = "posts";

--- a/prax-query/tests/inputs_relation.rs
+++ b/prax-query/tests/inputs_relation.rs
@@ -1,0 +1,108 @@
+use prax_query::filter::{Filter, FilterValue};
+use prax_query::inputs::{
+    WhereInput,
+    relation::{ListRelationFilter, LowerRelationFilter, RelationMeta, SingleRelationFilter},
+};
+use prax_query::traits::Model;
+
+struct Post;
+impl Model for Post {
+    const MODEL_NAME: &'static str = "Post";
+    const TABLE_NAME: &'static str = "posts";
+    const PRIMARY_KEY: &'static [&'static str] = &["id"];
+    const COLUMNS: &'static [&'static str] = &["id", "author_id", "published"];
+}
+
+#[derive(Default, Clone)]
+struct PostWhereInput {
+    pub published: Option<prax_query::inputs::BoolFilter>,
+}
+impl WhereInput for PostWhereInput {
+    type Model = Post;
+    fn into_ir(self) -> Filter {
+        use prax_query::inputs::ScalarFilter;
+        match self.published {
+            Some(f) => f.into_filter("published"),
+            None => Filter::None,
+        }
+    }
+}
+
+// Hand-built relation meta for `User.posts` so we don't need the codegen.
+struct UserPostsMeta;
+impl RelationMeta for UserPostsMeta {
+    const PARENT_TABLE: &'static str = "users";
+    const PARENT_PK: &'static str = "id";
+    const CHILD_TABLE: &'static str = "posts";
+    const CHILD_FK: &'static str = "author_id";
+}
+
+#[test]
+fn list_relation_some_lowers_to_exists_scalar_subquery() {
+    let rf = ListRelationFilter {
+        some: Some(PostWhereInput {
+            published: Some(prax_query::inputs::BoolFilter::equals(true)),
+        }),
+        ..Default::default()
+    };
+    let filter = rf.lower::<UserPostsMeta>();
+    match filter {
+        Filter::ScalarSubquery { sql, params } => {
+            assert!(sql.contains("EXISTS"));
+            assert!(sql.contains("posts"));
+            assert!(sql.contains("author_id"));
+            // The inner filter pulls `published = $?` into the subquery.
+            assert!(params.iter().any(|p| matches!(p, FilterValue::Bool(true))));
+        }
+        other => panic!("expected Filter::ScalarSubquery, got {:?}", other),
+    }
+}
+
+#[test]
+fn list_relation_none_lowers_to_not_exists() {
+    let rf = ListRelationFilter::<PostWhereInput> {
+        none: Some(PostWhereInput {
+            published: Some(prax_query::inputs::BoolFilter::equals(true)),
+        }),
+        ..Default::default()
+    };
+    let filter = rf.lower::<UserPostsMeta>();
+    match filter {
+        Filter::ScalarSubquery { sql, .. } => assert!(sql.starts_with("NOT EXISTS")),
+        other => panic!("expected NOT EXISTS subquery, got {:?}", other),
+    }
+}
+
+#[test]
+fn list_relation_every_lowers_to_not_exists_negated() {
+    let rf = ListRelationFilter::<PostWhereInput> {
+        every: Some(PostWhereInput {
+            published: Some(prax_query::inputs::BoolFilter::equals(true)),
+        }),
+        ..Default::default()
+    };
+    let filter = rf.lower::<UserPostsMeta>();
+    // `every: F` == `NOT EXISTS (child WHERE parent.pk = child.fk AND NOT (F))`.
+    match filter {
+        Filter::ScalarSubquery { sql, .. } => {
+            assert!(sql.starts_with("NOT EXISTS"));
+            assert!(sql.contains("NOT ("));
+        }
+        other => panic!("expected NOT EXISTS subquery, got {:?}", other),
+    }
+}
+
+#[test]
+fn single_relation_is_lowers_to_exists() {
+    let rf = SingleRelationFilter::<PostWhereInput> {
+        is: Some(PostWhereInput {
+            published: Some(prax_query::inputs::BoolFilter::equals(true)),
+        }),
+        ..Default::default()
+    };
+    let filter = rf.lower::<UserPostsMeta>();
+    match filter {
+        Filter::ScalarSubquery { sql, .. } => assert!(sql.starts_with("EXISTS")),
+        other => panic!("expected EXISTS subquery, got {:?}", other),
+    }
+}

--- a/prax-query/tests/inputs_scalar.rs
+++ b/prax-query/tests/inputs_scalar.rs
@@ -1,0 +1,67 @@
+use prax_query::filter::{Filter, FilterValue};
+use prax_query::inputs::{QueryMode, ScalarFilter, StringFilter, StringNullableFilter};
+
+#[test]
+fn string_filter_equals_lowers_to_filter_equals() {
+    let f = StringFilter::equals("alice@example.com");
+    let filter = f.into_filter("email");
+    assert_eq!(
+        filter,
+        Filter::Equals(
+            "email".into(),
+            FilterValue::String("alice@example.com".into())
+        )
+    );
+}
+
+#[test]
+fn string_filter_contains_lowers_to_filter_contains() {
+    let f = StringFilter::contains("@example.com");
+    let filter = f.into_filter("email");
+    assert!(matches!(filter, Filter::Contains(_, _)));
+}
+
+#[test]
+fn string_filter_combines_with_and_when_multiple_ops_set() {
+    let f = StringFilter {
+        contains: Some("@x.com".into()),
+        starts_with: Some("a".into()),
+        ..Default::default()
+    };
+    let filter = f.into_filter("email");
+    match filter {
+        Filter::And(parts) => assert_eq!(parts.len(), 2),
+        other => panic!("expected Filter::And, got {:?}", other),
+    }
+}
+
+#[test]
+fn string_nullable_filter_is_null_lowers_to_is_null() {
+    let f = StringNullableFilter {
+        is_null: Some(true),
+        ..Default::default()
+    };
+    let filter = f.into_filter("name");
+    assert_eq!(filter, Filter::IsNull("name".into()));
+}
+
+#[test]
+fn string_nullable_filter_is_not_null_lowers_to_is_not_null() {
+    let f = StringNullableFilter {
+        is_null: Some(false),
+        ..Default::default()
+    };
+    let filter = f.into_filter("name");
+    assert_eq!(filter, Filter::IsNotNull("name".into()));
+}
+
+#[test]
+fn query_mode_default_is_default() {
+    assert_eq!(QueryMode::default(), QueryMode::Default);
+}
+
+#[test]
+fn string_filter_from_scalar_shortcut() {
+    let f: StringFilter = "alice@x.com".into();
+    assert_eq!(f.equals, Some("alice@x.com".into()));
+}

--- a/prax-query/tests/inputs_scalar.rs
+++ b/prax-query/tests/inputs_scalar.rs
@@ -69,8 +69,10 @@ fn string_filter_from_scalar_shortcut() {
 #[allow(unused_imports)]
 use prax_query::inputs::{
     BigIntFilter, BigIntNullableFilter, BoolFilter, BoolNullableFilter, BytesFilter,
-    BytesNullableFilter, DecimalFilter, DecimalNullableFilter, FloatFilter, FloatNullableFilter,
-    IntFilter, IntNullableFilter, JsonFilter, JsonNullableFilter, UuidFilter, UuidNullableFilter,
+    BytesNullableFilter, DateFilter, DateNullableFilter, DateTimeFilter, DateTimeNullableFilter,
+    DecimalFilter, DecimalNullableFilter, EnumFilter, EnumNullableFilter, FloatFilter,
+    FloatNullableFilter, IntFilter, IntNullableFilter, JsonFilter, JsonNullableFilter, TimeFilter,
+    TimeNullableFilter, UuidFilter, UuidNullableFilter,
 };
 
 #[test]
@@ -202,4 +204,60 @@ fn bytes_filter_equals_lowers() {
         }
         other => panic!("expected Bytes Equals (base64-encoded), got {:?}", other),
     }
+}
+
+#[test]
+fn datetime_filter_equals_lowers() {
+    use chrono::{TimeZone, Utc};
+    let dt = Utc.with_ymd_and_hms(2026, 5, 18, 12, 0, 0).unwrap();
+    let f = DateTimeFilter::equals(dt);
+    let filter = f.into_filter("created_at");
+    // Encoded as RFC3339 string.
+    match filter {
+        Filter::Equals(col, FilterValue::String(s)) => {
+            assert_eq!(col, "created_at");
+            assert!(s.starts_with("2026-05-18T12:00:00"));
+        }
+        other => panic!("expected DateTime Equals, got {:?}", other),
+    }
+}
+
+#[test]
+fn date_filter_equals_lowers() {
+    use chrono::NaiveDate;
+    let d = NaiveDate::from_ymd_opt(2026, 5, 18).unwrap();
+    let f = DateFilter::equals(d);
+    let filter = f.into_filter("birthday");
+    match filter {
+        Filter::Equals(col, FilterValue::String(s)) => {
+            assert_eq!(col, "birthday");
+            assert_eq!(s, "2026-05-18");
+        }
+        other => panic!("expected Date Equals, got {:?}", other),
+    }
+}
+
+#[test]
+fn time_filter_equals_lowers() {
+    use chrono::NaiveTime;
+    let t = NaiveTime::from_hms_opt(13, 45, 0).unwrap();
+    let f = TimeFilter::equals(t);
+    let filter = f.into_filter("opens_at");
+    match filter {
+        Filter::Equals(col, FilterValue::String(s)) => {
+            assert_eq!(col, "opens_at");
+            assert_eq!(s, "13:45:00");
+        }
+        other => panic!("expected Time Equals, got {:?}", other),
+    }
+}
+
+#[test]
+fn enum_filter_equals_lowers() {
+    let f: EnumFilter<&str> = EnumFilter::equals("Admin");
+    let filter = f.into_filter("role");
+    assert_eq!(
+        filter,
+        Filter::Equals("role".into(), FilterValue::String("Admin".into()))
+    );
 }

--- a/prax-query/tests/inputs_scalar.rs
+++ b/prax-query/tests/inputs_scalar.rs
@@ -65,3 +65,141 @@ fn string_filter_from_scalar_shortcut() {
     let f: StringFilter = "alice@x.com".into();
     assert_eq!(f.equals, Some("alice@x.com".into()));
 }
+
+#[allow(unused_imports)]
+use prax_query::inputs::{
+    BigIntFilter, BigIntNullableFilter, BoolFilter, BoolNullableFilter, BytesFilter,
+    BytesNullableFilter, DecimalFilter, DecimalNullableFilter, FloatFilter, FloatNullableFilter,
+    IntFilter, IntNullableFilter, JsonFilter, JsonNullableFilter, UuidFilter, UuidNullableFilter,
+};
+
+#[test]
+fn int_filter_equals_lowers() {
+    let f = IntFilter::equals(42i32);
+    let filter = f.into_filter("age");
+    assert_eq!(filter, Filter::Equals("age".into(), FilterValue::Int(42)));
+}
+
+#[test]
+fn int_filter_gt_lowers() {
+    let f = IntFilter::gt(18i32);
+    let filter = f.into_filter("age");
+    assert_eq!(filter, Filter::Gt("age".into(), FilterValue::Int(18)));
+}
+
+#[test]
+fn int_filter_in_list_lowers() {
+    let f = IntFilter {
+        in_list: Some(vec![1, 2, 3]),
+        ..Default::default()
+    };
+    let filter = f.into_filter("id");
+    match filter {
+        Filter::In(col, values) => {
+            assert_eq!(col, "id");
+            assert_eq!(values.len(), 3);
+        }
+        other => panic!("expected Filter::In, got {:?}", other),
+    }
+}
+
+#[test]
+fn int_nullable_filter_is_null() {
+    let f = IntNullableFilter {
+        is_null: Some(true),
+        ..Default::default()
+    };
+    let filter = f.into_filter("deleted_at");
+    assert_eq!(filter, Filter::IsNull("deleted_at".into()));
+}
+
+#[test]
+fn bool_filter_equals_lowers() {
+    let f = BoolFilter::equals(true);
+    let filter = f.into_filter("active");
+    assert_eq!(
+        filter,
+        Filter::Equals("active".into(), FilterValue::Bool(true))
+    );
+}
+
+#[test]
+fn big_int_filter_equals_lowers() {
+    let f = BigIntFilter::equals(9_999_999_999i64);
+    let filter = f.into_filter("counter");
+    assert_eq!(
+        filter,
+        Filter::Equals("counter".into(), FilterValue::Int(9_999_999_999))
+    );
+}
+
+#[test]
+fn float_filter_equals_lowers() {
+    let f = FloatFilter::equals(2.71f64);
+    let filter = f.into_filter("score");
+    assert_eq!(
+        filter,
+        Filter::Equals("score".into(), FilterValue::Float(2.71))
+    );
+}
+
+#[test]
+fn decimal_filter_equals_lowers() {
+    use rust_decimal::Decimal;
+    use std::str::FromStr;
+    let v = Decimal::from_str("12.34").unwrap();
+    let f = DecimalFilter::equals(v);
+    let filter = f.into_filter("amount");
+    // Decimal flows through as a string in FilterValue::String — see lowering.
+    match filter {
+        Filter::Equals(col, FilterValue::String(s)) => {
+            assert_eq!(col, "amount");
+            assert_eq!(s, "12.34");
+        }
+        other => panic!("expected Decimal Equals to string, got {:?}", other),
+    }
+}
+
+#[test]
+fn uuid_filter_equals_lowers() {
+    use uuid::Uuid;
+    let id = Uuid::nil();
+    let f = UuidFilter::equals(id);
+    let filter = f.into_filter("id");
+    match filter {
+        Filter::Equals(col, FilterValue::String(s)) => {
+            assert_eq!(col, "id");
+            assert_eq!(s, id.to_string());
+        }
+        other => panic!("expected Uuid Equals to string, got {:?}", other),
+    }
+}
+
+#[test]
+fn json_filter_equals_lowers() {
+    let f = JsonFilter {
+        equals: Some(serde_json::json!({"k": 1})),
+        ..Default::default()
+    };
+    let filter = f.into_filter("data");
+    match filter {
+        Filter::Equals(col, FilterValue::Json(v)) => {
+            assert_eq!(col, "data");
+            assert_eq!(v, serde_json::json!({"k": 1}));
+        }
+        other => panic!("expected Json Equals, got {:?}", other),
+    }
+}
+
+#[test]
+fn bytes_filter_equals_lowers() {
+    let f = BytesFilter::equals(vec![1u8, 2, 3]);
+    let filter = f.into_filter("blob");
+    match filter {
+        Filter::Equals(col, FilterValue::String(s)) => {
+            assert_eq!(col, "blob");
+            assert!(!s.is_empty());
+        }
+        other => panic!("expected Bytes Equals (base64-encoded), got {:?}", other),
+    }
+}

--- a/prax-query/tests/inputs_update.rs
+++ b/prax-query/tests/inputs_update.rs
@@ -1,0 +1,52 @@
+use prax_query::inputs::{
+    BoolFieldUpdate, IntFieldUpdate, IntNullableFieldUpdate, StringFieldUpdate,
+    StringNullableFieldUpdate,
+};
+
+#[test]
+fn int_field_update_from_scalar_shortcut() {
+    let u: IntFieldUpdate = 5i32.into();
+    assert_eq!(u.set, Some(5));
+    assert!(u.increment.is_none());
+}
+
+#[test]
+fn int_field_update_increment_and_set_keeps_both() {
+    let u = IntFieldUpdate {
+        set: Some(0),
+        increment: Some(1),
+        ..Default::default()
+    };
+    assert_eq!(u.set, Some(0));
+    assert_eq!(u.increment, Some(1));
+}
+
+#[test]
+fn string_nullable_field_update_unset_marker() {
+    let u = StringNullableFieldUpdate {
+        unset: Some(true),
+        ..Default::default()
+    };
+    assert_eq!(u.unset, Some(true));
+}
+
+#[test]
+fn string_field_update_from_scalar_shortcut() {
+    let u: StringFieldUpdate = "Alice".into();
+    assert_eq!(u.set.as_deref(), Some("Alice"));
+}
+
+#[test]
+fn bool_field_update_from_scalar_shortcut() {
+    let u: BoolFieldUpdate = true.into();
+    assert_eq!(u.set, Some(true));
+}
+
+#[test]
+fn int_nullable_field_update_unset_marker() {
+    let u = IntNullableFieldUpdate {
+        unset: Some(true),
+        ..Default::default()
+    };
+    assert_eq!(u.unset, Some(true));
+}

--- a/prax-query/tests/operation_ext_methods.rs
+++ b/prax-query/tests/operation_ext_methods.rs
@@ -1,0 +1,146 @@
+use prax_query::filter::{Filter, FilterValue};
+use prax_query::inputs::{StringFilter, WhereInput};
+use prax_query::operations::{FindFirstOperation, FindManyOperation, FindUniqueOperation};
+use prax_query::traits::{BoxFuture, Model, QueryEngine};
+
+struct U;
+impl Model for U {
+    const MODEL_NAME: &'static str = "U";
+    const TABLE_NAME: &'static str = "users";
+    const PRIMARY_KEY: &'static [&'static str] = &["id"];
+    const COLUMNS: &'static [&'static str] = &["id", "email"];
+}
+impl prax_query::row::FromRow for U {
+    fn from_row(_row: &impl prax_query::row::RowRef) -> Result<Self, prax_query::row::RowError> {
+        Ok(U)
+    }
+}
+
+#[derive(Clone)]
+struct NoopEngine;
+impl QueryEngine for NoopEngine {
+    fn query_many<T: Model + prax_query::row::FromRow + Send + 'static>(
+        &self,
+        _: &str,
+        _: Vec<FilterValue>,
+    ) -> BoxFuture<'_, prax_query::error::QueryResult<Vec<T>>> {
+        Box::pin(async { Ok(Vec::new()) })
+    }
+    fn query_one<T: Model + prax_query::row::FromRow + Send + 'static>(
+        &self,
+        _: &str,
+        _: Vec<FilterValue>,
+    ) -> BoxFuture<'_, prax_query::error::QueryResult<T>> {
+        Box::pin(async { Err(prax_query::error::QueryError::not_found("t")) })
+    }
+    fn query_optional<T: Model + prax_query::row::FromRow + Send + 'static>(
+        &self,
+        _: &str,
+        _: Vec<FilterValue>,
+    ) -> BoxFuture<'_, prax_query::error::QueryResult<Option<T>>> {
+        Box::pin(async { Ok(None) })
+    }
+    fn execute_insert<T: Model + prax_query::row::FromRow + Send + 'static>(
+        &self,
+        _: &str,
+        _: Vec<FilterValue>,
+    ) -> BoxFuture<'_, prax_query::error::QueryResult<T>> {
+        Box::pin(async { Err(prax_query::error::QueryError::not_found("t")) })
+    }
+    fn execute_update<T: Model + prax_query::row::FromRow + Send + 'static>(
+        &self,
+        _: &str,
+        _: Vec<FilterValue>,
+    ) -> BoxFuture<'_, prax_query::error::QueryResult<Vec<T>>> {
+        Box::pin(async { Ok(Vec::new()) })
+    }
+    fn execute_delete(
+        &self,
+        _: &str,
+        _: Vec<FilterValue>,
+    ) -> BoxFuture<'_, prax_query::error::QueryResult<u64>> {
+        Box::pin(async { Ok(0) })
+    }
+    fn execute_raw(
+        &self,
+        _: &str,
+        _: Vec<FilterValue>,
+    ) -> BoxFuture<'_, prax_query::error::QueryResult<u64>> {
+        Box::pin(async { Ok(0) })
+    }
+    fn count(
+        &self,
+        _: &str,
+        _: Vec<FilterValue>,
+    ) -> BoxFuture<'_, prax_query::error::QueryResult<u64>> {
+        Box::pin(async { Ok(0) })
+    }
+}
+
+#[derive(Default, Clone)]
+struct UWhereInput {
+    pub email: Option<StringFilter>,
+}
+impl WhereInput for UWhereInput {
+    type Model = U;
+    fn into_ir(self) -> Filter {
+        use prax_query::inputs::ScalarFilter;
+        match self.email {
+            Some(f) => f.into_filter("email"),
+            None => Filter::None,
+        }
+    }
+}
+
+impl prax_query::inputs::WhereUniqueInput for UWhereInput {
+    type Model = U;
+    fn into_ir(self) -> Filter {
+        use prax_query::inputs::ScalarFilter;
+        match self.email {
+            Some(f) => f.into_filter("email"),
+            None => Filter::None,
+        }
+    }
+}
+
+#[test]
+fn find_many_with_where_input_replaces_filter_when_first() {
+    let op = FindManyOperation::<NoopEngine, U>::new(NoopEngine).with_where_input(UWhereInput {
+        email: Some(StringFilter::contains("@x.com")),
+    });
+    assert!(!matches!(op.filter_for_test(), Filter::None));
+}
+
+#[test]
+fn find_many_with_where_input_ands_with_existing() {
+    let op = FindManyOperation::<NoopEngine, U>::new(NoopEngine)
+        .r#where(Filter::Equals("id".into(), FilterValue::Int(1)))
+        .with_where_input(UWhereInput {
+            email: Some(StringFilter::contains("@x.com")),
+        });
+    match op.filter_for_test() {
+        Filter::And(parts) => assert_eq!(parts.len(), 2),
+        other => panic!("expected Filter::And, got {:?}", other),
+    }
+}
+
+#[test]
+fn find_unique_with_where_input_overwrites_filter() {
+    let op = FindUniqueOperation::<NoopEngine, U>::new(NoopEngine).with_where_input(UWhereInput {
+        email: Some(StringFilter::equals("x@y.com")),
+    });
+    assert!(!matches!(op.filter_for_test(), Filter::None));
+}
+
+#[test]
+fn find_first_with_where_input_ands_with_existing() {
+    let op = FindFirstOperation::<NoopEngine, U>::new(NoopEngine)
+        .r#where(Filter::Equals("id".into(), FilterValue::Int(1)))
+        .with_where_input(UWhereInput {
+            email: Some(StringFilter::contains("@x.com")),
+        });
+    match op.filter_for_test() {
+        Filter::And(parts) => assert_eq!(parts.len(), 2),
+        other => panic!("expected Filter::And, got {:?}", other),
+    }
+}

--- a/prax-query/tests/operation_ext_methods.rs
+++ b/prax-query/tests/operation_ext_methods.rs
@@ -167,3 +167,18 @@ fn delete_op_with_where_input_overwrites_filter_for_unique() {
     });
     assert!(!matches!(op.filter_for_test(), Filter::None));
 }
+
+use prax_query::operations::CountOperation;
+
+#[test]
+fn count_op_with_where_input_ands() {
+    let op = CountOperation::<NoopEngine, U>::new(NoopEngine)
+        .r#where(Filter::Equals("active".into(), FilterValue::Bool(true)))
+        .with_where_input(UWhereInput {
+            email: Some(StringFilter::contains("@x.com")),
+        });
+    match op.filter_for_test() {
+        Filter::And(parts) => assert_eq!(parts.len(), 2),
+        other => panic!("expected Filter::And, got {:?}", other),
+    }
+}

--- a/prax-query/tests/operation_ext_methods.rs
+++ b/prax-query/tests/operation_ext_methods.rs
@@ -144,3 +144,26 @@ fn find_first_with_where_input_ands_with_existing() {
         other => panic!("expected Filter::And, got {:?}", other),
     }
 }
+
+use prax_query::operations::{DeleteOperation, UpdateOperation};
+
+#[test]
+fn update_op_with_where_input_ands_with_existing() {
+    let op = UpdateOperation::<NoopEngine, U>::new(NoopEngine)
+        .r#where(Filter::Equals("id".into(), FilterValue::Int(1)))
+        .with_where_input(UWhereInput {
+            email: Some(StringFilter::contains("@x.com")),
+        });
+    match op.filter_for_test() {
+        Filter::And(parts) => assert_eq!(parts.len(), 2),
+        other => panic!("expected Filter::And, got {:?}", other),
+    }
+}
+
+#[test]
+fn delete_op_with_where_input_overwrites_filter_for_unique() {
+    let op = DeleteOperation::<NoopEngine, U>::new(NoopEngine).with_where_input(UWhereInput {
+        email: Some(StringFilter::equals("x@y.com")),
+    });
+    assert!(!matches!(op.filter_for_test(), Filter::None));
+}


### PR DESCRIPTION
## Summary

Phase 1 of the typed-query-traits design (spec: `docs/superpowers/specs/2026-05-18-typed-query-traits-design.md`). Adds the runtime trait foundation that codegen (phase 2) and macros (phase 3+) will lower onto.

All changes confined to `prax-query`. No codegen, no proc-macros, no engine changes — those land in subsequent phases. Existing fluent-builder API is byte-for-byte unchanged.

- **New `inputs/` module** with 10 input traits (`WhereInput`, `IncludeInput`, `SelectInput`, `OrderByInput`, `CreateInput`, `UpdateInput`, `WhereUniqueInput`, `CountSelect`, `AggregateInput`, `GroupByInput`), 28 scalar filter wrappers (`StringFilter`, `IntFilter`, …, plus nullable variants), 22 scalar field-update wrappers, relation filter wrappers (`ListRelationFilter` / `SingleRelationFilter` with EXISTS / NOT EXISTS lowering through a `RelationFilterMeta` adapter), and 13 per-operation `*Args` containers.
- **New `capabilities` module** with 9 marker traits (`SupportsRelationFilter`, `SupportsNestedWrites`, …) carrying `#[diagnostic::on_unimplemented]` messages for clear per-engine compile errors in later phases.
- **`Filter::ScalarSubquery` variant** (additive, `Filter` now `#[non_exhaustive]`) with `{N}` placeholder lowering — the IR foundation for relation-aggregate virtuals (phase 5.5) and nested writes (phase 5).
- **`QueryEngine::in_transaction()` default** so the phase-5 nested-write executor can detect a wrapping transaction.
- **`with_*_input` extension methods** on existing operations (`FindMany`, `FindFirst`, `FindUnique`, `Update`, `Delete`, `Create`, `Upsert`, `Count`, `Aggregate`) — they thread typed inputs through `into_ir()` and AND-compose with the existing fluent surface.

## Test plan

- [ ] `cargo fmt --all -- --check` — clean (pre-push hook enforced)
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [ ] `cargo test --workspace --lib` — 1058 lib tests pass (0 failures, 1 pre-existing ignored)
- [ ] `cargo test -p prax-query --tests` — 43 new integration tests pass across `inputs_scalar` (22), `inputs_relation` (4), `inputs_update` (6), `inputs_args` (4), `operation_ext_methods` (7)
- [ ] `cargo doc --workspace --no-deps --all-features` — clean (no new doc warnings)

## Known intentional gaps (phase-2 follow-ups)

- `with_data_input` / `with_create_input` / `with_update_input` / `with_include_input` on write operations are not wired here — those operation structs lack a unified `data` field or `includes` Vec at phase 1, so the methods would have nothing to store. Phase 2 codegen restructures the operations and wires these in.
- `with_order_by_input` / `with_cursor_input` / `with_aggregate_input` / `with_group_by_input` on `Count` / `Aggregate` are similarly deferred.
- `inputs::ScalarFilter`, `inputs::JsonFilter`, and `inputs::JsonNullableFilter` collide with pre-existing crate-root re-exports (`filter::ScalarFilter`, `json::JsonFilter`) and are re-exported at the crate root as `InputScalarFilter`, `InputJsonFilter`, `InputJsonNullableFilter`. Phase 2 codegen will use `inputs::` paths directly.
- `inputs::relation::RelationFilterMeta` is named to avoid collision with the existing `relations::RelationMeta` (relation-loader metadata).

## Commit anatomy

18 commits, all `feat(query):` / `refactor(query):` / `fix(query):` / `docs(query):` — squash-merge will collapse them into one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)