### PR TITLE
feat(schema): multi-file schemas + Prisma directory import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Multi-file schemas.** Point `[schema].path` in `prax.toml` at a directory
+  instead of a single file and prax recursively loads every `*.prax` under
+  it, merging them into one cohesive schema. Discovery is sorted
+  lexicographically by relative path for deterministic codegen output; hidden
+  entries, symlinks, and `target/` directories are skipped. The new
+  `prax_schema::load(path)` entry point auto-detects file vs. directory and
+  returns `LoadedSchema { schema, sources }` (or `LoadError { error, sources }`
+  on failure, with the partial source map preserved). Wired through
+  `prax generate`, `prax validate`, `prax migrate`, `prax db`, `prax format`
+  (per-file walk) and `prax-codegen`'s schema reader, so the `prax::client!`
+  macro also picks up directory inputs.
+- **Cross-file collision detection.** `Schema::try_merge` reports every
+  duplicate model/enum/type/view/serverGroup/policy/generator/raw_sql plus
+  multiple-datasource as a `SchemaError::DuplicateAcrossFiles` /
+  `MultipleDatasource` with both `SourceLoc`s, collected without
+  short-circuiting so users see every conflict in one run.
+- **`SchemaError::ParseInFile` and `EmptySchemaDirectory`** variants for
+  multi-file diagnostics. Every top-level AST item gains an additive
+  `source_id: Option<SourceId>` so the renderer can resolve errors back to
+  file paths.
+
+### Deprecated
+
+- `Schema::merge` (silent overwrite). Use `Schema::try_merge` for
+  collision-aware merging. The old method stays one release for compatibility.
+
 ## [0.9.7] - 2026-05-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-file diagnostics. Every top-level AST item gains an additive
   `source_id: Option<SourceId>` so the renderer can resolve errors back to
   file paths.
+- **Multi-file Prisma import.** `prax import --from prisma --input <dir>`
+  now mirrors Prisma's `prismaSchemaFolder` layouts into a Prax directory
+  tree: each `.prisma` becomes a `.prax` at the matching relative path, the
+  merged AST resolves cross-file relations cleanly, and duplicate models /
+  multiple datasource blocks across files are hard errors. Default output
+  directory is `./prax/schema`; `--force` is required to overwrite an
+  existing non-empty output directory. Single-file `prax import` behavior
+  is unchanged.
 
 ### Deprecated
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4604,6 +4604,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml 0.9.12+spec-1.1.0",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4852,9 +4852,11 @@ dependencies = [
  "regex-lite",
  "serde",
  "smol_str",
+ "tempfile",
  "thiserror 2.0.18",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,9 @@ uuid = { version = "1.10", features = ["v4", "serde"] }
 # Date/time
 chrono = { version = "0.4", features = ["serde"] }
 
+# Filesystem
+walkdir = "2.5"
+
 # Testing
 insta = { version = "1.40", features = ["yaml"] }
 pretty_assertions = "1.4"

--- a/docs/superpowers/plans/2026-05-19-multi-file-schema.md
+++ b/docs/superpowers/plans/2026-05-19-multi-file-schema.md
@@ -1,0 +1,2892 @@
+# Multi-file Schema Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let `prax.toml`'s `[schema].path` point at a directory of `*.prax` files (recursively walked, hard-error on duplicates, one cohesive output), and extend `prax import --from prisma` to mirror Prisma's multi-file layouts into the equivalent Prax tree.
+
+**Architecture:** New `prax_schema::loader` module that walks a directory, parses each file independently, merges with collision detection, and validates the merged AST. Every top-level AST item gains an additive `source_id: Option<SourceId>` so diagnostics can point at originating files. CLI/codegen/importer route through a single `prax_schema::load(path)` entry point that auto-detects file vs. directory.
+
+**Tech Stack:** Rust (workspace edition), `pest` (existing parser), `walkdir` (new dep in `prax-schema`), `miette` (existing diagnostics), `indexmap` (existing).
+
+**Spec:** `docs/superpowers/specs/2026-05-19-multi-file-schema-design.md` — read this first for full context.
+
+**Phasing:** Phase 1 (prax-schema foundation) → Phase 2 (CLI integration) → Phase 3 (codegen) → Phase 4 (Prisma importer). Each phase produces working, testable software. Phase 4 depends on Phase 1 being merged conceptually but its code lives in `prax-import` and is independent.
+
+---
+
+## Phase 1 — `prax-schema` foundation
+
+### Task 1: Add `walkdir` dependency to `prax-schema`
+
+**Files:**
+- Modify: `prax-schema/Cargo.toml`
+- Modify: `Cargo.toml` (root, if `walkdir` isn't already a workspace dep)
+
+- [ ] **Step 1: Check if walkdir is already a workspace dep**
+
+Run: `grep -n "walkdir" Cargo.toml prax-schema/Cargo.toml`
+Expected: probably not present (the cli uses `globset`/`ignore` indirectly but `walkdir` isn't direct).
+
+- [ ] **Step 2: Add to workspace dependencies**
+
+In root `Cargo.toml` under `[workspace.dependencies]`, add (alphabetical order):
+
+```toml
+walkdir = "2.5"
+```
+
+- [ ] **Step 3: Add to prax-schema/Cargo.toml**
+
+Under `[dependencies]`:
+
+```toml
+walkdir = { workspace = true }
+```
+
+- [ ] **Step 4: Verify build**
+
+Run: `cargo build -p prax-schema`
+Expected: clean compile.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml prax-schema/Cargo.toml
+git commit -m "build(schema): add walkdir for recursive schema directory discovery"
+```
+
+---
+
+### Task 2: Define `SourceId`, `SourceFile`, `SourceMap`
+
+**Files:**
+- Create: `prax-schema/src/loader/mod.rs`
+- Create: `prax-schema/src/loader/source.rs`
+- Modify: `prax-schema/src/lib.rs:242` (add `pub mod loader;`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `prax-schema/src/loader/source.rs`:
+
+```rust
+//! Source provenance tracking for multi-file schemas.
+
+use std::path::{Path, PathBuf};
+
+/// Opaque, dense identifier for a source file in a [`SourceMap`].
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Ord, PartialOrd)]
+pub struct SourceId(pub u32);
+
+/// A single source file (path + content) loaded into the schema.
+#[derive(Debug, Clone)]
+pub struct SourceFile {
+    pub path: PathBuf,
+    pub content: String,
+}
+
+/// Map of [`SourceId`] → [`SourceFile`].
+///
+/// Built incrementally during loading. Empty by default.
+#[derive(Debug, Clone, Default)]
+pub struct SourceMap {
+    files: Vec<SourceFile>,
+}
+
+impl SourceMap {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a new source file and return its [`SourceId`].
+    pub fn insert(&mut self, path: impl Into<PathBuf>, content: impl Into<String>) -> SourceId {
+        let id = SourceId(self.files.len() as u32);
+        self.files.push(SourceFile {
+            path: path.into(),
+            content: content.into(),
+        });
+        id
+    }
+
+    pub fn get(&self, id: SourceId) -> Option<&SourceFile> {
+        self.files.get(id.0 as usize)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (SourceId, &SourceFile)> {
+        self.files
+            .iter()
+            .enumerate()
+            .map(|(i, f)| (SourceId(i as u32), f))
+    }
+
+    pub fn len(&self) -> usize {
+        self.files.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.files.is_empty()
+    }
+
+    /// Convenience: path for a given id.
+    pub fn path_of(&self, id: SourceId) -> Option<&Path> {
+        self.get(id).map(|f| f.path.as_path())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_assigns_monotonic_ids() {
+        let mut map = SourceMap::new();
+        let a = map.insert("a.prax", "model A {}");
+        let b = map.insert("b.prax", "model B {}");
+        assert_eq!(a, SourceId(0));
+        assert_eq!(b, SourceId(1));
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn get_returns_inserted_file() {
+        let mut map = SourceMap::new();
+        let id = map.insert("/tmp/x.prax", "content");
+        let f = map.get(id).unwrap();
+        assert_eq!(f.path.to_str().unwrap(), "/tmp/x.prax");
+        assert_eq!(f.content, "content");
+    }
+
+    #[test]
+    fn get_unknown_id_returns_none() {
+        let map = SourceMap::new();
+        assert!(map.get(SourceId(42)).is_none());
+    }
+}
+```
+
+Create `prax-schema/src/loader/mod.rs`:
+
+```rust
+//! Multi-file schema loader.
+//!
+//! See `docs/superpowers/specs/2026-05-19-multi-file-schema-design.md`.
+
+pub mod source;
+
+pub use source::{SourceFile, SourceId, SourceMap};
+```
+
+Wire into `prax-schema/src/lib.rs` — add after `pub mod parser;`:
+
+```rust
+pub mod loader;
+```
+
+And re-export under the existing block:
+
+```rust
+pub use loader::{SourceFile, SourceId, SourceMap};
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cargo test -p prax-schema loader::source::tests`
+Expected: 3 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add prax-schema/src/loader prax-schema/src/lib.rs
+git commit -m "feat(schema): add SourceId/SourceMap for multi-file provenance"
+```
+
+---
+
+### Task 3: Add `source_id` field to top-level AST items
+
+**Files:**
+- Modify: `prax-schema/src/ast/model.rs`
+- Modify: `prax-schema/src/ast/types.rs` (CompositeType)
+- Modify: `prax-schema/src/ast/schema.rs` (View, RawSql)
+- Modify: `prax-schema/src/ast/datasource.rs`
+- Modify: `prax-schema/src/ast/generator.rs`
+- Modify: `prax-schema/src/ast/server_group.rs`
+- Modify: `prax-schema/src/ast/policy.rs`
+- Modify: `prax-schema/src/ast/mod.rs` (Enum)
+
+- [ ] **Step 1: Add field to Model**
+
+Locate `pub struct Model` in `prax-schema/src/ast/model.rs`. Add after the existing fields:
+
+```rust
+    /// Source file this model was parsed from (None for single-file path).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<crate::loader::SourceId>,
+```
+
+The struct must already derive `Serialize, Deserialize` — add `serde::{Serialize, Deserialize}` to imports if not already there.
+
+- [ ] **Step 2: Repeat for Enum, CompositeType, View, ServerGroup, Policy, Generator, Datasource, RawSql**
+
+Add the identical field declaration to each. Locations:
+- `Enum` — likely `prax-schema/src/ast/mod.rs` or its own file; grep `pub struct Enum`
+- `CompositeType` — `prax-schema/src/ast/types.rs`
+- `View` — `prax-schema/src/ast/schema.rs` (search `pub struct View`)
+- `ServerGroup` — `prax-schema/src/ast/server_group.rs`
+- `Policy` — `prax-schema/src/ast/policy.rs`
+- `Generator` — `prax-schema/src/ast/generator.rs`
+- `Datasource` — `prax-schema/src/ast/datasource.rs`
+- `RawSql` — `prax-schema/src/ast/schema.rs`
+
+Run: `grep -rn "pub struct \(Model\|Enum\|CompositeType\|View\|ServerGroup\|Policy\|Generator\|Datasource\|RawSql\)\b" prax-schema/src/ast/`
+Use the results to find exact file:line for each.
+
+- [ ] **Step 3: Compile check**
+
+Run: `cargo build -p prax-schema`
+Expected: clean compile. Any `Default` derives will still work because `Option::default() == None`.
+
+- [ ] **Step 4: Verify serde compatibility**
+
+Existing tests deserialize schemas. Verify they still pass:
+
+Run: `cargo test -p prax-schema`
+Expected: all existing tests pass (the new field defaults to None and is skipped on serialize).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add prax-schema/src/ast/
+git commit -m "feat(schema): add optional source_id to top-level AST items"
+```
+
+---
+
+### Task 4: Add `stamp_source` helper
+
+**Files:**
+- Modify: `prax-schema/src/loader/mod.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `prax-schema/src/loader/mod.rs`:
+
+```rust
+use crate::ast::Schema;
+
+/// Stamp every top-level item in `schema` with `source`.
+///
+/// Called by the loader right after parsing a per-file [`Schema`], before merging.
+pub(crate) fn stamp_source(schema: &mut Schema, source: SourceId) {
+    for m in schema.models.values_mut() {
+        m.source_id = Some(source);
+    }
+    for e in schema.enums.values_mut() {
+        e.source_id = Some(source);
+    }
+    for t in schema.types.values_mut() {
+        t.source_id = Some(source);
+    }
+    for v in schema.views.values_mut() {
+        v.source_id = Some(source);
+    }
+    for sg in schema.server_groups.values_mut() {
+        sg.source_id = Some(source);
+    }
+    for p in &mut schema.policies {
+        p.source_id = Some(source);
+    }
+    for g in schema.generators.values_mut() {
+        g.source_id = Some(source);
+    }
+    if let Some(ds) = &mut schema.datasource {
+        ds.source_id = Some(source);
+    }
+    for r in &mut schema.raw_sql {
+        r.source_id = Some(source);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::parse_schema;
+
+    #[test]
+    fn stamp_marks_all_items() {
+        let mut schema = parse_schema(
+            r#"
+            datasource db { provider = "postgresql" url = "x" }
+            generator client { provider = "prax-client" }
+            enum Role { User Admin }
+            model User { id Int @id @auto role Role }
+            "#,
+        )
+        .unwrap();
+        stamp_source(&mut schema, SourceId(7));
+        assert_eq!(schema.models["User"].source_id, Some(SourceId(7)));
+        assert_eq!(schema.enums["Role"].source_id, Some(SourceId(7)));
+        assert_eq!(schema.datasource.unwrap().source_id, Some(SourceId(7)));
+        assert_eq!(schema.generators["client"].source_id, Some(SourceId(7)));
+    }
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cargo test -p prax-schema loader::tests::stamp_marks_all_items`
+Expected: pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add prax-schema/src/loader/mod.rs
+git commit -m "feat(schema): add stamp_source helper for loader provenance"
+```
+
+---
+
+### Task 5: Add new `SchemaError` variants and `SourceLoc`
+
+**Files:**
+- Modify: `prax-schema/src/error.rs`
+- Modify: `prax-schema/src/loader/source.rs` (add `SourceLoc`)
+
+- [ ] **Step 1: Add SourceLoc to source.rs**
+
+In `prax-schema/src/loader/source.rs`, append:
+
+```rust
+use crate::ast::Span;
+
+/// A (source file id, span) pair used in cross-file diagnostics.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct SourceLoc {
+    pub source: SourceId,
+    pub span: Span,
+}
+
+impl SourceLoc {
+    pub fn new(source: SourceId, span: Span) -> Self {
+        Self { source, span }
+    }
+}
+```
+
+Re-export from `loader/mod.rs`:
+
+```rust
+pub use source::{SourceFile, SourceId, SourceLoc, SourceMap};
+```
+
+And from `lib.rs`:
+
+```rust
+pub use loader::{SourceFile, SourceId, SourceLoc, SourceMap};
+```
+
+- [ ] **Step 2: Add error variants**
+
+In `prax-schema/src/error.rs`, append new variants to the `SchemaError` enum (after the existing variants, before any closing brace):
+
+```rust
+    /// Parse failure in a specific file within a multi-file schema directory.
+    #[error("parse error in {source:?}")]
+    #[diagnostic(code(prax::schema::parse_in_file))]
+    ParseInFile {
+        source: crate::loader::SourceId,
+        #[source]
+        inner: Box<SchemaError>,
+    },
+
+    /// Same-named item declared in two source files.
+    #[error("duplicate {kind} `{name}` declared in two files")]
+    #[diagnostic(code(prax::schema::duplicate_across_files))]
+    DuplicateAcrossFiles {
+        kind: &'static str,
+        name: String,
+        first: crate::loader::SourceLoc,
+        second: crate::loader::SourceLoc,
+    },
+
+    /// More than one `datasource` block across source files.
+    #[error("multiple datasource blocks declared (exactly one allowed across all files)")]
+    #[diagnostic(code(prax::schema::multiple_datasource))]
+    MultipleDatasource {
+        first: crate::loader::SourceLoc,
+        second: crate::loader::SourceLoc,
+    },
+
+    /// Schema directory contained no `*.prax` files.
+    #[error("schema directory `{path}` contains no .prax files")]
+    #[diagnostic(code(prax::schema::empty_directory))]
+    EmptySchemaDirectory { path: std::path::PathBuf },
+```
+
+- [ ] **Step 3: Compile check**
+
+Run: `cargo build -p prax-schema`
+Expected: clean compile (note: miette `#[diagnostic]` and thiserror `#[error]` macros pick up the new variants automatically).
+
+- [ ] **Step 4: Add a small test**
+
+Append to `prax-schema/src/error.rs` (or its test mod) — verifies the new variants format correctly:
+
+```rust
+#[cfg(test)]
+mod multi_file_error_tests {
+    use super::*;
+    use crate::ast::Span;
+    use crate::loader::{SourceId, SourceLoc};
+
+    #[test]
+    fn duplicate_across_files_displays_name_and_kind() {
+        let err = SchemaError::DuplicateAcrossFiles {
+            kind: "model",
+            name: "User".to_string(),
+            first: SourceLoc::new(SourceId(0), Span::new(0, 10)),
+            second: SourceLoc::new(SourceId(1), Span::new(0, 10)),
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("duplicate model"));
+        assert!(msg.contains("User"));
+    }
+
+    #[test]
+    fn empty_directory_displays_path() {
+        let err = SchemaError::EmptySchemaDirectory {
+            path: std::path::PathBuf::from("/tmp/empty"),
+        };
+        assert!(format!("{err}").contains("/tmp/empty"));
+    }
+}
+```
+
+Run: `cargo test -p prax-schema multi_file_error_tests`
+Expected: 2 pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add prax-schema/src/error.rs prax-schema/src/loader/source.rs prax-schema/src/loader/mod.rs prax-schema/src/lib.rs
+git commit -m "feat(schema): add ParseInFile/DuplicateAcrossFiles/EmptyDir error variants"
+```
+
+---
+
+### Task 6: Add `MergeConflict` and `Schema::try_merge`
+
+**Files:**
+- Create: `prax-schema/src/loader/merge.rs`
+- Modify: `prax-schema/src/loader/mod.rs` (export merge)
+- Modify: `prax-schema/src/ast/schema.rs` (deprecate `merge`, add `try_merge`)
+
+- [ ] **Step 1: Define MergeConflict in merge.rs**
+
+Create `prax-schema/src/loader/merge.rs`:
+
+```rust
+//! Schema merging with cross-file collision detection.
+
+use smol_str::SmolStr;
+
+use super::source::SourceLoc;
+
+/// A single conflict found while merging two [`Schema`]s.
+///
+/// Collected without short-circuiting so the loader can report every duplicate
+/// in one pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MergeConflict {
+    DuplicateModel { name: SmolStr, existing: SourceLoc, incoming: SourceLoc },
+    DuplicateEnum { name: SmolStr, existing: SourceLoc, incoming: SourceLoc },
+    DuplicateType { name: SmolStr, existing: SourceLoc, incoming: SourceLoc },
+    DuplicateView { name: SmolStr, existing: SourceLoc, incoming: SourceLoc },
+    DuplicateServerGroup { name: SmolStr, existing: SourceLoc, incoming: SourceLoc },
+    DuplicatePolicy { name: SmolStr, existing: SourceLoc, incoming: SourceLoc },
+    DuplicateGenerator { name: SmolStr, existing: SourceLoc, incoming: SourceLoc },
+    DuplicateRawSql { name: SmolStr, existing: SourceLoc, incoming: SourceLoc },
+    MultipleDatasource { existing: SourceLoc, incoming: SourceLoc },
+}
+```
+
+Re-export from `loader/mod.rs`:
+
+```rust
+pub mod merge;
+pub use merge::MergeConflict;
+```
+
+- [ ] **Step 2: Add try_merge to Schema**
+
+In `prax-schema/src/ast/schema.rs`, mark the existing `merge` as deprecated and add `try_merge`. Find the existing `pub fn merge`:
+
+```rust
+    /// Merge another schema into this one.
+    pub fn merge(&mut self, other: Schema) {
+        self.models.extend(other.models);
+        // ...existing body...
+    }
+```
+
+Replace with (keep existing `merge` but deprecate it):
+
+```rust
+    /// Merge another schema into this one (deprecated: use [`Schema::try_merge`]).
+    ///
+    /// Silently overwrites duplicates. Kept for backward compatibility; will be
+    /// removed in a future release.
+    #[deprecated(since = "0.9.8", note = "use try_merge for collision-aware merging")]
+    pub fn merge(&mut self, other: Schema) {
+        self.models.extend(other.models);
+        self.enums.extend(other.enums);
+        self.types.extend(other.types);
+        self.views.extend(other.views);
+        self.server_groups.extend(other.server_groups);
+        self.policies.extend(other.policies);
+        self.raw_sql.extend(other.raw_sql);
+    }
+
+    /// Merge `other` into `self`, returning every collision found rather than
+    /// silently overwriting.
+    ///
+    /// Items whose `source_id` is `None` are treated as locationless (used in
+    /// tests that don't go through the loader); their span is reported as
+    /// `Span::new(0, 0)` and source as `SourceId(u32::MAX)`. In production
+    /// usage the loader stamps every item via `stamp_source` first.
+    pub fn try_merge(&mut self, other: Schema) -> Result<(), Vec<crate::loader::MergeConflict>> {
+        use crate::loader::{MergeConflict, SourceId, SourceLoc};
+        use crate::ast::Span;
+
+        fn loc<T: HasProvenance>(item: &T) -> SourceLoc {
+            SourceLoc::new(
+                item.source_id().unwrap_or(SourceId(u32::MAX)),
+                item.span(),
+            )
+        }
+
+        let mut conflicts = Vec::new();
+
+        // Models
+        for (name, m) in other.models {
+            if let Some(existing) = self.models.get(&name) {
+                conflicts.push(MergeConflict::DuplicateModel {
+                    name: name.clone(),
+                    existing: loc(existing),
+                    incoming: loc(&m),
+                });
+            } else {
+                self.models.insert(name, m);
+            }
+        }
+
+        // Enums
+        for (name, e) in other.enums {
+            if let Some(existing) = self.enums.get(&name) {
+                conflicts.push(MergeConflict::DuplicateEnum {
+                    name: name.clone(),
+                    existing: loc(existing),
+                    incoming: loc(&e),
+                });
+            } else {
+                self.enums.insert(name, e);
+            }
+        }
+
+        // Composite types
+        for (name, t) in other.types {
+            if let Some(existing) = self.types.get(&name) {
+                conflicts.push(MergeConflict::DuplicateType {
+                    name: name.clone(),
+                    existing: loc(existing),
+                    incoming: loc(&t),
+                });
+            } else {
+                self.types.insert(name, t);
+            }
+        }
+
+        // Views
+        for (name, v) in other.views {
+            if let Some(existing) = self.views.get(&name) {
+                conflicts.push(MergeConflict::DuplicateView {
+                    name: name.clone(),
+                    existing: loc(existing),
+                    incoming: loc(&v),
+                });
+            } else {
+                self.views.insert(name, v);
+            }
+        }
+
+        // Server groups
+        for (name, sg) in other.server_groups {
+            if let Some(existing) = self.server_groups.get(&name) {
+                conflicts.push(MergeConflict::DuplicateServerGroup {
+                    name: name.clone(),
+                    existing: loc(existing),
+                    incoming: loc(&sg),
+                });
+            } else {
+                self.server_groups.insert(name, sg);
+            }
+        }
+
+        // Generators
+        for (name, g) in other.generators {
+            if let Some(existing) = self.generators.get(&name) {
+                conflicts.push(MergeConflict::DuplicateGenerator {
+                    name: name.clone(),
+                    existing: loc(existing),
+                    incoming: loc(&g),
+                });
+            } else {
+                self.generators.insert(name, g);
+            }
+        }
+
+        // Policies: Vec, key is policy.name()
+        for p in other.policies {
+            if let Some(existing) = self.policies.iter().find(|x| x.name() == p.name()) {
+                conflicts.push(MergeConflict::DuplicatePolicy {
+                    name: SmolStr::new(p.name()),
+                    existing: loc(existing),
+                    incoming: loc(&p),
+                });
+            } else {
+                self.policies.push(p);
+            }
+        }
+
+        // Raw SQL: Vec, key is raw.name
+        for r in other.raw_sql {
+            if let Some(existing) = self.raw_sql.iter().find(|x| x.name == r.name) {
+                conflicts.push(MergeConflict::DuplicateRawSql {
+                    name: r.name.clone(),
+                    existing: loc(existing),
+                    incoming: loc(&r),
+                });
+            } else {
+                self.raw_sql.push(r);
+            }
+        }
+
+        // Datasource: at most one across all files
+        match (&self.datasource, other.datasource) {
+            (Some(existing), Some(incoming)) => {
+                conflicts.push(MergeConflict::MultipleDatasource {
+                    existing: loc(existing),
+                    incoming: loc(&incoming),
+                });
+            }
+            (None, Some(incoming)) => self.datasource = Some(incoming),
+            (_, None) => {}
+        }
+
+        if conflicts.is_empty() {
+            Ok(())
+        } else {
+            Err(conflicts)
+        }
+    }
+}
+
+/// Internal helper trait used by [`Schema::try_merge`] to extract location info.
+trait HasProvenance {
+    fn source_id(&self) -> Option<crate::loader::SourceId>;
+    fn span(&self) -> crate::ast::Span;
+}
+
+macro_rules! impl_has_provenance {
+    ($t:ty) => {
+        impl HasProvenance for $t {
+            fn source_id(&self) -> Option<crate::loader::SourceId> {
+                self.source_id
+            }
+            fn span(&self) -> crate::ast::Span {
+                self.span
+            }
+        }
+    };
+    ($t:ty, span_method) => {
+        impl HasProvenance for $t {
+            fn source_id(&self) -> Option<crate::loader::SourceId> {
+                self.source_id
+            }
+            fn span(&self) -> crate::ast::Span {
+                self.span()
+            }
+        }
+    };
+}
+
+impl_has_provenance!(crate::ast::Model);
+impl_has_provenance!(crate::ast::Enum);
+impl_has_provenance!(crate::ast::CompositeType);
+impl_has_provenance!(crate::ast::View);
+impl_has_provenance!(crate::ast::ServerGroup);
+impl_has_provenance!(crate::ast::Generator);
+impl_has_provenance!(crate::ast::Datasource);
+
+// Policy and RawSql may not have a `span: Span` field; if not, use Span::default().
+impl HasProvenance for crate::ast::Policy {
+    fn source_id(&self) -> Option<crate::loader::SourceId> {
+        self.source_id
+    }
+    fn span(&self) -> crate::ast::Span {
+        self.span()
+    }
+}
+
+impl HasProvenance for crate::ast::RawSql {
+    fn source_id(&self) -> Option<crate::loader::SourceId> {
+        self.source_id
+    }
+    fn span(&self) -> crate::ast::Span {
+        crate::ast::Span::new(0, 0)
+    }
+}
+```
+
+> **Implementation note:** if any of the AST structs use a `span()` accessor instead of a `span: Span` field, adjust the `impl_has_provenance!` macro arm or write the impl by hand. Check with: `grep -n "pub span\|fn span(" prax-schema/src/ast/{model,enum,types,policy}.rs`.
+
+- [ ] **Step 3: Write the failing test**
+
+Append to `prax-schema/src/loader/merge.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use crate::ast::Schema;
+    use crate::loader::{SourceId, stamp_source};
+    use crate::parser::parse_schema;
+
+    use super::MergeConflict;
+
+    fn stamped(input: &str, sid: u32) -> Schema {
+        let mut s = parse_schema(input).unwrap();
+        stamp_source(&mut s, SourceId(sid));
+        s
+    }
+
+    #[test]
+    fn merge_distinct_models_succeeds() {
+        let mut a = stamped("model A { id Int @id @auto }", 0);
+        let b = stamped("model B { id Int @id @auto }", 1);
+        assert!(a.try_merge(b).is_ok());
+        assert!(a.get_model("A").is_some());
+        assert!(a.get_model("B").is_some());
+        assert_eq!(a.get_model("B").unwrap().source_id, Some(SourceId(1)));
+    }
+
+    #[test]
+    fn merge_duplicate_models_reports_both_locations() {
+        let mut a = stamped("model User { id Int @id @auto }", 0);
+        let b = stamped("model User { id Int @id @auto }", 1);
+        let err = a.try_merge(b).unwrap_err();
+        assert_eq!(err.len(), 1);
+        match &err[0] {
+            MergeConflict::DuplicateModel { name, existing, incoming } => {
+                assert_eq!(name.as_str(), "User");
+                assert_eq!(existing.source, SourceId(0));
+                assert_eq!(incoming.source, SourceId(1));
+            }
+            other => panic!("unexpected conflict: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn merge_collects_all_conflicts_without_short_circuit() {
+        let mut a = stamped(
+            "model A { id Int @id @auto } model B { id Int @id @auto }",
+            0,
+        );
+        let b = stamped(
+            "model A { id Int @id @auto } model B { id Int @id @auto }",
+            1,
+        );
+        let err = a.try_merge(b).unwrap_err();
+        assert_eq!(err.len(), 2);
+    }
+
+    #[test]
+    fn merge_two_datasources_errors() {
+        let mut a = stamped(
+            r#"datasource db { provider = "postgresql" url = "x" }"#,
+            0,
+        );
+        let b = stamped(
+            r#"datasource db { provider = "postgresql" url = "y" }"#,
+            1,
+        );
+        let err = a.try_merge(b).unwrap_err();
+        assert!(matches!(err[0], MergeConflict::MultipleDatasource { .. }));
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test -p prax-schema loader::merge`
+Expected: 4 pass.
+
+(If the `HasProvenance` macro arms don't match an AST struct's actual shape, the build will fail with a clear error. Fix by writing the impl by hand using whatever `span()` accessor or field exists.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add prax-schema/src/loader/merge.rs prax-schema/src/loader/mod.rs prax-schema/src/ast/schema.rs
+git commit -m "feat(schema): add try_merge with cross-file collision detection"
+```
+
+---
+
+### Task 7: Discovery — recursive `*.prax` walker
+
+**Files:**
+- Create: `prax-schema/src/loader/discovery.rs`
+- Modify: `prax-schema/src/loader/mod.rs` (export discovery)
+
+- [ ] **Step 1: Define the walker**
+
+Create `prax-schema/src/loader/discovery.rs`:
+
+```rust
+//! Recursive `*.prax` discovery for multi-file schema directories.
+
+use std::path::{Path, PathBuf};
+
+use walkdir::WalkDir;
+
+use crate::error::{SchemaError, SchemaResult};
+
+/// A discovered `*.prax` file with its absolute and relative paths.
+#[derive(Debug, Clone)]
+pub struct Discovered {
+    /// Absolute path on disk.
+    pub absolute: PathBuf,
+    /// Path relative to the discovery root (used for sort order + emit mirroring).
+    pub relative: PathBuf,
+}
+
+/// Recursively find all `*.prax` files under `root`, sorted lexicographically
+/// by the relative path.
+///
+/// Skipped:
+/// - Hidden entries (filename starts with `.`)
+/// - Symlinks (not followed)
+/// - Any directory named `target`
+pub fn discover(root: impl AsRef<Path>) -> SchemaResult<Vec<Discovered>> {
+    let root = root.as_ref();
+    let canonical_root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+
+    let mut out = Vec::new();
+    for entry in WalkDir::new(&canonical_root)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|e| !is_skipped(e))
+    {
+        let entry = entry.map_err(|e| SchemaError::IoError {
+            path: e.path().map(|p| p.display().to_string()).unwrap_or_default(),
+            source: e.into(),
+        })?;
+
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        if entry.path().extension().and_then(|s| s.to_str()) != Some("prax") {
+            continue;
+        }
+
+        let relative = entry
+            .path()
+            .strip_prefix(&canonical_root)
+            .unwrap_or(entry.path())
+            .to_path_buf();
+
+        out.push(Discovered {
+            absolute: entry.path().to_path_buf(),
+            relative,
+        });
+    }
+
+    out.sort_by(|a, b| a.relative.cmp(&b.relative));
+    Ok(out)
+}
+
+fn is_skipped(entry: &walkdir::DirEntry) -> bool {
+    // Always allow the root itself.
+    if entry.depth() == 0 {
+        return false;
+    }
+    if let Some(name) = entry.file_name().to_str() {
+        if name.starts_with('.') {
+            return true;
+        }
+        if entry.file_type().is_dir() && name == "target" {
+            return true;
+        }
+    }
+    if entry.file_type().is_symlink() {
+        return true;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn write(dir: &Path, name: &str, content: &str) {
+        let p = dir.join(name);
+        if let Some(parent) = p.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(p, content).unwrap();
+    }
+
+    #[test]
+    fn flat_directory_returns_sorted_prax_files() {
+        let dir = tempdir().unwrap();
+        write(dir.path(), "b.prax", "// b");
+        write(dir.path(), "a.prax", "// a");
+        write(dir.path(), "c.prax", "// c");
+
+        let found = discover(dir.path()).unwrap();
+        let names: Vec<_> = found.iter().map(|d| d.relative.to_str().unwrap()).collect();
+        assert_eq!(names, vec!["a.prax", "b.prax", "c.prax"]);
+    }
+
+    #[test]
+    fn recursive_descent_finds_nested_files() {
+        let dir = tempdir().unwrap();
+        write(dir.path(), "schema.prax", "// root");
+        write(dir.path(), "models/user.prax", "model U {}");
+        write(dir.path(), "models/post.prax", "model P {}");
+        write(dir.path(), "enums/role.prax", "enum R {}");
+
+        let found = discover(dir.path()).unwrap();
+        assert_eq!(found.len(), 4);
+    }
+
+    #[test]
+    fn hidden_dirs_are_skipped() {
+        let dir = tempdir().unwrap();
+        write(dir.path(), "ok.prax", "// ok");
+        write(dir.path(), ".git/HEAD", "// not prax");
+        write(dir.path(), ".cache/bad.prax", "// skipped");
+
+        let found = discover(dir.path()).unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].relative.to_str().unwrap(), "ok.prax");
+    }
+
+    #[test]
+    fn target_directory_is_skipped() {
+        let dir = tempdir().unwrap();
+        write(dir.path(), "ok.prax", "// ok");
+        write(dir.path(), "target/build.prax", "// skipped");
+
+        let found = discover(dir.path()).unwrap();
+        assert_eq!(found.len(), 1);
+    }
+
+    #[test]
+    fn non_prax_files_ignored() {
+        let dir = tempdir().unwrap();
+        write(dir.path(), "ok.prax", "// ok");
+        write(dir.path(), "README.md", "# readme");
+        write(dir.path(), "schema.prisma", "// wrong ext");
+
+        let found = discover(dir.path()).unwrap();
+        assert_eq!(found.len(), 1);
+    }
+}
+```
+
+- [ ] **Step 2: Add tempfile as dev-dependency**
+
+In `prax-schema/Cargo.toml` under `[dev-dependencies]`:
+
+```toml
+tempfile = { workspace = true }
+```
+
+(Verify `tempfile` is already a workspace dep in root `Cargo.toml`; if not, add `tempfile = "3"` to `[workspace.dependencies]`.)
+
+- [ ] **Step 3: Wire into loader/mod.rs**
+
+```rust
+pub mod discovery;
+pub use discovery::Discovered;
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test -p prax-schema loader::discovery`
+Expected: 5 pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add prax-schema/src/loader prax-schema/Cargo.toml Cargo.toml
+git commit -m "feat(schema): add recursive .prax file discovery"
+```
+
+---
+
+### Task 8: `LoadedSchema`, `LoadError`, and the `load` entry point
+
+**Files:**
+- Modify: `prax-schema/src/loader/mod.rs`
+
+- [ ] **Step 1: Add LoadedSchema and LoadError**
+
+Append to `prax-schema/src/loader/mod.rs`:
+
+```rust
+use std::path::{Path, PathBuf};
+
+use crate::error::SchemaError;
+use crate::ast::Schema;
+use crate::parser::parse_schema;
+use crate::validator::validate_schema;
+
+/// A successfully loaded multi-file (or single-file) schema, paired with the
+/// source map needed for downstream diagnostics rendering.
+#[derive(Debug, Clone)]
+pub struct LoadedSchema {
+    pub schema: Schema,
+    pub sources: SourceMap,
+}
+
+/// Error returned by [`load`], carrying the partial source map built up to the
+/// point of failure so the renderer can resolve [`SourceId`]s back to file
+/// content.
+#[derive(Debug)]
+pub struct LoadError {
+    pub error: SchemaError,
+    pub sources: SourceMap,
+}
+
+impl std::fmt::Display for LoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.error.fmt(f)
+    }
+}
+
+impl std::error::Error for LoadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.error)
+    }
+}
+
+/// Load a schema from a file or directory.
+///
+/// - If `path` is a file: parse the single file.
+/// - If `path` is a directory: recursively find `*.prax`, parse each, merge
+///   with collision detection, then validate the merged AST.
+pub fn load(path: impl AsRef<Path>) -> Result<LoadedSchema, LoadError> {
+    let path = path.as_ref();
+    let meta = std::fs::metadata(path).map_err(|e| LoadError {
+        error: SchemaError::IoError {
+            path: path.display().to_string(),
+            source: e,
+        },
+        sources: SourceMap::new(),
+    })?;
+
+    if meta.is_file() {
+        load_single(path)
+    } else if meta.is_dir() {
+        load_directory(path)
+    } else {
+        Err(LoadError {
+            error: SchemaError::ConfigError {
+                message: format!(
+                    "schema path `{}` is neither a file nor a directory",
+                    path.display()
+                ),
+            },
+            sources: SourceMap::new(),
+        })
+    }
+}
+
+fn load_single(path: &Path) -> Result<LoadedSchema, LoadError> {
+    let mut sources = SourceMap::new();
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) => {
+            return Err(LoadError {
+                error: SchemaError::IoError {
+                    path: path.display().to_string(),
+                    source: e,
+                },
+                sources,
+            });
+        }
+    };
+    let sid = sources.insert(path.to_path_buf(), content.clone());
+
+    let mut schema = match parse_schema(&content) {
+        Ok(s) => s,
+        Err(e) => {
+            return Err(LoadError { error: e, sources });
+        }
+    };
+    stamp_source(&mut schema, sid);
+
+    // Re-validate by re-parsing through validate_schema for relation resolution.
+    // (validate_schema reads &str — we already have the AST; the existing
+    // validate path uses content. We replicate by running the validator
+    // directly on the merged schema.)
+    if let Err(e) = crate::validator::Validator::new().validate(&mut schema) {
+        return Err(LoadError { error: e, sources });
+    }
+
+    Ok(LoadedSchema { schema, sources })
+}
+
+fn load_directory(root: &Path) -> Result<LoadedSchema, LoadError> {
+    let mut sources = SourceMap::new();
+
+    let files = match discovery::discover(root) {
+        Ok(v) => v,
+        Err(e) => return Err(LoadError { error: e, sources }),
+    };
+
+    if files.is_empty() {
+        return Err(LoadError {
+            error: SchemaError::EmptySchemaDirectory {
+                path: root.to_path_buf(),
+            },
+            sources,
+        });
+    }
+
+    // Phase 1: read + parse each file (fail-fast on syntax error)
+    let mut per_file: Vec<(SourceId, Schema)> = Vec::with_capacity(files.len());
+    for f in files {
+        let content = match std::fs::read_to_string(&f.absolute) {
+            Ok(c) => c,
+            Err(e) => {
+                return Err(LoadError {
+                    error: SchemaError::IoError {
+                        path: f.absolute.display().to_string(),
+                        source: e,
+                    },
+                    sources,
+                });
+            }
+        };
+        let sid = sources.insert(f.absolute.clone(), content.clone());
+
+        let mut schema_i = match parse_schema(&content) {
+            Ok(s) => s,
+            Err(inner) => {
+                return Err(LoadError {
+                    error: SchemaError::ParseInFile {
+                        source: sid,
+                        inner: Box::new(inner),
+                    },
+                    sources,
+                });
+            }
+        };
+        stamp_source(&mut schema_i, sid);
+        per_file.push((sid, schema_i));
+    }
+
+    // Phase 2: merge with conflict collection
+    let mut merged = Schema::new();
+    let mut all_conflicts: Vec<MergeConflict> = Vec::new();
+    for (_, schema_i) in per_file {
+        if let Err(conflicts) = merged.try_merge(schema_i) {
+            all_conflicts.extend(conflicts);
+        }
+    }
+
+    if !all_conflicts.is_empty() {
+        return Err(LoadError {
+            error: from_conflicts(all_conflicts),
+            sources,
+        });
+    }
+
+    // Phase 3: validate merged schema
+    if let Err(e) = crate::validator::Validator::new().validate(&mut merged) {
+        return Err(LoadError { error: e, sources });
+    }
+
+    Ok(LoadedSchema { schema: merged, sources })
+}
+
+/// Bundle a batch of [`MergeConflict`]s into a single [`SchemaError`].
+///
+/// If exactly one conflict, returns it directly. Otherwise wraps in
+/// `ValidationFailed` to display all at once.
+fn from_conflicts(conflicts: Vec<MergeConflict>) -> SchemaError {
+    let mut errors: Vec<SchemaError> = conflicts.into_iter().map(conflict_to_error).collect();
+    if errors.len() == 1 {
+        errors.remove(0)
+    } else {
+        SchemaError::ValidationFailed {
+            count: errors.len(),
+            errors,
+        }
+    }
+}
+
+fn conflict_to_error(c: MergeConflict) -> SchemaError {
+    match c {
+        MergeConflict::DuplicateModel { name, existing, incoming } => {
+            SchemaError::DuplicateAcrossFiles {
+                kind: "model",
+                name: name.to_string(),
+                first: existing,
+                second: incoming,
+            }
+        }
+        MergeConflict::DuplicateEnum { name, existing, incoming } => {
+            SchemaError::DuplicateAcrossFiles {
+                kind: "enum",
+                name: name.to_string(),
+                first: existing,
+                second: incoming,
+            }
+        }
+        MergeConflict::DuplicateType { name, existing, incoming } => {
+            SchemaError::DuplicateAcrossFiles {
+                kind: "type",
+                name: name.to_string(),
+                first: existing,
+                second: incoming,
+            }
+        }
+        MergeConflict::DuplicateView { name, existing, incoming } => {
+            SchemaError::DuplicateAcrossFiles {
+                kind: "view",
+                name: name.to_string(),
+                first: existing,
+                second: incoming,
+            }
+        }
+        MergeConflict::DuplicateServerGroup { name, existing, incoming } => {
+            SchemaError::DuplicateAcrossFiles {
+                kind: "serverGroup",
+                name: name.to_string(),
+                first: existing,
+                second: incoming,
+            }
+        }
+        MergeConflict::DuplicatePolicy { name, existing, incoming } => {
+            SchemaError::DuplicateAcrossFiles {
+                kind: "policy",
+                name: name.to_string(),
+                first: existing,
+                second: incoming,
+            }
+        }
+        MergeConflict::DuplicateGenerator { name, existing, incoming } => {
+            SchemaError::DuplicateAcrossFiles {
+                kind: "generator",
+                name: name.to_string(),
+                first: existing,
+                second: incoming,
+            }
+        }
+        MergeConflict::DuplicateRawSql { name, existing, incoming } => {
+            SchemaError::DuplicateAcrossFiles {
+                kind: "rawSql",
+                name: name.to_string(),
+                first: existing,
+                second: incoming,
+            }
+        }
+        MergeConflict::MultipleDatasource { existing, incoming } => {
+            SchemaError::MultipleDatasource {
+                first: existing,
+                second: incoming,
+            }
+        }
+    }
+}
+```
+
+> **If `Validator::new().validate(&mut schema)` doesn't match the existing API:** The validator today is invoked via `validate_schema(content: &str) -> SchemaResult<Schema>` which re-parses. Look at `prax-schema/src/validator.rs` to find the actual public entry. If only the string-form exists, add a sibling `pub fn validate_ast(schema: &mut Schema) -> SchemaResult<()>` that runs the existing validation logic on an already-parsed schema, and call it here.
+
+- [ ] **Step 2: Re-export load/LoadedSchema/LoadError**
+
+In `prax-schema/src/loader/mod.rs` (existing re-exports section):
+
+```rust
+pub use merge::MergeConflict;
+pub use source::{SourceFile, SourceId, SourceLoc, SourceMap};
+```
+
+…stays. Then `load`, `LoadedSchema`, `LoadError` are already public from the same file.
+
+In `prax-schema/src/lib.rs`, append to existing re-exports:
+
+```rust
+pub use loader::{LoadedSchema, LoadError, MergeConflict, load};
+```
+
+- [ ] **Step 3: Compile**
+
+Run: `cargo build -p prax-schema`
+Expected: clean. May need the `validate_ast` shim mentioned above.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add prax-schema/src/loader/mod.rs prax-schema/src/lib.rs prax-schema/src/validator.rs
+git commit -m "feat(schema): add load() entry point for single-file or directory schemas"
+```
+
+---
+
+### Task 9: Loader integration test — happy path
+
+**Files:**
+- Create: `prax-schema/tests/multi_file_loader.rs`
+- Create: `prax-schema/tests/fixtures/multi_file/happy_path/datasource.prax`
+- Create: `prax-schema/tests/fixtures/multi_file/happy_path/models/user.prax`
+- Create: `prax-schema/tests/fixtures/multi_file/happy_path/models/post.prax`
+
+- [ ] **Step 1: Create fixture files**
+
+`prax-schema/tests/fixtures/multi_file/happy_path/datasource.prax`:
+
+```
+datasource db {
+    provider = "postgresql"
+    url = "postgres://localhost/test"
+}
+
+generator client {
+    provider = "prax-client"
+}
+```
+
+`prax-schema/tests/fixtures/multi_file/happy_path/models/user.prax`:
+
+```
+model User {
+    id    Int    @id @auto
+    email String @unique
+    posts Post[]
+}
+```
+
+`prax-schema/tests/fixtures/multi_file/happy_path/models/post.prax`:
+
+```
+model Post {
+    id        Int  @id @auto
+    title     String
+    author_id Int
+    author    User @relation(fields: [author_id], references: [id])
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+`prax-schema/tests/multi_file_loader.rs`:
+
+```rust
+use prax_schema::load;
+
+#[test]
+fn loads_directory_and_resolves_cross_file_relations() {
+    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/multi_file/happy_path");
+    let loaded = load(&path).expect("load should succeed");
+
+    assert!(loaded.schema.get_model("User").is_some());
+    assert!(loaded.schema.get_model("Post").is_some());
+    assert!(loaded.schema.datasource.is_some());
+
+    // Source map covers all three files.
+    assert_eq!(loaded.sources.len(), 3);
+
+    // Cross-file relation resolved.
+    let post = loaded.schema.get_model("Post").unwrap();
+    let author = post.fields.get("author").unwrap();
+    assert!(author.is_relation());
+}
+
+#[test]
+fn loads_single_file_unchanged() {
+    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../examples/prax/schema.prax");
+    let loaded = load(&path).expect("single-file load should work");
+    assert!(loaded.sources.len() == 1);
+    assert!(loaded.schema.models.len() >= 1);
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p prax-schema --test multi_file_loader`
+Expected: both pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add prax-schema/tests
+git commit -m "test(schema): add multi-file loader happy-path fixtures + tests"
+```
+
+---
+
+### Task 10: Loader integration test — error paths
+
+**Files:**
+- Modify: `prax-schema/tests/multi_file_loader.rs`
+- Create: `prax-schema/tests/fixtures/multi_file/duplicate_models/a.prax`
+- Create: `prax-schema/tests/fixtures/multi_file/duplicate_models/b.prax`
+- Create: `prax-schema/tests/fixtures/multi_file/two_datasources/a.prax`
+- Create: `prax-schema/tests/fixtures/multi_file/two_datasources/b.prax`
+- Create: `prax-schema/tests/fixtures/multi_file/empty/.gitkeep`
+
+- [ ] **Step 1: Create fixture files**
+
+`duplicate_models/a.prax`:
+
+```
+model User { id Int @id @auto email String }
+```
+
+`duplicate_models/b.prax`:
+
+```
+model User { id Int @id @auto name String }
+```
+
+`two_datasources/a.prax`:
+
+```
+datasource db { provider = "postgresql" url = "x" }
+```
+
+`two_datasources/b.prax`:
+
+```
+datasource db { provider = "postgresql" url = "y" }
+model X { id Int @id @auto }
+```
+
+`empty/.gitkeep`: empty file (so git preserves the directory).
+
+- [ ] **Step 2: Append tests**
+
+To `prax-schema/tests/multi_file_loader.rs`:
+
+```rust
+use prax_schema::SchemaError;
+
+#[test]
+fn duplicate_model_across_files_errors() {
+    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/multi_file/duplicate_models");
+    let err = load(&path).unwrap_err();
+    let msg = format!("{}", err.error);
+    assert!(msg.contains("duplicate model"), "got: {msg}");
+    assert!(msg.contains("User"), "got: {msg}");
+    // SourceMap has both files even on error.
+    assert_eq!(err.sources.len(), 2);
+}
+
+#[test]
+fn two_datasources_errors() {
+    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/multi_file/two_datasources");
+    let err = load(&path).unwrap_err();
+    match err.error {
+        SchemaError::MultipleDatasource { .. } => {}
+        SchemaError::ValidationFailed { errors, .. } => {
+            assert!(errors.iter().any(|e| matches!(e, SchemaError::MultipleDatasource { .. })));
+        }
+        other => panic!("expected MultipleDatasource, got {other:?}"),
+    }
+}
+
+#[test]
+fn empty_directory_errors() {
+    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/multi_file/empty");
+    let err = load(&path).unwrap_err();
+    assert!(matches!(err.error, SchemaError::EmptySchemaDirectory { .. }));
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p prax-schema --test multi_file_loader`
+Expected: 5 pass total.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add prax-schema/tests
+git commit -m "test(schema): add multi-file loader error-path fixtures + tests"
+```
+
+---
+
+## Phase 2 — `prax-cli` integration
+
+### Task 11: `schema_loader.rs` helper + `CliError::Schema` refactor
+
+**Files:**
+- Create: `prax-cli/src/schema_loader.rs`
+- Modify: `prax-cli/src/lib.rs` or `prax-cli/src/main.rs` (`pub mod schema_loader;`)
+- Modify: `prax-cli/src/error.rs`
+
+- [ ] **Step 1: Refactor CliError::Schema**
+
+Find the existing `CliError::Schema` variant in `prax-cli/src/error.rs`. Today it's likely a tuple variant `Schema(String)`. Replace with:
+
+```rust
+    Schema {
+        error: prax_schema::SchemaError,
+        sources: Option<prax_schema::SourceMap>,
+    },
+```
+
+Update its `Display` and miette impls to render via `error.report(&sources)` when `sources.is_some()` (the `report` helper lands in Task 12). For now, just print the underlying error:
+
+```rust
+    CliError::Schema { error, .. } => write!(f, "{error}"),
+```
+
+Update every existing call site that constructs `CliError::Schema(string)` — they'll exist in each command's local `parse_schema` helper. Grep:
+
+```bash
+grep -rn "CliError::Schema" prax-cli/src/
+```
+
+For now, convert each to:
+
+```rust
+CliError::Schema {
+    error: prax_schema::SchemaError::ConfigError { message: <the old string> },
+    sources: None,
+}
+```
+
+…knowing Task 12+ replaces those callsites entirely.
+
+- [ ] **Step 2: Add the loader helper**
+
+Create `prax-cli/src/schema_loader.rs`:
+
+```rust
+//! Shared schema-loading helper used by every CLI command.
+
+use std::path::{Path, PathBuf};
+
+use prax_schema::{LoadedSchema, LoadError, load};
+
+use crate::config::{Config, SCHEMA_FILE_PATH};
+use crate::error::{CliError, CliResult};
+
+/// Resolve the schema path (from `--schema` flag or config), then load it.
+///
+/// Returns `LoadedSchema` whose `sources` is non-empty whenever a file was
+/// successfully read at least partially.
+pub fn load_schema(
+    args_path: Option<&Path>,
+    config: &Config,
+) -> CliResult<LoadedSchema> {
+    let path: PathBuf = args_path
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(&config.schema.path));
+    if !path.exists() {
+        return Err(CliError::Config(format!(
+            "Schema not found: {}",
+            path.display()
+        )));
+    }
+    load(&path).map_err(|LoadError { error, sources }| CliError::Schema {
+        error,
+        sources: Some(sources),
+    })
+}
+
+/// Variant that uses the default schema path from config when no override.
+pub fn load_schema_default(config: &Config) -> CliResult<LoadedSchema> {
+    load_schema(None, config)
+}
+```
+
+- [ ] **Step 3: Wire into lib/main**
+
+In `prax-cli/src/lib.rs` (or `main.rs`, wherever modules are declared):
+
+```rust
+pub mod schema_loader;
+```
+
+- [ ] **Step 4: Compile**
+
+Run: `cargo build -p prax-orm-cli`
+Expected: clean build, possibly with warnings about unused old `parse_schema` helpers in each command (those go away next).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add prax-cli/src/schema_loader.rs prax-cli/src/error.rs prax-cli/src/lib.rs prax-cli/src/main.rs
+git commit -m "feat(cli): add schema_loader helper for multi-file aware loading"
+```
+
+---
+
+### Task 12: Add `SchemaError::report()` helper for miette rendering
+
+**Files:**
+- Modify: `prax-schema/src/error.rs`
+
+- [ ] **Step 1: Add the Report newtype**
+
+Append to `prax-schema/src/error.rs`:
+
+```rust
+use crate::loader::{SourceId, SourceMap};
+
+/// Pairs a [`SchemaError`] with a [`SourceMap`] so miette can render
+/// file-aware diagnostics. Produced by [`SchemaError::report`].
+pub struct Report<'a> {
+    pub(crate) err: &'a SchemaError,
+    pub(crate) sources: &'a SourceMap,
+}
+
+impl SchemaError {
+    /// Pair this error with a source map for miette rendering.
+    pub fn report<'a>(&'a self, sources: &'a SourceMap) -> Report<'a> {
+        Report { err: self, sources }
+    }
+}
+
+impl std::fmt::Display for Report<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.err.fmt(f)?;
+        match self.err {
+            SchemaError::DuplicateAcrossFiles { kind, name, first, second } => {
+                if let (Some(a), Some(b)) = (self.sources.path_of(first.source), self.sources.path_of(second.source)) {
+                    write!(f, "\n  first:  {} (span {}..{})", a.display(), first.span.start, first.span.end)?;
+                    write!(f, "\n  second: {} (span {}..{})", b.display(), second.span.start, second.span.end)?;
+                }
+            }
+            SchemaError::MultipleDatasource { first, second } => {
+                let _ = name_unused();
+                if let (Some(a), Some(b)) = (self.sources.path_of(first.source), self.sources.path_of(second.source)) {
+                    write!(f, "\n  first:  {}", a.display())?;
+                    write!(f, "\n  second: {}", b.display())?;
+                }
+            }
+            SchemaError::ParseInFile { source, inner } => {
+                if let Some(p) = self.sources.path_of(*source) {
+                    write!(f, "\n  in file: {}", p.display())?;
+                }
+                write!(f, "\n  detail: {inner}")?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for Report<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self, f)
+    }
+}
+
+impl std::error::Error for Report<'_> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.err)
+    }
+}
+
+// Helper to keep the compiler happy in unused-binding match arms.
+fn name_unused() {}
+```
+
+> **Note:** A proper `miette::Diagnostic` impl with `source_code()` + labeled spans is a follow-up. For now, this `Display`-based renderer prints clear file paths for every multi-file error, which is the user-facing requirement. Migration to full miette spans goes in a later PR.
+
+- [ ] **Step 2: Wire CliError::Schema Display**
+
+In `prax-cli/src/error.rs`, update the `Schema { error, sources }` Display arm:
+
+```rust
+CliError::Schema { error, sources } => match sources {
+    Some(map) => write!(f, "{}", error.report(map)),
+    None => write!(f, "{error}"),
+},
+```
+
+- [ ] **Step 3: Test**
+
+Add to `prax-schema/src/error.rs` test module:
+
+```rust
+#[test]
+fn report_prints_file_paths_for_duplicate() {
+    use crate::loader::{SourceId, SourceLoc, SourceMap};
+    use crate::ast::Span;
+
+    let mut sources = SourceMap::new();
+    sources.insert("/tmp/a.prax", "x");
+    sources.insert("/tmp/b.prax", "y");
+
+    let err = SchemaError::DuplicateAcrossFiles {
+        kind: "model",
+        name: "User".into(),
+        first: SourceLoc::new(SourceId(0), Span::new(0, 5)),
+        second: SourceLoc::new(SourceId(1), Span::new(0, 5)),
+    };
+    let rendered = format!("{}", err.report(&sources));
+    assert!(rendered.contains("/tmp/a.prax"));
+    assert!(rendered.contains("/tmp/b.prax"));
+}
+```
+
+Run: `cargo test -p prax-schema report_prints_file_paths_for_duplicate`
+Expected: pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add prax-schema/src/error.rs prax-cli/src/error.rs
+git commit -m "feat(schema): add SchemaError::report for source-aware rendering"
+```
+
+---
+
+### Task 13: Wire `prax-cli/src/commands/generate.rs` to the loader
+
+**Files:**
+- Modify: `prax-cli/src/commands/generate.rs`
+
+- [ ] **Step 1: Replace the local schema-loading block**
+
+In `prax-cli/src/commands/generate.rs`, find the existing schema-loading code (around lines 25–56). It currently:
+
+```rust
+let schema_path = args.schema.clone().unwrap_or_else(|| cwd.join(SCHEMA_FILE_PATH));
+if !schema_path.exists() { /* err */ }
+let schema_content = std::fs::read_to_string(&schema_path)?;
+let schema = parse_schema(&schema_content)?;
+```
+
+Replace with:
+
+```rust
+use crate::schema_loader::load_schema;
+
+// ...
+
+let loaded = load_schema(args.schema.as_deref(), &config)?;
+let schema = &loaded.schema;
+```
+
+Update `generate_code(schema, ...)` call to pass `&loaded.schema`. Remove the local `fn parse_schema(content: &str) -> CliResult<Schema>` helper at the bottom of the file (lines ~91–97) and the no-op `fn validate_schema`.
+
+- [ ] **Step 2: Output a schema path log line that works for both modes**
+
+Where `output::kv("Schema", &schema_path.display().to_string())` is called, replace with:
+
+```rust
+let display_path = args.schema.as_deref()
+    .map(|p| p.display().to_string())
+    .unwrap_or_else(|| config.schema.path.clone());
+output::kv("Schema", &display_path);
+if loaded.sources.len() > 1 {
+    output::kv("Source files", &loaded.sources.len().to_string());
+}
+```
+
+- [ ] **Step 3: Build and run existing tests**
+
+Run: `cargo build -p prax-orm-cli && cargo test -p prax-orm-cli`
+Expected: existing CLI tests pass (they use single-file schemas, which still work).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add prax-cli/src/commands/generate.rs
+git commit -m "refactor(cli): route generate through prax_schema::load"
+```
+
+---
+
+### Task 14: Wire migrate, validate, db through the loader
+
+**Files:**
+- Modify: `prax-cli/src/commands/migrate.rs`
+- Modify: `prax-cli/src/commands/validate.rs`
+- Modify: `prax-cli/src/commands/db.rs`
+
+Apply the same pattern as Task 13 to each command:
+
+- [ ] **Step 1: migrate.rs — both call sites**
+
+`prax-cli/src/commands/migrate.rs` has two schema reads (line ~48 and line ~328). Replace each:
+
+```rust
+let loaded = crate::schema_loader::load_schema(args.schema.as_deref(), &config)?;
+let schema = &loaded.schema;
+```
+
+Delete the bottom local `fn parse_schema(content: &str) -> CliResult<Schema>` (around line 442).
+
+- [ ] **Step 2: validate.rs**
+
+`prax-cli/src/commands/validate.rs:28`: same replacement. Delete local helper at line ~109.
+
+- [ ] **Step 3: db.rs**
+
+`prax-cli/src/commands/db.rs:46`: same replacement. Delete local helper at line ~373.
+
+- [ ] **Step 4: Compile + test**
+
+Run: `cargo build -p prax-orm-cli && cargo test -p prax-orm-cli`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add prax-cli/src/commands
+git commit -m "refactor(cli): route migrate/validate/db through prax_schema::load"
+```
+
+---
+
+### Task 15: `prax format` — per-file directory handling
+
+**Files:**
+- Modify: `prax-cli/src/commands/format.rs`
+
+- [ ] **Step 1: Replace single-file body with branching logic**
+
+`prax-cli/src/commands/format.rs` today reads one file, parses it, reformats, writes it. Refactor:
+
+```rust
+use std::path::Path;
+use prax_schema::parse_schema;
+use prax_schema::loader::discovery::discover;
+
+pub async fn run(args: FormatArgs) -> CliResult<()> {
+    let path = resolve_path(&args);   // existing logic for resolving --schema
+    if path.is_file() {
+        format_one(&path)?;
+    } else if path.is_dir() {
+        let files = discover(&path).map_err(|e| CliError::Schema { error: e, sources: None })?;
+        if files.is_empty() {
+            return Err(CliError::Config(format!(
+                "No .prax files found in {}",
+                path.display()
+            )));
+        }
+        for f in files {
+            format_one(&f.absolute)?;
+        }
+    } else {
+        return Err(CliError::Config(format!(
+            "Schema path not found: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn format_one(path: &Path) -> CliResult<()> {
+    let content = std::fs::read_to_string(path)?;
+    let schema = parse_schema(&content).map_err(|e| CliError::Schema {
+        error: e,
+        sources: None,
+    })?;
+    let formatted = format_schema_text(&schema);   // existing renderer
+    std::fs::write(path, formatted)?;
+    output::success(&format!("Formatted {}", path.display()));
+    Ok(())
+}
+```
+
+> **Why per-file (not merged):** Formatting is purely syntactic. Merging would require a way to re-split the formatted output back into the source files, which is not how `format_schema_text` works. Per-file is correct, simpler, and preserves the user's organization. Add a `//` comment in the code explaining this.
+
+- [ ] **Step 2: Re-export discovery::discover from prax-schema**
+
+The format command needs `prax_schema::loader::discovery::discover` to be public. In `prax-schema/src/loader/mod.rs`:
+
+```rust
+pub mod discovery;
+```
+
+is already there from Task 7. Verify `pub fn discover` in `discovery.rs` — should already be `pub`. The `crate::loader::discovery::discover` path should already work from outside the crate as `prax_schema::loader::discovery::discover` (verify with `cargo doc -p prax-schema --open`).
+
+- [ ] **Step 3: Build + run existing format tests**
+
+Run: `cargo build -p prax-orm-cli`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add prax-cli/src/commands/format.rs
+git commit -m "feat(cli): format walks directory schemas per-file"
+```
+
+---
+
+### Task 16: `prax init --multi-file` flag
+
+**Files:**
+- Modify: `prax-cli/src/cli.rs` (or wherever `InitArgs` lives)
+- Modify: `prax-cli/src/commands/init.rs`
+
+- [ ] **Step 1: Add flag to InitArgs**
+
+Find `InitArgs` (likely in `prax-cli/src/cli.rs`). Add:
+
+```rust
+    /// Scaffold a multi-file schema directory (./prax/schema/) instead of a single schema.prax.
+    #[arg(long)]
+    pub multi_file: bool,
+```
+
+- [ ] **Step 2: Branch in init::run**
+
+In `prax-cli/src/commands/init.rs`, find the schema-writing block. Today it writes one file `schema.prax`. Add:
+
+```rust
+if args.multi_file {
+    let root = cwd.join("prax/schema");
+    std::fs::create_dir_all(root.join("models"))?;
+
+    std::fs::write(
+        root.join("datasource.prax"),
+        DATASOURCE_TEMPLATE,
+    )?;
+    std::fs::write(
+        root.join("models/example.prax"),
+        EXAMPLE_MODEL_TEMPLATE,
+    )?;
+
+    // Update prax.toml's [schema].path to point at the directory.
+    let config_path = cwd.join(CONFIG_FILE_NAME);
+    let mut config = Config::default();
+    config.schema.path = "prax/schema".to_string();
+    let toml = toml::to_string(&config).unwrap();
+    std::fs::write(&config_path, toml)?;
+
+    output::success("Scaffolded multi-file schema at ./prax/schema/");
+} else {
+    // ... existing single-file path ...
+}
+```
+
+With templates split out:
+
+```rust
+const DATASOURCE_TEMPLATE: &str = r#"datasource db {
+    provider = "postgresql"
+    url = env("DATABASE_URL")
+}
+
+generator client {
+    provider = "prax-client"
+    output   = "./src/generated"
+}
+"#;
+
+const EXAMPLE_MODEL_TEMPLATE: &str = r#"/// Example model — replace me.
+model Example {
+    id    Int    @id @auto
+    name  String
+}
+"#;
+```
+
+- [ ] **Step 3: Add CLI integration test**
+
+In `prax-cli/tests/cli_tests.rs` add:
+
+```rust
+#[test]
+fn init_multi_file_creates_directory_layout() {
+    let tmp = tempfile::tempdir().unwrap();
+    let status = std::process::Command::new(env!("CARGO_BIN_EXE_prax"))
+        .arg("init")
+        .arg("--multi-file")
+        .current_dir(tmp.path())
+        .status()
+        .unwrap();
+    assert!(status.success());
+    assert!(tmp.path().join("prax/schema/datasource.prax").exists());
+    assert!(tmp.path().join("prax/schema/models/example.prax").exists());
+    assert!(tmp.path().join("prax.toml").exists());
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p prax-orm-cli --test cli_tests init_multi_file_creates_directory_layout`
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add prax-cli/src
+git commit -m "feat(cli): add --multi-file flag to prax init"
+```
+
+---
+
+### Task 17: CLI integration tests for multi-file generate / validate
+
+**Files:**
+- Modify: `prax-cli/tests/cli_tests.rs`
+- Create: `prax-cli/tests/fixtures/multi_file_basic/schema/datasource.prax`
+- Create: `prax-cli/tests/fixtures/multi_file_basic/schema/models/user.prax`
+- Create: `prax-cli/tests/fixtures/multi_file_basic/schema/models/post.prax`
+- Create: `prax-cli/tests/fixtures/multi_file_basic/prax.toml`
+
+- [ ] **Step 1: Create fixture**
+
+`prax-cli/tests/fixtures/multi_file_basic/prax.toml`:
+
+```toml
+[database]
+provider = "postgresql"
+url = "postgres://localhost/test"
+
+[schema]
+path = "schema"
+
+[generator.client]
+output = "./generated"
+```
+
+`schema/datasource.prax`:
+
+```
+datasource db {
+    provider = "postgresql"
+    url = "postgres://localhost/test"
+}
+
+generator client {
+    provider = "prax-client"
+}
+```
+
+`schema/models/user.prax`:
+
+```
+model User {
+    id    Int    @id @auto
+    email String @unique
+    posts Post[]
+}
+```
+
+`schema/models/post.prax`:
+
+```
+model Post {
+    id        Int    @id @auto
+    title     String
+    author_id Int
+    author    User   @relation(fields: [author_id], references: [id])
+}
+```
+
+- [ ] **Step 2: Add tests**
+
+In `prax-cli/tests/cli_tests.rs`:
+
+```rust
+#[test]
+fn validate_works_on_directory_schema() {
+    let fixture = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/multi_file_basic");
+    let status = std::process::Command::new(env!("CARGO_BIN_EXE_prax"))
+        .arg("validate")
+        .current_dir(&fixture)
+        .status()
+        .unwrap();
+    assert!(status.success());
+}
+
+#[test]
+fn generate_works_on_directory_schema() {
+    let fixture = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/multi_file_basic");
+    // Generate into a temp output dir so we don't pollute the fixture.
+    let out = tempfile::tempdir().unwrap();
+    let status = std::process::Command::new(env!("CARGO_BIN_EXE_prax"))
+        .arg("generate")
+        .arg("--output")
+        .arg(out.path())
+        .current_dir(&fixture)
+        .status()
+        .unwrap();
+    assert!(status.success());
+    // At minimum, the client module should exist.
+    assert!(out.path().join("mod.rs").exists() || out.path().join("lib.rs").exists());
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p prax-orm-cli --test cli_tests validate_works_on_directory_schema generate_works_on_directory_schema`
+Expected: both pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add prax-cli/tests
+git commit -m "test(cli): add directory-schema integration tests for validate + generate"
+```
+
+---
+
+## Phase 3 — `prax-codegen` integration
+
+### Task 18: Route `schema_reader::read_and_parse_schema` through `load`
+
+**Files:**
+- Modify: `prax-codegen/src/schema_reader.rs`
+
+- [ ] **Step 1: Update the function**
+
+In `prax-codegen/src/schema_reader.rs:18`:
+
+```rust
+pub fn read_and_parse_schema(path: &str) -> Result<Schema, SchemaReadError> {
+    let loaded = prax_schema::load(path).map_err(|e| {
+        // SchemaReadError today wraps a string — keep that shape, format the
+        // loader error with its source map for path-aware messages.
+        SchemaReadError::ParseError(format!("{}", e.error.report(&e.sources)))
+    })?;
+    Ok(loaded.schema)
+}
+```
+
+- [ ] **Step 2: Existing tests cover single-file path**
+
+Run: `cargo test -p prax-codegen`
+Expected: existing tests still pass (single-file path is preserved).
+
+- [ ] **Step 3: Add a multi-file test**
+
+In `prax-codegen/src/schema_reader.rs` test module, add:
+
+```rust
+#[test]
+fn reads_directory_schema() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("ds.prax"),
+        r#"datasource db { provider = "postgresql" url = "x" }"#,
+    ).unwrap();
+    std::fs::write(
+        dir.path().join("user.prax"),
+        "model User { id Int @id @auto }",
+    ).unwrap();
+    let schema = read_and_parse_schema(dir.path().to_str().unwrap()).unwrap();
+    assert!(schema.get_model("User").is_some());
+    assert!(schema.datasource.is_some());
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cargo test -p prax-codegen schema_reader`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add prax-codegen/src/schema_reader.rs
+git commit -m "refactor(codegen): route schema reader through prax_schema::load"
+```
+
+---
+
+## Phase 4 — Prisma multi-file import
+
+### Task 19: Add `PrismaSourceId` provenance to `PrismaSchema`
+
+**Files:**
+- Modify: `prax-import/src/prisma/types.rs`
+
+- [ ] **Step 1: Add type**
+
+In `prax-import/src/prisma/types.rs` at the top:
+
+```rust
+/// Opaque identifier for a `.prisma` source file when importing multi-file
+/// Prisma schemas. Parallel to (but deliberately distinct from)
+/// `prax_schema::SourceId`.
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Ord, PartialOrd)]
+pub struct PrismaSourceId(pub u32);
+```
+
+Add an `Option<PrismaSourceId>` field to `PrismaModel`, `PrismaEnum`, `PrismaDatasource`, and `PrismaGenerator` (or whatever they're called — grep `pub struct Prisma` in the file). Same shape:
+
+```rust
+    pub source_id: Option<PrismaSourceId>,
+```
+
+Default for these structs already exists; the new `Option` field defaults to `None`. Single-file existing path needs no changes.
+
+- [ ] **Step 2: Compile**
+
+Run: `cargo build -p prax-import`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add prax-import/src/prisma/types.rs
+git commit -m "feat(import): add PrismaSourceId provenance to Prisma AST"
+```
+
+---
+
+### Task 20: Multi-file Prisma parse + merge
+
+**Files:**
+- Create: `prax-import/src/prisma/multi_file.rs`
+- Modify: `prax-import/src/prisma/mod.rs`
+
+- [ ] **Step 1: Define the multi-file loader**
+
+Create `prax-import/src/prisma/multi_file.rs`:
+
+```rust
+//! Multi-file Prisma schema discovery, parse, and merge.
+
+use std::path::{Path, PathBuf};
+
+use walkdir::WalkDir;
+
+use super::parser::parse_prisma_schema;
+use super::types::{PrismaSchema, PrismaSourceId};
+use crate::error::{ImportError, ImportResult};
+
+#[derive(Debug, Clone)]
+pub struct PrismaFile {
+    pub absolute: PathBuf,
+    pub relative: PathBuf,
+}
+
+#[derive(Debug, Default)]
+pub struct PrismaSourceMap {
+    files: Vec<PrismaFile>,
+}
+
+impl PrismaSourceMap {
+    pub fn get(&self, id: PrismaSourceId) -> Option<&PrismaFile> {
+        self.files.get(id.0 as usize)
+    }
+    pub fn iter(&self) -> impl Iterator<Item = (PrismaSourceId, &PrismaFile)> {
+        self.files
+            .iter()
+            .enumerate()
+            .map(|(i, f)| (PrismaSourceId(i as u32), f))
+    }
+    pub fn len(&self) -> usize { self.files.len() }
+    pub fn is_empty(&self) -> bool { self.files.is_empty() }
+}
+
+/// Discover all `*.prisma` files under `root`, sorted by relative path.
+pub fn discover_prisma(root: &Path) -> ImportResult<Vec<PrismaFile>> {
+    let canonical = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    let mut out = Vec::new();
+    for entry in WalkDir::new(&canonical)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|e| !is_skipped(e))
+    {
+        let entry = entry.map_err(|e| ImportError::Io {
+            message: format!("{e}"),
+        })?;
+        if !entry.file_type().is_file() { continue; }
+        if entry.path().extension().and_then(|s| s.to_str()) != Some("prisma") { continue; }
+        let relative = entry
+            .path()
+            .strip_prefix(&canonical)
+            .unwrap_or(entry.path())
+            .to_path_buf();
+        out.push(PrismaFile {
+            absolute: entry.path().to_path_buf(),
+            relative,
+        });
+    }
+    out.sort_by(|a, b| a.relative.cmp(&b.relative));
+    Ok(out)
+}
+
+fn is_skipped(entry: &walkdir::DirEntry) -> bool {
+    if entry.depth() == 0 { return false; }
+    if let Some(name) = entry.file_name().to_str() {
+        if name.starts_with('.') { return true; }
+        if entry.file_type().is_dir() && name == "node_modules" { return true; }
+    }
+    if entry.file_type().is_symlink() { return true; }
+    false
+}
+
+/// Parse every `.prisma` file under `root`, stamp source provenance,
+/// and merge into one `PrismaSchema`.
+pub fn parse_and_merge_directory(root: &Path) -> ImportResult<(PrismaSchema, PrismaSourceMap)> {
+    let files = discover_prisma(root)?;
+    if files.is_empty() {
+        return Err(ImportError::Io {
+            message: format!("no .prisma files found under {}", root.display()),
+        });
+    }
+
+    let mut sources = PrismaSourceMap { files: files.clone() };
+    let mut merged = PrismaSchema::default();
+
+    for (idx, f) in files.iter().enumerate() {
+        let sid = PrismaSourceId(idx as u32);
+        let content = std::fs::read_to_string(&f.absolute).map_err(|e| ImportError::Io {
+            message: format!("read {}: {e}", f.absolute.display()),
+        })?;
+        let mut per_file = parse_prisma_schema(&content)?;
+        stamp_prisma(&mut per_file, sid);
+        try_merge_prisma(&mut merged, per_file, sid)?;
+    }
+
+    Ok((merged, sources))
+}
+
+fn stamp_prisma(s: &mut PrismaSchema, sid: PrismaSourceId) {
+    for m in &mut s.models { m.source_id = Some(sid); }
+    for e in &mut s.enums { e.source_id = Some(sid); }
+    if let Some(ds) = &mut s.datasource { ds.source_id = Some(sid); }
+    for g in &mut s.generators { g.source_id = Some(sid); }
+}
+
+fn try_merge_prisma(
+    into: &mut PrismaSchema,
+    other: PrismaSchema,
+    incoming_sid: PrismaSourceId,
+) -> ImportResult<()> {
+    for m in other.models {
+        if let Some(existing) = into.models.iter().find(|x| x.name == m.name) {
+            return Err(ImportError::DuplicateModel {
+                name: m.name.clone(),
+                first: existing.source_id.unwrap_or(PrismaSourceId(0)),
+                second: incoming_sid,
+            });
+        }
+        into.models.push(m);
+    }
+    for e in other.enums {
+        if let Some(existing) = into.enums.iter().find(|x| x.name == e.name) {
+            return Err(ImportError::DuplicateEnum {
+                name: e.name.clone(),
+                first: existing.source_id.unwrap_or(PrismaSourceId(0)),
+                second: incoming_sid,
+            });
+        }
+        into.enums.push(e);
+    }
+    if let Some(incoming) = other.datasource {
+        if let Some(existing) = &into.datasource {
+            return Err(ImportError::MultipleDatasource {
+                first: existing.source_id.unwrap_or(PrismaSourceId(0)),
+                second: incoming_sid,
+            });
+        }
+        into.datasource = Some(incoming);
+    }
+    for g in other.generators {
+        if let Some(existing) = into.generators.iter().find(|x| x.name == g.name) {
+            return Err(ImportError::DuplicateGenerator {
+                name: g.name.clone(),
+                first: existing.source_id.unwrap_or(PrismaSourceId(0)),
+                second: incoming_sid,
+            });
+        }
+        into.generators.push(g);
+    }
+    Ok(())
+}
+```
+
+> **Note on `ImportError`:** the new variants (`DuplicateModel`, `DuplicateEnum`, `MultipleDatasource`, `DuplicateGenerator`, `Io`) need to exist on the type. Add them in `prax-import/src/error.rs` if they don't already.
+
+- [ ] **Step 2: Add the new ImportError variants**
+
+In `prax-import/src/error.rs`, add to the `ImportError` enum:
+
+```rust
+    #[error("duplicate prisma model `{name}` across files")]
+    DuplicateModel { name: String, first: crate::prisma::types::PrismaSourceId, second: crate::prisma::types::PrismaSourceId },
+
+    #[error("duplicate prisma enum `{name}` across files")]
+    DuplicateEnum { name: String, first: crate::prisma::types::PrismaSourceId, second: crate::prisma::types::PrismaSourceId },
+
+    #[error("multiple datasource blocks across prisma files")]
+    MultipleDatasource { first: crate::prisma::types::PrismaSourceId, second: crate::prisma::types::PrismaSourceId },
+
+    #[error("duplicate prisma generator `{name}` across files")]
+    DuplicateGenerator { name: String, first: crate::prisma::types::PrismaSourceId, second: crate::prisma::types::PrismaSourceId },
+
+    #[error("i/o error: {message}")]
+    Io { message: String },
+```
+
+- [ ] **Step 3: Wire into the prisma module**
+
+In `prax-import/src/prisma/mod.rs`:
+
+```rust
+pub mod multi_file;
+pub use multi_file::{discover_prisma, parse_and_merge_directory, PrismaFile, PrismaSourceMap};
+```
+
+Add `walkdir = { workspace = true }` to `prax-import/Cargo.toml`.
+
+- [ ] **Step 4: Test**
+
+Create `prax-import/tests/multi_file_prisma.rs`:
+
+```rust
+use prax_import::prisma::parse_and_merge_directory;
+
+#[test]
+fn parses_and_merges_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("a.prisma"),
+        r#"
+        datasource db { provider = "postgresql" url = env("X") }
+        model A { id Int @id @default(autoincrement()) }
+        "#,
+    ).unwrap();
+    std::fs::write(
+        dir.path().join("b.prisma"),
+        "model B { id Int @id @default(autoincrement()) }",
+    ).unwrap();
+
+    let (merged, sources) = parse_and_merge_directory(dir.path()).unwrap();
+    assert_eq!(merged.models.len(), 2);
+    assert!(merged.datasource.is_some());
+    assert_eq!(sources.len(), 2);
+}
+
+#[test]
+fn duplicate_models_error() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("a.prisma"),
+        "model X { id Int @id @default(autoincrement()) }",
+    ).unwrap();
+    std::fs::write(
+        dir.path().join("b.prisma"),
+        "model X { id Int @id @default(autoincrement()) }",
+    ).unwrap();
+
+    let err = parse_and_merge_directory(dir.path()).unwrap_err();
+    let msg = format!("{err}");
+    assert!(msg.contains("duplicate") && msg.contains("X"));
+}
+```
+
+Run: `cargo test -p prax-import --test multi_file_prisma`
+Expected: 2 pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add prax-import prax-import/Cargo.toml
+git commit -m "feat(import): add multi-file Prisma parse + merge"
+```
+
+---
+
+### Task 21: Multi-file Prisma → Prax conversion + emission
+
+**Files:**
+- Modify: `prax-import/src/prisma/parser.rs` (or a new `convert.rs`)
+- Modify: `prax-import/src/lib.rs` (re-exports)
+
+- [ ] **Step 1: Add the conversion + emit function**
+
+In `prax-import/src/prisma/parser.rs` (or a new sibling module), add:
+
+```rust
+use std::path::{Path, PathBuf};
+use super::multi_file::{parse_and_merge_directory, PrismaFile, PrismaSourceMap};
+use super::types::{PrismaSchema, PrismaSourceId};
+
+/// Convert a directory of `.prisma` files to a directory of `.prax` files,
+/// mirroring the input layout.
+///
+/// `format_text` is the function that turns a per-file `prax Schema` back into
+/// `.prax` source text (the CLI's existing `format_schema`).
+pub fn import_prisma_directory<F>(
+    input: &Path,
+    output: &Path,
+    format_text: F,
+    force: bool,
+) -> ImportResult<usize>
+where
+    F: Fn(&crate::Schema) -> String,
+{
+    let (merged_prisma, sources) = parse_and_merge_directory(input)?;
+    let merged_prax = convert_prisma_to_prax(merged_prisma.clone())?;
+
+    // Bucket prax items by their PrismaSourceId (carried through via the
+    // converter — see Step 2).
+    let mut buckets: std::collections::HashMap<PrismaSourceId, crate::Schema> = Default::default();
+    bucket_prax_items(&merged_prax, &mut buckets);
+
+    // Pre-flight: check output dir
+    if output.exists() {
+        let is_empty = output.read_dir().map(|mut d| d.next().is_none()).unwrap_or(true);
+        if !is_empty && !force {
+            return Err(ImportError::Io {
+                message: format!(
+                    "output directory {} is not empty (pass --force to overwrite)",
+                    output.display()
+                ),
+            });
+        }
+    }
+    std::fs::create_dir_all(output).map_err(|e| ImportError::Io {
+        message: format!("create {}: {e}", output.display()),
+    })?;
+
+    let mut emitted = 0usize;
+    for (sid, prax_for_file) in &buckets {
+        // Empty bucket = source had only comments, no declarations. Skip.
+        if prax_for_file.models.is_empty()
+            && prax_for_file.enums.is_empty()
+            && prax_for_file.datasource.is_none()
+            && prax_for_file.generators.is_empty()
+        {
+            continue;
+        }
+
+        let file = sources.get(*sid).expect("source map covers all stamped ids");
+        let mut out_path = output.join(&file.relative);
+        out_path.set_extension("prax");
+
+        if let Some(parent) = out_path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| ImportError::Io {
+                message: format!("create {}: {e}", parent.display()),
+            })?;
+        }
+
+        let text = format_text(prax_for_file);
+        std::fs::write(&out_path, text).map_err(|e| ImportError::Io {
+            message: format!("write {}: {e}", out_path.display()),
+        })?;
+        emitted += 1;
+    }
+    Ok(emitted)
+}
+
+fn bucket_prax_items(
+    merged: &crate::Schema,
+    out: &mut std::collections::HashMap<PrismaSourceId, crate::Schema>,
+) {
+    // Models and enums in the merged prax::Schema have `source_id: Option<prax_schema::SourceId>`,
+    // NOT PrismaSourceId. The converter (Step 2) must translate Prisma source IDs
+    // through to prax source IDs in a 1:1 mapping (PrismaSourceId(n) → SourceId(n)).
+    use prax_schema::SourceId as PraxSourceId;
+    for (name, m) in &merged.models {
+        let sid = PrismaSourceId(m.source_id.unwrap_or(PraxSourceId(0)).0);
+        out.entry(sid).or_insert_with(crate::Schema::new).add_model(m.clone());
+    }
+    for (name, e) in &merged.enums {
+        let sid = PrismaSourceId(e.source_id.unwrap_or(PraxSourceId(0)).0);
+        out.entry(sid).or_insert_with(crate::Schema::new).add_enum(e.clone());
+    }
+    if let Some(ds) = &merged.datasource {
+        let sid = PrismaSourceId(ds.source_id.unwrap_or(PraxSourceId(0)).0);
+        out.entry(sid).or_insert_with(crate::Schema::new).set_datasource(ds.clone());
+    }
+    for (name, g) in &merged.generators {
+        let sid = PrismaSourceId(g.source_id.unwrap_or(PraxSourceId(0)).0);
+        out.entry(sid).or_insert_with(crate::Schema::new).add_generator(g.clone());
+    }
+}
+```
+
+- [ ] **Step 2: Wire source IDs through `convert_prisma_to_prax`**
+
+`convert_prisma_to_prax` (in `prax-import/src/prisma/parser.rs:524`) takes a `PrismaSchema`, returns a prax `Schema`. We need each output item to carry its originating `PrismaSourceId` (translated to `prax_schema::SourceId(same_number)`).
+
+In `convert_model`, after constructing the prax `Model`, add:
+
+```rust
+    if let Some(pid) = prisma_model.source_id {
+        model.source_id = Some(prax_schema::SourceId(pid.0));
+    }
+```
+
+Same for `convert_enum`, datasource, generators.
+
+- [ ] **Step 3: Test the full multi-file round-trip**
+
+Append to `prax-import/tests/multi_file_prisma.rs`:
+
+```rust
+use prax_import::prisma::import_prisma_directory;
+use prax_import::format_schema;   // re-exported from prax-import (or wherever the renderer lives)
+
+#[test]
+fn directory_round_trip_mirrors_layout() {
+    let input = tempfile::tempdir().unwrap();
+    let output = tempfile::tempdir().unwrap();
+
+    std::fs::create_dir_all(input.path().join("models")).unwrap();
+    std::fs::write(
+        input.path().join("schema.prisma"),
+        r#"
+        datasource db { provider = "postgresql" url = env("DB") }
+        generator client { provider = "prisma-client-js" }
+        "#,
+    ).unwrap();
+    std::fs::write(
+        input.path().join("models/user.prisma"),
+        "model User { id Int @id @default(autoincrement()) email String @unique }",
+    ).unwrap();
+    std::fs::write(
+        input.path().join("models/post.prisma"),
+        "model Post { id Int @id @default(autoincrement()) author_id Int author User @relation(fields: [author_id], references: [id]) }",
+    ).unwrap();
+
+    let count = import_prisma_directory(input.path(), output.path(), format_schema, false).unwrap();
+    assert_eq!(count, 3);
+    assert!(output.path().join("schema.prax").exists());
+    assert!(output.path().join("models/user.prax").exists());
+    assert!(output.path().join("models/post.prax").exists());
+
+    // The output should now load cleanly with prax_schema::load.
+    let loaded = prax_schema::load(output.path()).expect("output loads cleanly");
+    assert!(loaded.schema.get_model("User").is_some());
+    assert!(loaded.schema.get_model("Post").is_some());
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cargo test -p prax-import --test multi_file_prisma`
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add prax-import/src
+git commit -m "feat(import): emit multi-file Prax mirroring Prisma directory layouts"
+```
+
+---
+
+### Task 22: CLI `prax import` auto-detects directory inputs
+
+**Files:**
+- Modify: `prax-cli/src/commands/import.rs`
+
+- [ ] **Step 1: Branch on input type**
+
+In `prax-cli/src/commands/import.rs:run`, after the input-exists check, add:
+
+```rust
+let input_is_dir = args.input.is_dir();
+if input_is_dir && args.from != ImportSource::Prisma {
+    return Err(CliError::Config(
+        "Directory inputs are only supported for --from prisma".to_string(),
+    ));
+}
+
+if input_is_dir {
+    // Multi-file mode.
+    let output_dir = args.output.clone().unwrap_or_else(|| std::path::PathBuf::from("./prax/schema"));
+    let count = prax_import::prisma::import_prisma_directory(
+        &args.input,
+        &output_dir,
+        format_schema,
+        args.force,
+    )
+    .map_err(|e| CliError::Config(format!("Import failed: {e}")))?;
+    output::success(&format!("✓ Imported {count} files into {}", output_dir.display()));
+    return Ok(());
+}
+
+// Single-file path falls through to existing code.
+```
+
+- [ ] **Step 2: CLI integration test**
+
+In `prax-cli/tests/cli_tests.rs`:
+
+```rust
+#[test]
+fn import_prisma_directory_creates_mirrored_prax_directory() {
+    let input = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(input.path().join("models")).unwrap();
+    std::fs::write(
+        input.path().join("schema.prisma"),
+        r#"datasource db { provider = "postgresql" url = env("X") } generator client { provider = "prisma-client-js" }"#,
+    ).unwrap();
+    std::fs::write(
+        input.path().join("models/u.prisma"),
+        "model U { id Int @id @default(autoincrement()) }",
+    ).unwrap();
+    let output = tempfile::tempdir().unwrap();
+    let status = std::process::Command::new(env!("CARGO_BIN_EXE_prax"))
+        .arg("import")
+        .arg("--from").arg("prisma")
+        .arg("--input").arg(input.path())
+        .arg("--output").arg(output.path())
+        .arg("--force")
+        .status()
+        .unwrap();
+    assert!(status.success());
+    assert!(output.path().join("schema.prax").exists());
+    assert!(output.path().join("models/u.prax").exists());
+}
+```
+
+- [ ] **Step 3: Run**
+
+Run: `cargo test -p prax-orm-cli --test cli_tests import_prisma_directory_creates_mirrored_prax_directory`
+Expected: pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add prax-cli/src/commands/import.rs prax-cli/tests/cli_tests.rs
+git commit -m "feat(cli): import auto-detects Prisma directory inputs"
+```
+
+---
+
+## Wrap-up
+
+### Task 23: Update example, README, CHANGELOG
+
+**Files:**
+- Modify: `examples/prax/` (add a multi-file variant)
+- Modify: `README.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add multi-file example**
+
+Create `examples/prax/multi_file_schema/`:
+
+```
+multi_file_schema/
+  datasource.prax        # datasource + generator
+  models/
+    user.prax
+    post.prax
+  enums/
+    role.prax
+```
+
+Content mirrors the existing `examples/prax/schema.prax` split across files. Aim for ~20-30 lines per file.
+
+- [ ] **Step 2: README note**
+
+Add a short section to `README.md` (under existing schema docs):
+
+```markdown
+## Multi-file schemas
+
+Point `[schema].path` in `prax.toml` at a directory instead of a file:
+
+```toml
+[schema]
+path = "prax/schema"
+```
+
+Prax recursively loads every `*.prax` file in that directory and merges them
+into one schema. Duplicate model/enum/type names across files are hard errors
+with both file locations reported. Run `prax init --multi-file` to scaffold
+the directory layout.
+```
+
+- [ ] **Step 3: CHANGELOG entry**
+
+Prepend to `CHANGELOG.md`:
+
+```markdown
+## [Unreleased]
+
+### Added
+- Multi-file schema support: `[schema].path` may now be a directory; `*.prax`
+  files are loaded recursively, sorted lexicographically by relative path, and
+  merged with hard-error collision detection (`SchemaError::DuplicateAcrossFiles`).
+- `prax_schema::load(path)` returns `LoadedSchema { schema, sources }` and a
+  partial source map on the error path via `LoadError`.
+- `prax init --multi-file` scaffolds `./prax/schema/` directory layout.
+- `prax import --from prisma --input <dir>` mirrors Prisma `prismaSchemaFolder`
+  layouts into a Prax directory of `.prax` files.
+
+### Deprecated
+- `Schema::merge` (silent overwrite) — use `Schema::try_merge` for collision-aware merging.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add examples README.md CHANGELOG.md
+git commit -m "docs(schema): document multi-file schemas + Prisma directory import"
+```
+
+---
+
+### Task 24: Full workspace check + final commit
+
+- [ ] **Step 1: Lint, test, format**
+
+Run in order:
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Open PR (optional, user-driven)**
+
+If the user is ready to merge, run:
+
+```bash
+gh pr create --base develop --title "feat(schema): multi-file schemas + Prisma directory import" \
+  --body-file docs/superpowers/specs/2026-05-19-multi-file-schema-design.md
+```
+
+(Or use the gh PR command in the standard PR-creation flow.)
+
+---
+
+## Self-Review Notes
+
+- All spec requirements have at least one task: discovery (Task 7), AST provenance (Tasks 3-4), merge semantics (Task 6), diagnostics (Tasks 5, 12), load entry point (Task 8), CLI integration (Tasks 11, 13-17), codegen (Task 18), importer (Tasks 19-22), backward-compat regression (covered by existing tests + Task 9 single-file case).
+- `LoadError` always carries the partial `SourceMap` — spec requirement honored end-to-end.
+- `format` is intentionally NOT routed through `load()` — per-file path, with comment in code.
+- No "TBD" / "TODO" in tasks. Two implementation notes flagged inline (Validator entry-point and HasProvenance macro arms) tell the engineer how to resolve them based on what they find in the codebase.
+
+## Open follow-ups not in this plan
+
+- Full miette `Diagnostic` impl with `source_code()` + labeled spans (current `Report` uses Display rendering). Tracked as a docs note in the spec under "Open questions deferred to the plan" — pick this up after the multi-file PR lands.
+- `prax-codegen`'s `SchemaReadError` carrying a `SourceMap` for richer proc-macro errors (currently strings).

--- a/docs/superpowers/specs/2026-05-18-typed-query-traits-design.md
+++ b/docs/superpowers/specs/2026-05-18-typed-query-traits-design.md
@@ -1,0 +1,754 @@
+# Typed Query Trait System and Prisma-Style Macro DSL
+
+- **Status**: Draft
+- **Date**: 2026-05-18
+- **Author**: Joseph R. Quinn (with Claude)
+- **Affects**: `prax-query`, `prax-codegen`, every engine crate, `prax-migrate`, `prax-schema`, the docs Angular site
+- **Builds on**: existing `Filter` / `IncludeSpec` / `CreateData` / `UpdateData` / `QueryEngine` (unchanged)
+
+## 1. Goals and non-goals
+
+### Goals
+
+- A declarative, Prisma-like macro DSL for the full operation surface of `prax-query` (`find_*`, `create`, `update`, `delete`, `upsert`, `count`, `aggregate`, `group_by`).
+- A typed trait system that codegen emits per model so the macro is a thin layer on top of inspectable, documentable structs rather than ad-hoc proc-macro output.
+- Compile-time validation of field names, operators, relation cardinality, and engine capability.
+- Composition: spread (`..base`) and conditional (`#[if(...)]`) field syntax for building queries from runtime values.
+- Full coexistence with the existing fluent builder API. Nothing breaks; nothing is deprecated in this design.
+- First-class support for computed and virtual fields (DB-generated columns and relation aggregates).
+
+### Non-goals
+
+- Generic result types parameterized by `include` shape (defer; relations stay `Option<Vec<T>>` on the model).
+- Polymorphic relations or single-table inheritance.
+- Custom raw SQL fragments inside the DSL — `raw_query!` covers that.
+- Pure-Rust computed accessors woven into WHERE clauses — out of scope; use `@generated` columns or `@aggregate` virtuals.
+- CQL (ScyllaDB / Cassandra) nested writes — explicitly compile-time blocked.
+- MongoDB-specific operators (`$exists`, `$type`, geo queries).
+- MongoDB `$lookup` lowering for aggregate virtuals — follow-up plan.
+
+## 2. Architecture — three layers
+
+### Layer 1: Runtime IR (unchanged)
+
+`prax-query`'s `Filter`, `FilterValue`, `IncludeSpec`, `OrderBy`, `Pagination`, `CreateData`, `UpdateData`, `QueryEngine`, and every operation in `prax_query::operations` stay exactly as they are. They are the canonical runtime IR consumed by the dialect/SQL builders. **Query execution does not change.**
+
+One additive change to the IR: a new `Filter::ScalarSubquery { sql: Cow<'static, str>, params: Vec<FilterValue> }` variant to support relation-aggregate virtual fields (see §9). SQL builders splice the embedded SQL into the surrounding WHERE/SELECT. Marked `#[non_exhaustive]` so future additions remain non-breaking.
+
+### Layer 2: Per-model typed inputs (new, codegen-emitted)
+
+Codegen emits a per-model `inputs` submodule containing the following types and trait impls. For a model `User`:
+
+| Generated type                | New trait                                | Lowers to (runtime IR)                |
+|-------------------------------|------------------------------------------|---------------------------------------|
+| `UserWhereInput`              | `WhereInput<Model = User>`               | `Filter`                              |
+| `UserWhereUniqueInput`        | `WhereUniqueInput<Model = User>`         | `Filter` (unique-only invariant)      |
+| `UserInclude`                 | `IncludeInput<Model = User>`             | `Include` (set of `IncludeSpec`)      |
+| `UserSelect`                  | `SelectInput<Model = User>`              | `SelectionSet`                        |
+| `UserOrderBy`                 | `OrderByInput<Model = User>`             | `OrderBy`                             |
+| `UserCreateInput`             | `CreateInput<Model = User>`              | `NestedWritePlan`                     |
+| `UserUpdateInput`             | `UpdateInput<Model = User>`              | `NestedWritePlan`                     |
+| `UserCountSelect`             | `CountSelect<Model = User>`              | `_count` aggregate spec               |
+| `UserAggregateInput`          | `AggregateInput<Model = User>`           | aggregate spec                        |
+| `UserGroupByInput`            | `GroupByInput<Model = User>`             | group-by spec                         |
+
+Each trait has the form:
+
+```rust
+pub trait WhereInput {
+    type Model: crate::traits::Model;
+    fn into_ir(self) -> Filter;
+}
+```
+
+— one method, plus an associated `Model` type so bounds remain tight.
+
+Shared scalar filter wrappers in `prax_query::inputs`:
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct StringFilter {
+    pub equals:      Option<String>,
+    pub not:         Option<Box<StringFilter>>,
+    pub in_list:     Option<Vec<String>>,
+    pub not_in:      Option<Vec<String>>,
+    pub lt:          Option<String>,
+    pub lte:         Option<String>,
+    pub gt:          Option<String>,
+    pub gte:         Option<String>,
+    pub contains:    Option<String>,
+    pub starts_with: Option<String>,
+    pub ends_with:   Option<String>,
+    pub mode:        Option<QueryMode>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct StringNullableFilter {
+    // every StringFilter field, plus:
+    pub is_null: Option<bool>,
+}
+
+// Plus: IntFilter, BigIntFilter, FloatFilter, DecimalFilter, BoolFilter,
+//       BytesFilter, DateTimeFilter, DateFilter, TimeFilter, UuidFilter,
+//       JsonFilter, EnumFilter<E>, and nullable variants.
+
+#[derive(Debug, Clone, Default)]
+pub struct ListRelationFilter<W> { pub some: Option<W>, pub every: Option<W>, pub none: Option<W> }
+
+#[derive(Debug, Clone, Default)]
+pub struct SingleRelationFilter<W> { pub is: Option<W>, pub is_not: Option<W> }
+```
+
+Each scalar filter has helper constructors (`StringFilter::contains("...")`, `IntFilter::gt(18)`) and `From<scalar>` impls so the macro can accept `email: "a@b.com"` as shorthand for `email: { equals: "a@b.com" }`.
+
+Scalar field updates use dedicated wrappers for atomic operations:
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct IntFieldUpdate {
+    pub set:       Option<i64>,
+    pub increment: Option<i64>,
+    pub decrement: Option<i64>,
+    pub multiply:  Option<i64>,
+    pub divide:    Option<i64>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct StringNullableFieldUpdate {
+    pub set:   Option<String>,
+    pub unset: Option<bool>,
+}
+
+impl From<i64>    for IntFieldUpdate              { /* { set: Some(v), .. } */ }
+impl From<String> for StringNullableFieldUpdate   { /* { set: Some(v), .. } */ }
+```
+
+### Layer 3: Macros and capability gates (new)
+
+One proc-macro per operation in `prax-codegen`:
+
+```
+prax::find_unique!   prax::find_first!     prax::find_many!
+prax::create!        prax::create_many!
+prax::update!        prax::update_many!
+prax::delete!        prax::delete_many!
+prax::upsert!
+prax::count!         prax::aggregate!      prax::group_by!
+```
+
+Plus shape macros for composition:
+
+```
+prax::where!         prax::include!        prax::select!
+prax::order_by!      prax::data!
+```
+
+All macros are schema-aware proc-macros that load the schema once per compile and emit token streams that construct the layer-2 input types.
+
+Capability marker traits in `prax_query::capabilities`:
+
+- `SupportsRelationFilter` — `some`/`every`/`none`/`is`/`is_not` available.
+- `SupportsCorrelatedSubquery` — superset for nested EXISTS.
+- `SupportsJsonPath` — JSON-path filter operators.
+- `SupportsCaseInsensitiveMode` — Postgres ILIKE; others fall back to `LOWER(...)` and skip the gate.
+- `SupportsFullTextSearch`, `SupportsArrayOps` — extensible.
+- `SupportsGeneratedColumns` — DDL for `GENERATED ALWAYS AS (...)`.
+- `SupportsScalarSubqueryInSelect` — relation-aggregate virtuals.
+- `SupportsNestedWrites` — Prisma-style nested create/connect/disconnect.
+
+Engine crates impl the marker traits they satisfy. Methods on input types and macro expansions that produce capability-dependent fragments carry `where E: SupportsX` bounds, so misuse fails at compile time with a `#[diagnostic::on_unimplemented]` message.
+
+## 3. Generated input types — concrete shapes
+
+For the example schema:
+
+```text
+model User {
+    id        Int      @id @auto
+    email     String   @unique
+    name      String?
+    age       Int?
+    active    Boolean  @default(true)
+    role      Role
+    posts     Post[]
+    profile   Profile?
+    createdAt DateTime @default(now())
+}
+```
+
+codegen emits, in module `inputs::user`:
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct UserWhereInput {
+    pub id:         Option<IntFilter>,
+    pub email:      Option<StringFilter>,
+    pub name:       Option<StringNullableFilter>,
+    pub age:        Option<IntNullableFilter>,
+    pub active:     Option<BoolFilter>,
+    pub role:       Option<EnumFilter<Role>>,
+    pub created_at: Option<DateTimeFilter>,
+
+    // Relation filters — only emitted when the engine impls SupportsRelationFilter.
+    pub posts:   Option<ListRelationFilter<PostWhereInput>>,
+    pub profile: Option<SingleRelationFilter<ProfileWhereInput>>,
+
+    // Logical combinators.
+    pub and: Option<Vec<UserWhereInput>>,
+    pub or:  Option<Vec<UserWhereInput>>,
+    pub not: Option<Box<UserWhereInput>>,
+}
+
+#[derive(Debug, Clone)]
+pub enum UserWhereUniqueInput {
+    Id(i64),
+    Email(String),
+    // Composite uniques generated as named variants.
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct UserInclude {
+    pub posts:   Option<PostsIncludeArgs>,
+    pub profile: Option<ProfileIncludeArgs>,
+    pub _count:  Option<UserCountSelect>,
+}
+// Codegen emits `#[allow(non_snake_case)]` on UserInclude/UserSelect so the
+// `_count` ident doesn't trigger lints in user crates. The leading underscore
+// follows the Prisma convention and disambiguates from any user-defined `count`
+// field on a model.
+
+#[derive(Debug, Clone, Default)]
+pub struct PostsIncludeArgs {
+    pub r#where:  Option<PostWhereInput>,
+    pub order_by: Option<Vec<PostOrderBy>>,
+    pub skip:     Option<u64>,
+    pub take:     Option<u64>,
+    pub cursor:   Option<PostWhereUniqueInput>,
+    pub include:  Option<PostInclude>,
+    pub select:   Option<PostSelect>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct UserSelect {
+    pub id:         Option<bool>,
+    pub email:      Option<bool>,
+    pub name:       Option<bool>,
+    pub age:        Option<bool>,
+    pub active:     Option<bool>,
+    pub role:       Option<bool>,
+    pub created_at: Option<bool>,
+    pub posts:      Option<PostsSelectArgs>,
+    pub profile:    Option<ProfileSelectArgs>,
+    pub _count:     Option<UserCountSelect>,
+}
+
+#[derive(Debug, Clone)]
+pub enum UserOrderBy {
+    Id(SortOrder),
+    Email(SortOrder),
+    Name(NullableSortOrder),
+    Age(NullableSortOrder),
+    CreatedAt(SortOrder),
+    Posts(PostsOrderByRelationAggregate),  // _count, _avg, _sum on the relation
+    Profile(ProfileOrderBy),
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct UserCreateInput {
+    pub email:   String,                          // required
+    pub name:    Option<String>,
+    pub age:     Option<i32>,
+    pub active:  Option<bool>,
+    pub role:    Role,
+    pub posts:   Option<PostsCreateNestedInput>,
+    pub profile: Option<ProfileCreateNestedInput>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct UserUpdateInput {
+    pub email:   Option<StringFieldUpdate>,
+    pub name:    Option<StringNullableFieldUpdate>,
+    pub age:     Option<IntFieldUpdate>,
+    pub active:  Option<BoolFieldUpdate>,
+    pub role:    Option<EnumFieldUpdate<Role>>,
+    pub posts:   Option<PostsUpdateNestedInput>,
+    pub profile: Option<ProfileUpdateNestedInput>,
+}
+```
+
+Notes:
+
+- `Option<T>` for every field is what makes `..Default::default()` work and lets the macro spread/merge cleanly. Required `CreateInput` fields stay bare (no `Option`).
+- `From<scalar>` impls on filters/updates allow `email: "x"` → `{ equals: "x" }` and `name: "Alice"` → `{ set: "Alice" }`.
+- `NullableSortOrder` (Prisma's `{ sort: asc, nulls: first }`) is in scope: emitted on `UserOrderBy` variants for nullable fields.
+- `_count` lives in `UserSelect` / `UserInclude` only (not as a top-level `_count` key on findMany).
+
+## 4. Macro grammar and expansion
+
+### Forms
+
+```rust
+// Form 1: accessor + brace block (recommended).
+prax::find_many!(client.user, { where: { email: { contains: "@x.com" } }, take: 10 });
+
+// Form 2: typed-accessor path (generic code).
+prax::find_many!(User on &engine, { where: { ... } });
+
+// Form 3: explicit `for` annotation (when accessor can't be resolved automatically).
+prax::find_many!(get_client().user(), for User, { where: { ... } });
+```
+
+The grammar reflects all three forms:
+
+```
+operation_macro_args := accessor_expr ("," "for" model_ident)? "," operation_input
+accessor_expr        := expr | model_ident "on" expr
+```
+
+The macro produces an unexec'd operation (`FindManyOperation<E, User>`). The caller invokes `.exec().await?` themselves. That preserves composition with transactions, middleware, tenant context, etc.
+
+### Grammar (EBNF-ish)
+
+```
+operation_input  := "{" field_list "}"
+field_list       := (field ",")* field?
+field            := ident ":" value
+                  | ".." expr                                  // spread
+                  | "..move" expr                              // move-spread (no clone)
+                  | "#[if(" expr ")]" ident ":" value
+                  | "#[else_if(" expr ")]" ident ":" value
+                  | "#[else]" ident ":" value
+value            := literal | path | expr_in_parens
+                  | "{" field_list "}"                         // nested input shape
+                  | "[" expr_list "]"                          // list (in_list, AND, etc.)
+                  | "true" | "false"                           // include/select shortcuts
+                  | "@(" expr ")"                              // explicit Rust expr escape
+                  | bare_ident                                 // role: Admin → role: { equals: Admin }
+```
+
+### Top-level keys per operation
+
+| Macro              | Allowed top-level keys                                                            |
+|--------------------|-----------------------------------------------------------------------------------|
+| `find_unique!`     | `where` (must be unique), `include` xor `select`                                  |
+| `find_first!`      | `where`, `order_by`, `cursor`, `skip`, `take`, `include` xor `select`             |
+| `find_many!`       | `where`, `order_by`, `cursor`, `skip`, `take`, `distinct`, `include` xor `select` |
+| `create!`          | `data`, `include` xor `select`                                                    |
+| `create_many!`     | `data`, `skip_duplicates`                                                         |
+| `update!`          | `where` (unique), `data`, `include` xor `select`                                  |
+| `update_many!`     | `where`, `data`                                                                   |
+| `upsert!`          | `where` (unique), `create`, `update`, `include` xor `select`                      |
+| `delete!`          | `where` (unique), `include` xor `select`                                          |
+| `delete_many!`     | `where`                                                                           |
+| `count!`           | `where`, `order_by`, `cursor`, `skip`, `take`, `select`                           |
+| `aggregate!`       | `where`, `order_by`, `cursor`, `skip`, `take`, `_count`, `_avg`, `_sum`, `_min`, `_max` |
+| `group_by!`        | `by`, `where`, `having`, `order_by`, `skip`, `take`, `_count`, `_avg`, `_sum`, `_min`, `_max` |
+
+Unknown keys at any level produce a "did you mean" diagnostic computed against the actual model.
+
+### Operator naming
+
+Snake_case Rust idiom: `gt`, `gte`, `lt`, `lte`, `equals`, `not`, `in_list`, `not_in`, `contains`, `starts_with`, `ends_with`, `mode: insensitive`, `some`, `every`, `none`, `is`, `is_not`, `is_null`, `set`, `increment`, `decrement`, `multiply`, `divide`, `unset`.
+
+### Spread and conditional semantics
+
+- `..expr` clones `expr` (which must be the same input type) and any subsequent `field: value` entries overwrite. Later wins, matching Rust struct-update syntax. The macro inserts `Clone::clone(&expr)` so the spread doesn't consume.
+- `..move expr` is the same but moves (no clone) — opt-in for hot paths.
+- `#[if(cond)] field: value` lowers to a `let __tmp = …; if cond { __w.field = Some(__tmp); }` block. Pairs with `#[else_if]` and `#[else]`.
+- Bare identifiers as values (`role: Admin`) are resolved against the schema; if the field is an enum, becomes `EnumFilter::equals(Path::Admin)`.
+- `@(expr)` escapes DSL parsing — treat the contents as a Rust expression.
+- `order_by: { field: dir }` auto-wraps to `vec![{ field: dir }]`.
+
+### Expansion example
+
+```rust
+prax::find_many!(client.user, {
+    where: {
+        email: { contains: "@x.com", mode: insensitive },
+        age:   { gte: 18 },
+        ..base_filter,
+        posts: { some: { published: true } },
+        or: [
+            { role: Admin },
+            { role: Moderator },
+        ],
+    },
+    include: {
+        posts: {
+            where: { published: true },
+            order_by: { created_at: desc },
+            take: 5,
+        },
+        profile: true,
+    },
+    order_by: [{ created_at: desc }],
+    take: 10,
+});
+```
+
+expands (sketch) to:
+
+```rust
+{
+    let __where = {
+        let mut __w = ::prax::inputs::user::UserWhereInput {
+            email: Some(::prax::inputs::StringFilter {
+                contains: Some(("@x.com").into()),
+                mode:     Some(::prax::inputs::QueryMode::Insensitive),
+                ..::core::default::Default::default()
+            }),
+            age: Some(::prax::inputs::IntNullableFilter::gte(18)),
+            ..::core::clone::Clone::clone(&(base_filter))
+        };
+        __w.posts = Some(::prax::inputs::ListRelationFilter {
+            some: Some(::prax::inputs::post::PostWhereInput {
+                published: Some(true.into()),
+                ..::core::default::Default::default()
+            }),
+            ..::core::default::Default::default()
+        });
+        __w.or = Some(::std::vec![ /* ... */ ]);
+        __w
+    };
+    let __include = ::prax::inputs::user::UserInclude { /* ... */ };
+    ::prax::traits::ModelAccessor::find_many(&client.user())
+        .with_where_input(__where)
+        .with_include_input(__include)
+        .with_order_by_input(::std::vec![/* ... */])
+        .take(10)
+}
+```
+
+The macro never invents new runtime types. `with_*_input` are extension methods on each `Operation` that call `into_ir()` and stash the resulting `Filter`/`Include`/`OrderBy`. The existing `.r#where(filter)` / `.include(spec)` builder methods stay untouched.
+
+## 5. Schema-aware proc-macro implementation
+
+### Schema discovery
+
+```rust
+fn resolve_schema() -> &'static Arc<Schema>;
+```
+
+Resolution order:
+
+1. `PRAX_SCHEMA` env var (absolute or relative to `CARGO_MANIFEST_DIR`). Used directly if set; error if file missing.
+2. Walk up from `CARGO_MANIFEST_DIR` looking for `prax.toml`. Read `[generator.client].schema` (defaults to `prax/schema.prax`). Resolve relative to the `prax.toml` location.
+3. No `prax.toml` found → hard error: *"Could not find a `prax.toml` in any ancestor of $CARGO_MANIFEST_DIR. Set `PRAX_SCHEMA=path/to/schema.prax` or run `prax init`."*
+
+Caching: `OnceLock<Mutex<HashMap<PathBuf, Arc<Schema>>>>` keyed by absolute schema path. First macro call parses; subsequent calls hit cache.
+
+Dependency tracking: prefer `proc_macro::tracked_path::path(absolute_schema)` for re-trigger on schema change. Fallback for older toolchains: emit `const _: &[u8] = include_bytes!(absolute_schema_path);` inside a hidden module of the expansion so rustc's dep graph notices changes.
+
+### Macro flow
+
+```
+parse TokenStream
+  → resolve_schema() — &Schema
+  → resolve model from accessor expr (`client.user` → "User")
+  → parse DSL block into typed AST (WhereInputAst, IncludeAst, …)
+  → validate AST against schema:
+      - unknown field → "did you mean `{closest}`" (strsim::jaro_winkler ≥ 0.85)
+      - wrong operator for scalar type → "field `age` (Int) does not support `contains`"
+      - relation op on non-relation → "field `email` is not a relation"
+      - `some`/`every`/`none` on to-one → "use `is`/`is_not` for to-one"
+      - `where` not unique on find_unique/update/etc.
+      - `select` xor `include`
+  → lower AST → token stream constructing layer-2 input structs
+  → emit
+```
+
+### Accessor resolution
+
+- `client.MODEL` → snake_case the last path segment, match against `schema.models` (PascalCase).
+- `MODEL on EXPR` → take the type-position `MODEL` ident directly.
+- `expr(), for MODEL` → explicit annotation.
+
+Failures here produce a clear error pointing to the accessor token.
+
+### Codegen entry points
+
+1. `prax generate` (CLI) — emits `inputs/` submodule alongside existing client `mod.rs`.
+2. `#[derive(Model)]` — emits `<model_snake>_inputs` sibling module. Requires sibling models defined in the same module for relation-filter codegen to resolve cross-model types (default constraint; documented).
+3. `prax_schema!` macro — same codegen as `prax generate`, inline.
+
+### Compile-time cost budget
+
+Per-model generated input footprint: ~200–400 lines (~10 types). For a 50-model schema with 8 fields average, ~16 kLOC generated — comparable to a moderately large `serde::Deserialize` derive footprint. Schema parse: ~5–10 ms once per crate per compile; subsequent macro calls in the same compile are <100 µs.
+
+Feature-gated: `prax/inputs` Cargo feature on `prax-codegen` (default-on). Disabling skips input-type codegen for users who prefer the existing fluent API.
+
+## 6. Write operations and nested-write plans
+
+### Principles
+
+1. **Lower to existing operations.** Nested writes compile to a sequence of `Create`/`Update`/`Upsert`/`Delete` runtime operations inside a single transaction. No new SQL.
+2. **Reuse engine transactions.** The macro auto-wraps multi-op plans in `engine.transaction(...)`. Single-op plans skip the wrapper.
+3. **Static dependency ordering.** Codegen knows relation directions; the plan emits ops in topological order. No runtime topo-sort.
+
+### Nested input shapes
+
+For `posts: Post[]` (FK on `Post.authorId`):
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct PostsCreateNestedInput {
+    pub create:            Option<Vec<PostCreateWithoutAuthorInput>>,
+    pub create_many:       Option<PostsCreateManyWithoutAuthorInput>,
+    pub connect:           Option<Vec<PostWhereUniqueInput>>,
+    pub connect_or_create: Option<Vec<PostConnectOrCreateWithoutAuthorInput>>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PostsUpdateNestedInput {
+    pub create:            Option<Vec<PostCreateWithoutAuthorInput>>,
+    pub connect:           Option<Vec<PostWhereUniqueInput>>,
+    pub disconnect:        Option<Vec<PostWhereUniqueInput>>,
+    pub set:               Option<Vec<PostWhereUniqueInput>>,
+    pub update:            Option<Vec<PostUpdateWithWhereUniqueWithoutAuthorInput>>,
+    pub update_many:       Option<Vec<PostUpdateManyWithWhereWithoutAuthorInput>>,
+    pub upsert:            Option<Vec<PostUpsertWithWhereUniqueWithoutAuthorInput>>,
+    pub delete:            Option<Vec<PostWhereUniqueInput>>,
+    pub delete_many:       Option<Vec<PostScalarWhereWithoutAuthorInput>>,
+    pub connect_or_create: Option<Vec<PostConnectOrCreateWithoutAuthorInput>>,
+}
+```
+
+`*WithoutAuthorInput` variants omit the FK fields the parent insert will fill in via `RETURNING`.
+
+For `profile: Profile?` (to-one, FK on child):
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct ProfileCreateNestedInput {
+    pub create:            Option<Box<ProfileCreateWithoutUserInput>>,
+    pub connect:           Option<ProfileWhereUniqueInput>,
+    pub connect_or_create: Option<Box<ProfileConnectOrCreateWithoutUserInput>>,
+}
+```
+
+### `NestedWritePlan`
+
+```rust
+pub enum NestedWriteOp {
+    InsertSelf { columns: Vec<&'static str>, values: Vec<FilterValue>, returning: ReturningSpec },
+    InsertChild { parent_id_slot: SlotId, model: &'static str, columns: Vec<&'static str>, values: Vec<FilterValue> },
+    Connect { parent_id_slot: SlotId, child_pk: WhereUniqueInput, fk_column: &'static str },
+    ConnectOrCreate { /* ... */ },
+    UpsertChild { /* ... */ },
+    UpdateChild { /* ... */ },
+    DeleteChild { /* ... */ },
+    SetRelation { /* ... */ },
+}
+
+pub struct NestedWritePlan {
+    pub ops: Vec<NestedWriteOp>,
+    pub return_root_via: SlotId,
+}
+```
+
+`SlotId` placeholders are substituted with PKs returned from earlier ops. The executor walks the plan in order; `Self` inserts before children; inverse-direction creates run the parent op first.
+
+### `connect_or_create`
+
+Two lowerings:
+
+- **Engines with upsert syntax** (Postgres `ON CONFLICT`, SQLite `ON CONFLICT`, MySQL `INSERT … ON DUPLICATE KEY UPDATE`, MSSQL `MERGE`): single statement.
+- **Other engines**: two-statement `SELECT pk WHERE unique = …; INSERT if missing` inside the surrounding transaction.
+
+### `set: [...]` (full relation replacement)
+
+Diff-based: fetch current children → DELETE those not in the new set → INSERT/CONNECT those that are new. Heavy but consistent. **Enabled by default** to match Prisma. Document the cost.
+
+### Returning typed shape after a nested write
+
+After commit, the executor runs a final find with the requested `include`/`select` against the inserted PK. Adds one roundtrip but reuses the existing find-with-include path.
+
+### Capability gating
+
+- All SQL drivers + MongoDB: full support.
+- CQL (ScyllaDB / Cassandra): `*CreateNestedInput` / `*UpdateNestedInput` types are gated behind `SupportsNestedWrites`. CQL engines don't impl it, so nested writes don't compile.
+
+### `QueryEngine` additions
+
+- `fn in_transaction(&self) -> bool` — additive, default returns `false`. Drivers that support transactions override.
+
+## 7. Error handling
+
+Three categories:
+
+### Compile-time errors
+
+- Unknown field, wrong operator for scalar type, `some` on non-relation, relation cardinality mismatch, `where` not unique where required, `select` and `include` both set, capability-trait not satisfied.
+- Emitted via `syn::Error::to_compile_error` with token-level spans.
+- Capability errors carry `#[diagnostic::on_unimplemented]` messages.
+
+### Runtime errors (additive `QueryError` variants, `#[non_exhaustive]`)
+
+- `QueryError::RelationNotFound { relation, parent_id }`
+- `QueryError::UniqueViolationOnConnectOrCreate { model, unique }`
+- `QueryError::RequiredWhereMissing { operation }`
+- `QueryError::NestedWriteFailed { op, source: Box<QueryError> }`
+
+### Capability mismatches caught early
+
+Marker-trait bounds on input methods plus `with_*_input` extension methods make capability errors compile-time, not runtime.
+
+## 8. Coexistence and migration path
+
+### Coexistence
+
+- Existing `.r#where(filter)` / `.include(spec)` / `CreateData::new().set(…)` API unchanged.
+- New `with_where_input<W: WhereInput<Model = M>>(self, w: W) -> Self` and siblings on every `Operation`.
+- Old and new can be combined; later calls AND-compose with earlier filters.
+- Third interface: explicit struct construction (`FindManyArgs { r#where: Some(UserWhereInput { … }), .. }`) is supported and documented.
+
+### Phasing (non-breaking, each phase ships independently)
+
+| Phase | Crates | Deliverable | Effort |
+|-------|--------|-------------|--------|
+| 1 | `prax-query` | New traits, scalar filter wrappers, `ListRelationFilter`/`SingleRelationFilter`, capability marker traits, `*Args` structs, `with_*_input` ext methods | 3–4 days |
+| 2 | `prax-codegen`, engine crates | `prax generate` / `prax_schema!` / `#[derive(Model)]` emit `inputs/` modules. Engines impl capability marker traits | 4–5 days |
+| 3 | `prax-codegen` | Read operation macros + schema discovery + cache + `trybuild` UI tests | 4–5 days |
+| 4 | `prax-codegen` | Shape macros (`where!`, `include!`, …), spread, conditional, bare-ident enum resolution | 2–3 days |
+| 5 | `prax-codegen`, `prax-query` | Write macros + `NestedWritePlan` executor + `connect_or_create` paths + `SupportsNestedWrites` gating | 5–7 days |
+| 5.5 | `prax-schema`, `prax-codegen`, `prax-migrate`, engine crates | Computed/virtual field support (§9) | 3 days |
+| 6 | `prax-codegen`, `prax-query` | Aggregate macros (`count!`, `aggregate!`, `group_by!`) | 2–3 days |
+| 7 | repo-wide | Examples migrated, docs site updated (§10), cookbook, rustdoc chapter, cross-engine consistency tests | 5–8 days |
+
+**Total: 28–38 feature-days.**
+
+### Compatibility guarantees
+
+- Every public symbol in `prax-query`'s current API remains.
+- New `Filter::ScalarSubquery` variant lands behind `#[non_exhaustive]`.
+- `QueryError` is `#[non_exhaustive]`; new variants are additive.
+- `Model` and `ModelAccessor` traits unchanged.
+
+## 9. Computed and virtual fields
+
+Three classes:
+
+### (1) DB-generated columns
+
+```text
+model User {
+    id        Int    @id @auto
+    firstName String
+    lastName  String
+    fullName  String @generated("first_name || ' ' || last_name") @stored
+    searchKey String @generated("LOWER(email)") @virtual
+}
+```
+
+- New `FieldKind::DbGenerated { expr: String, stored: bool }` variant in the `prax-schema` AST.
+- Real scalar field in the result struct.
+- Included in `WhereInput` and `SelectInput`.
+- Excluded from `CreateInput` and `UpdateInput`.
+- `prax-migrate` SQL generator emits `GENERATED ALWAYS AS (expr) STORED|VIRTUAL` DDL; CQL dialect rejects with clear error.
+- Capability gate: `SupportsGeneratedColumns` — PG/MySQL/SQLite/MSSQL/DuckDB.
+
+### (2) Relation aggregate virtuals
+
+```text
+model User {
+    id         Int    @id @auto
+    posts      Post[]
+    postCount  Int    @count(posts)
+    totalViews Int    @sum(posts.views)
+    lastPostAt DateTime? @max(posts.created_at)
+}
+```
+
+- New `FieldKind::Aggregate { kind, relation, field }` variant.
+- Scalar field on result struct; no underlying column.
+- Included in `WhereInput` and `SelectInput`; excluded from `CreateInput`/`UpdateInput`.
+- `WhereInput::into_ir` produces `Filter::ScalarSubquery { sql, params }` (new IR variant).
+- SELECT lowering: scalar subquery `(SELECT COUNT(*) FROM posts p WHERE p.author_id = u.id) AS post_count`. Lateral-join is an optimization, not baseline.
+- `_count` accessor in `select` / `include` reuses the same machinery — `select: { _count: { posts: true } }` and a schema-level `@count(posts)` field produce the same lowering.
+- Capability gate: `SupportsScalarSubqueryInSelect`. Implemented at phase 5.5 by every SQL engine (PG / MySQL / SQLite / MSSQL / DuckDB) via scalar subqueries. **Not** implemented by `prax-mongodb` until the follow-up `$lookup`-lowering plan ships; until then, MongoDB code that uses relation-aggregate virtuals fails to compile with a clear capability-trait diagnostic. CQL engines never implement this gate.
+
+### (3) Pure-Rust computed methods
+
+Regular `impl User { fn display_name(&self) -> String { … } }`. No DSL involvement. Documented as "for derived values that depend only on already-loaded fields and never need to be filtered on."
+
+## 10. Documentation site updates (Angular `docs/` workspace)
+
+### New pages and routes
+
+| Route | Page module | Content |
+|-------|-------------|---------|
+| `/queries/input-types` | `queries-input-types.page` | Reference for the trait family and per-model generated structs |
+| `/queries/macros` | `queries-macros.page` | Full grammar reference for every operation macro and shape macro; spread + conditional syntax; capability-trait error messages |
+| `/queries/relation-filters` | `queries-relation-filters.page` | `some`/`every`/`none`/`is`/`is_not` — examples, generated SQL per dialect, cross-engine support matrix |
+| `/queries/nested-writes` | `queries-nested-writes.page` | Nested `connect` / `create` / `connect_or_create` / `disconnect` / `set` / `update` / `upsert` / `delete` / `delete_many`; transaction semantics; CQL unsupported note |
+| `/queries/computed-fields` | `queries-computed-fields.page` | `@generated` columns and `@count` / `@sum` / `@avg` / `@min` / `@max` virtuals |
+| `/migration/from-fluent-builder` | `migration-from-fluent.page` | Side-by-side fluent → macro cookbook |
+| `/migration/prisma-to-prax` | `migration-prisma-to-prax.page` | Prisma TS → Prax cheat sheet (snake_case operator names, Rust syntax differences) |
+
+### Existing pages requiring substantive updates
+
+Each gets a new "Macro DSL" or "Input types" section. The fluent-builder example moves under a "Dynamic composition" sub-heading.
+
+- `queries-crud.page` — primary CRUD examples switch to macros.
+- `queries-filtering.page` — refactor around `WhereInput` and scalar filters.
+- `queries-pagination.page` — `skip`/`take`/`cursor` inside macros.
+- `queries-aggregations.page` — `aggregate!`, `group_by!`, `count!`, `_count` virtual.
+- `queries-upsert.page` — `upsert!` macro.
+- `queries-json.page` — JSON-field filters; capability gating per engine.
+- `queries-search.page` — `mode: insensitive` and per-engine behavior.
+- `schema-relations.page` — include/select/relation-filter shapes; relation cardinality drives `ListRelationFilter` vs `SingleRelationFilter`.
+- `schema-overview.page` — link to new generated-types reference.
+- `schema-fields.page` — `@generated`, `@stored`, `@virtual`, `@count` / `@sum` / `@avg` / `@min` / `@max` attributes.
+- `schema-attributes.page` — same attribute reference detail.
+- `home.page`, `quickstart.page` — landing examples switch to macro form.
+- `advanced-errors.page` — new `QueryError` variants and error mapping.
+- `examples.page` — every example rewritten in the new style.
+- `database-{postgresql,mysql,sqlite,mssql,duckdb,mongodb}.page` — capability matrix table noting which marker traits each engine implements. New pages to add: `database-scylladb.page` and `database-cassandra.page` (route + module + html) — these don't exist on the docs site today and the new feature surface is a natural moment to introduce them.
+
+### Navigation / IA changes
+
+- New "Macro DSL" sidebar group: `/queries/macros`, `/queries/input-types`, `/queries/relation-filters`, `/queries/nested-writes`, `/queries/computed-fields`.
+- New "Migration" sidebar group with the two migration pages.
+- Existing "Queries" group reordered so `queries/crud` and `queries/filtering` lead with macro examples and link out to the new Macro DSL group.
+
+### Cross-link audit
+
+- Every `prax::*!` macro reference on any page links to `/queries/macros#<macro>`.
+- Every `WhereInput` / `IncludeInput` / capability-trait mention links to `/queries/input-types#<anchor>`.
+
+### Build verification
+
+- `pnpm --filter docs build`, `pnpm --filter docs lint`, `pnpm --filter docs test` must pass before phase 7 closes.
+- If a docs CI job exists, extend it to cover the new pages; otherwise add one that triggers on `docs/**` changes.
+
+## 11. Testing strategy
+
+| Layer | Location | What it catches |
+|-------|----------|-----------------|
+| Unit: `into_ir` lowerings | `prax-query/tests/inputs/` | Hand-built `UserWhereInput` lowers to expected `Filter`. Pure data, no engine. |
+| Macro UI tests | `prax-codegen/tests/ui/` | DSL parsing, diagnostics, "did you mean", capability-trait errors. `trybuild` with `.stderr` snapshots. Schema-aware diagnostics pinned via committed `tests/fixtures/schema.prax`, found via `PRAX_SCHEMA`. |
+| Per-engine integration | `prax-postgres/tests/inputs_dsl.rs` (and siblings) | Macros against real engines, assert rows. Reuses existing test containers. |
+| Cross-engine consistency | `prax-query/tests/cross_engine_dsl/` | Same macro call against PG/MySQL/SQLite/MSSQL/DuckDB; results agree. |
+| `compile_fail.rs` | `prax-query/tests/` | Capability gates: `prax::find_many!(scylla_client.user, { where: { posts: { some: ... } } })` fails to compile. |
+
+Test schema (`tests/fixtures/schema.prax`) covers: one-to-one, one-to-many, many-to-many (implicit join), self-relation, composite PK, nullable-FK, enum field, JSON field, `@generated` columns, `@count` / `@sum` virtuals.
+
+Shared test schemas live in a new private workspace member `prax-test-schema` so all engine crates pull from one fixture set.
+
+## 12. Risks and mitigations
+
+| Risk | Probability | Mitigation |
+|------|-------------|------------|
+| `proc_macro::tracked_path` not on MSRV | Medium | `include_bytes!`-inside-hidden-module fallback; build.rs / env-var hash as final fallback |
+| Compile-time bloat from generated input types | Medium | Feature-gate `inputs` codegen behind `prax/inputs` (default-on); ~16 kLOC per 50-model schema is acceptable |
+| Diagnostic span quality on macro errors | Medium | Use `syn::Error::to_compile_error` with per-token spans; `trybuild` snapshots gate regressions |
+| `connect_or_create` race semantics | Medium | One concrete path per engine; document the per-engine atomicity guarantees |
+| Many-to-many through implicit join tables in nested writes | Medium | Codegen reads the schema's join table; phase 5 covers implicit-join only; explicit-join-model M2M deferred |
+| Capability-trait proliferation | Low | Cap at the nine traits in §2; finer-grained gates become runtime errors |
+
+## 13. Open follow-ups (post-design)
+
+- MongoDB `$lookup` lowering for relation-aggregate virtuals (separate plan after phase 6).
+- Generic result types parameterized by include shape (a future research design — not promised).
+- Explicit-join-model M2M in nested writes (separate plan).
+- Migration helpers for translating Prisma schemas to Prax schemas (could live in `prax-import`).

--- a/docs/superpowers/specs/2026-05-19-multi-file-schema-design.md
+++ b/docs/superpowers/specs/2026-05-19-multi-file-schema-design.md
@@ -1,0 +1,558 @@
+# Multi-file schema support — design spec
+
+**Status:** Draft
+**Date:** 2026-05-19
+**Branch:** `feature/multi-file-schema`
+**Driver:** allow Prax to load multiple `.prax` files from a directory and merge them into one cohesive schema (Prisma-style), and have `prax import --from prisma` mirror Prisma's multi-file layouts into the equivalent Prax layout.
+
+## Motivation
+
+Today every Prax project has exactly one `schema.prax` file. As schemas grow this becomes unwieldy — large schemas in single files have poor diff hygiene, painful merge conflicts, and force one team's domain to live alongside another's. Prisma solved this with the `prismaSchemaFolder` preview (now GA): point the schema config at a directory, every `*.prisma` file in it merges into one logical schema.
+
+We adopt the same model, with one deliberate divergence: discovery is **recursive** so users can organize files into subdirectories (`models/`, `enums/`, `policies/`) without flag gymnastics.
+
+## Non-goals
+
+- No new schema-language constructs (no `include` / `import` directive).
+- No partial loading or lazy parsing.
+- No change to generated client code shape — multi-file in, single cohesive `src/generated/` out.
+- No change to migration history or event log — the merged schema is the desired state, exactly as today.
+
+## User-visible behavior
+
+### Activation: auto-detect from `[schema].path`
+
+`prax.toml`'s `[schema].path` already exists; today it's expected to be a file. After this work:
+
+- If `[schema].path` points to an **existing file**, load that file (today's behavior, unchanged).
+- If `[schema].path` points to an **existing directory**, load every `*.prax` in it recursively, merged into one schema.
+
+No new config key. `prax init` still scaffolds `schema.prax` by default. A new `--multi-file` flag on `prax init` (or `--layout=directory`) scaffolds the directory layout instead:
+
+```
+prax/
+  schema/
+    datasource.prax     # datasource + generator only
+    models/
+      user.prax
+      post.prax
+```
+
+and points `prax.toml`'s `[schema].path` at `prax/schema`.
+
+### Discovery rules
+
+Inside a schema directory:
+
+- Recursive descent (subdirectories are walked).
+- Match: `*.prax`, sorted lexicographically by **relative path** for determinism.
+- Skip: hidden files and directories (leading `.`), symlinks, and any `target/` directory.
+- Empty directory → `SchemaError::EmptySchemaDirectory { path }` rather than silently producing nothing.
+
+### Conflict policy (hard-error with both locations)
+
+Duplicate definitions across files are an error, **never** silently overridden. The following items must be unique across the entire directory:
+
+| Item | Uniqueness key |
+|---|---|
+| `model` | name |
+| `enum` | name |
+| `type` (composite) | name |
+| `view` | name |
+| `serverGroup` | name |
+| `policy` | name |
+| `generator` | name (multiple distinct generators allowed) |
+| `datasource` | **exactly one** across the whole directory |
+| raw SQL (`@@sql(name = "…")`) | name |
+
+Each duplicate produces a `SchemaError::DuplicateAcrossFiles { kind, name, first, second }` where both `SourceLoc`s point at the originating file + span, so the rendered miette diagnostic shows both locations under one error header. `try_merge` collects **all** conflicts before returning so users see every duplicate in one run.
+
+### Backward compatibility
+
+The single-file path is preserved end-to-end:
+- `parse_schema(&str)` and `parse_schema_file(path)` keep their current signatures and semantics.
+- Existing `schema.prax` projects continue to work with no `prax.toml` change.
+- Generated output for a single-file project is byte-for-byte identical to today.
+
+A regression snapshot test in `prax-schema` asserts this invariant.
+
+## Architecture
+
+### Module layout in `prax-schema`
+
+```
+prax-schema/src/
+├── ast/                 (small additive change: see §AST provenance)
+├── parser/              unchanged; still takes &str
+├── loader/              NEW
+│   ├── mod.rs           pub fn load(path) -> SchemaResult<LoadedSchema>
+│   ├── discovery.rs     recursive walk, returns Vec<SourceFile>
+│   ├── source.rs        SourceId, SourceMap, SourceFile
+│   └── merge.rs         try_merge with collision detection
+├── error.rs             additions: file-aware variants
+├── validator.rs         unchanged signature; sees the merged Schema
+└── lib.rs               re-exports loader::{load, LoadedSchema, SourceMap}
+```
+
+### Public surface added to `prax_schema`
+
+```rust
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub struct SourceId(u32);
+
+pub struct SourceFile {
+    pub path: PathBuf,
+    pub content: String,
+}
+
+pub struct SourceMap {
+    files: Vec<SourceFile>,           // index = SourceId.0 as usize
+}
+
+impl SourceMap {
+    pub fn get(&self, id: SourceId) -> Option<&SourceFile>;
+    pub fn iter(&self) -> impl Iterator<Item = (SourceId, &SourceFile)>;
+    pub fn len(&self) -> usize;
+}
+
+pub struct LoadedSchema {
+    pub schema: Schema,
+    pub sources: SourceMap,
+}
+
+pub struct LoadError {
+    pub error: SchemaError,
+    pub sources: SourceMap,            // partial map built up to the point of failure
+}
+
+pub fn load(path: impl AsRef<Path>) -> Result<LoadedSchema, LoadError>;
+```
+
+`SourceId(u32)` is cheap to copy and embed in errors. The map lives on `LoadedSchema` on the success path and on `LoadError` on the failure path — either way the renderer can resolve `SourceId` → file content. Errors themselves carry only `SourceId`s, not inline buffers.
+
+## Load flow
+
+```
+load(path):
+  if path is a file → load_single(path)
+  else if path is a dir → load_directory(path)
+  else → Err(SchemaError::IoError { ... not found ... })
+
+load_single(path):
+  read file → assign SourceId(0) → parse_schema(content)
+  stamp_source(&mut schema, SourceId(0))
+  validate(&schema)
+  LoadedSchema { schema, sources: { 0 => path } }
+
+load_directory(root):
+  files = discover(root)
+  if files.is_empty() → Err(EmptySchemaDirectory { path: root })
+
+  sources = SourceMap::new()
+  per_file_schemas = []
+
+  for sid, file in files.enumerate():
+      sources.insert(sid, file)            # always insert first, so even a parse
+                                           # failure carries content for rendering
+      match parse_schema(&file.content):
+          Ok(s)  → per_file_schemas.push((sid, s))
+          Err(e) → return Err(LoadError {
+              error: SchemaError::ParseInFile { source: sid, inner: Box::new(e) },
+              sources,
+          })
+
+  for (sid, schema_i) in &mut per_file_schemas:
+      stamp_source(schema_i, *sid)
+
+  merged = Schema::new()
+  all_conflicts: Vec<MergeConflict> = []
+  for (_, schema_i) in per_file_schemas:
+      if let Err(conflicts) = merged.try_merge(schema_i):
+          all_conflicts.extend(conflicts)
+  if !all_conflicts.is_empty():
+      return Err(LoadError {
+          error: SchemaError::from_conflicts(all_conflicts),
+          sources,
+      })
+
+  if let Err(e) = validate(&merged):       # existing validator, sees merged AST
+      return Err(LoadError { error: e, sources });
+  Ok(LoadedSchema { schema: merged, sources })
+```
+
+Key decisions:
+
+- **Sort order:** lexicographic on the path relative to the root, so merge order is stable across machines.
+- **Per-file syntax errors are fail-fast** (we stop at the first malformed file), but **merge conflicts are batched** (all duplicates reported in one error). Mixed behavior is intentional: there's no useful partial schema if file 3 of 10 is unparseable, but there is value in seeing all duplicate-model errors at once.
+- **Validation runs once on the merged schema** — relation resolution, unknown-type errors, missing `@id`, etc. all work naturally across files because by validation time everything's in one `Schema`.
+
+### Discovery details
+
+- Walker: the `walkdir` crate (already a transitive dep across the workspace; if absent from `prax-schema/Cargo.toml`, add it directly — it's small).
+- Skip predicate, applied during the walk:
+  - Hidden entries (filename starts with `.`).
+  - Symlinks (do not follow).
+  - Any directory literally named `target` (avoids accidentally scanning build output if a user points the schema dir at the repo root by mistake).
+- Files matched: extension `.prax` (case-sensitive). Non-`.prax` files in the directory are ignored.
+- Sort: collect all matched files, then sort by `path.strip_prefix(root)` lexicographically (UTF-8 byte order).
+
+## AST provenance
+
+Every top-level item gains an additive field:
+
+```rust
+pub source_id: Option<SourceId>,
+```
+
+Applied to: `Model`, `Enum`, `CompositeType`, `View`, `ServerGroup`, `Policy`, `Generator`, `Datasource`, `RawSql`. `Relation` is populated post-validation from already-stamped models and inherits provenance via `from_model`'s `source_id` (no separate field needed).
+
+- Field is `Option<SourceId>` so the default constructor doesn't need to know about source IDs.
+- `parse_schema(&str)` (single-buffer) leaves the field `None` — callers that don't use the loader see no behavior change.
+- The loader's `stamp_source(&mut Schema, SourceId)` helper sets it on every item after parsing each file, before merging.
+
+This is the only AST change. It's purely additive and serde-compatible (skips `None` on serialize).
+
+## Merge semantics (`try_merge`)
+
+The current `Schema::merge` does `IndexMap::extend` — silent overwrite. It is deprecated for one release in favor of:
+
+```rust
+impl Schema {
+    pub fn try_merge(&mut self, other: Schema) -> Result<(), Vec<MergeConflict>>;
+}
+
+pub enum MergeConflict {
+    DuplicateModel       { name: SmolStr, existing: SourceLoc, incoming: SourceLoc },
+    DuplicateEnum        { name: SmolStr, existing: SourceLoc, incoming: SourceLoc },
+    DuplicateType        { name: SmolStr, existing: SourceLoc, incoming: SourceLoc },
+    DuplicateView        { name: SmolStr, existing: SourceLoc, incoming: SourceLoc },
+    DuplicateServerGroup { name: SmolStr, existing: SourceLoc, incoming: SourceLoc },
+    DuplicatePolicy      { name: SmolStr, existing: SourceLoc, incoming: SourceLoc },
+    DuplicateGenerator   { name: SmolStr, existing: SourceLoc, incoming: SourceLoc },
+    DuplicateRawSql      { name: SmolStr, existing: SourceLoc, incoming: SourceLoc },
+    MultipleDatasource   {                existing: SourceLoc, incoming: SourceLoc },
+}
+
+pub struct SourceLoc {
+    pub source: SourceId,
+    pub span: Span,
+}
+```
+
+Per-item rules:
+
+| Container | Behavior |
+|---|---|
+| `models`, `enums`, `types`, `views`, `server_groups`, `generators` (`IndexMap<name, _>`) | Hard error on duplicate name. Otherwise insert. |
+| `policies` (`Vec<Policy>`) | Hard error on duplicate `name()`. Otherwise concatenate. |
+| `raw_sql` (`Vec<RawSql>`) | Hard error on duplicate `name`. Otherwise concatenate. |
+| `datasource: Option<Datasource>` | Hard error if both schemas have one. Otherwise take whichever is `Some`. |
+| `relations` | Empty pre-validation; nothing to merge. |
+
+`try_merge` collects all conflicts without short-circuiting so the user sees every error in one pass.
+
+The existing `Schema::merge` stays for one release with `#[deprecated]` pointing at `try_merge`, then is removed.
+
+## Diagnostics
+
+### New error variants
+
+`SchemaError` gains:
+
+```rust
+SchemaError::ParseInFile {
+    source: SourceId,
+    #[source] inner: Box<SchemaError>,    // wraps the inner SyntaxError
+},
+
+SchemaError::DuplicateAcrossFiles {
+    kind: &'static str,        // "model", "enum", "datasource", …
+    name: String,              // empty for datasource
+    first: SourceLoc,
+    second: SourceLoc,
+},
+
+SchemaError::EmptySchemaDirectory { path: PathBuf },
+```
+
+### Rendering with a `SourceMap`
+
+A small newtype pairs an error with its source map for miette rendering:
+
+```rust
+pub struct Report<'a> {
+    err: &'a SchemaError,
+    sources: &'a SourceMap,
+}
+
+impl miette::Diagnostic for Report<'_> {
+    fn source_code(&self) -> Option<&dyn miette::SourceCode> { /* picks the right file */ }
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> { /* two labels for cross-file conflicts */ }
+}
+
+impl SchemaError {
+    pub fn report<'a>(&'a self, sources: &'a SourceMap) -> Report<'a> {
+        Report { err: self, sources }
+    }
+}
+```
+
+For `DuplicateAcrossFiles`, the rendered miette diagnostic has two labeled spans (one per file) under a single error header. For `ParseInFile`, it unwraps to the inner `SyntaxError` and points its `source_code` at the right file's content from the map.
+
+### Single-file path keeps existing errors
+
+`parse_schema(&str)` still emits `SyntaxError { src, span, message }` directly — single-file callers, tests, and doctests are unchanged. The loader catches that error, wraps it in `ParseInFile { source, inner }`, and the report layer renders either form correctly.
+
+### Loader / caller API for error handling
+
+```rust
+match prax_schema::load(&schema_path) {
+    Ok(LoadedSchema { schema, sources }) => /* use schema; sources for any later rendering */,
+    Err(LoadError { error, sources }) => {
+        eprintln!("{:?}", miette::Report::new(error.report(&sources)));
+        std::process::exit(1);
+    }
+}
+```
+
+For the CLI specifically: `CliError::Schema` grows to a struct variant `Schema { error: SchemaError, sources: Option<SourceMap> }` (Option because some `SchemaError`s — e.g., the `IoError` raised when the path itself doesn't exist — are produced before any file is read and have no source map). The CLI's miette setup picks `error.report(&sources)` when `Some`, falls back to the bare error otherwise.
+
+## Integration with consumers
+
+### `prax-cli` — five subcommands
+
+Each command today has its own local `parse_schema(content: &str)` helper plus a `std::fs::read_to_string + parse` block. Both go away and are replaced by a single shared helper in `prax-cli/src/schema_loader.rs`:
+
+```rust
+pub fn load_schema(args_path: Option<&Path>, config: &Config) -> CliResult<LoadedSchema> {
+    let path = args_path
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(&config.schema.path));
+    if !path.exists() {
+        return Err(CliError::Config(format!(
+            "Schema not found: {}", path.display()
+        )));
+    }
+    prax_schema::load(&path).map_err(|LoadError { error, sources }| CliError::Schema {
+        error,
+        sources: Some(sources),
+    })
+}
+```
+
+Per-command treatment:
+
+| Command | Behavior change |
+|---|---|
+| `generate` | Use `loaded.schema` for codegen. Generated output unchanged. |
+| `migrate` | Use `loaded.schema` as desired state. Diffing unaffected. |
+| `validate` | `load()` already validates. Print success / error report. |
+| `db` (push/pull/seed) | Same as `migrate`. |
+| `format` | **Per-file**: when path is a directory, walk each `*.prax` and reformat it independently, rewriting in place. Skips merge — formatting is purely syntactic. |
+
+`format` is the **only** command that does not go through `load()`; it stays at the syntactic layer and uses `parse_schema(&str)` per file. A comment in the implementation explains why.
+
+#### Error rendering refactor
+
+`CliError::Schema` becomes a struct variant carrying both the error and the partial source map (which is `Some(_)` whenever the error came out of `load()`, `None` when raised earlier):
+
+```rust
+pub enum CliError {
+    // …
+    Schema {
+        error: prax_schema::SchemaError,
+        sources: Option<prax_schema::SourceMap>,
+    },
+}
+```
+
+The `Display` / miette impl renders via `error.report(sources)` when `sources.is_some()` and falls back to the bare error otherwise.
+
+### `prax-codegen` — `schema_reader.rs`
+
+`read_and_parse_schema(path: &str) -> Result<Schema, SchemaReadError>` becomes a thin wrapper around `prax_schema::load`, returning `LoadedSchema.schema`. It accepts either a file or a directory path transparently — the proc-macro path now also supports `prax::client!(path = "./prax/schema")` for multi-file projects without any macro-level changes.
+
+`SchemaReadError` either:
+
+- (Option 1, minimal) keeps its current shape and prints `file: line` from each `SourceLoc` directly without rendering snippets, *or*
+- (Option 2, fuller) adds a `SourceMap` field and renders miette diagnostics in compile-time errors.
+
+The plan picks Option 1 first and notes Option 2 as a follow-up — proc-macro span fidelity isn't critical for the multi-file rollout.
+
+### `prax-import` — multi-file Prisma import
+
+Today `prax_import::import_prisma_schema_file(path)` handles one `.prisma` file. We extend the importer to handle directories produced by Prisma's `prismaSchemaFolder` layout, emitting a mirrored directory of `.prax` files.
+
+#### Input/output detection (no new flags)
+
+- `--input` is a **file** → today's behavior, unchanged. `--output` defaults to `schema.prax`, must be a file path.
+- `--input` is a **directory** → multi-file mode. `--output` defaults to `./prax/schema`, must be a directory path. If it exists and is non-empty, `--force` is required to overwrite.
+
+Same auto-detect rule the loader uses — one mental model.
+
+#### Discovery
+
+Recursively walk `--input` for `*.prisma`, sorted lexicographically by relative path. Skip:
+
+- Hidden files and directories.
+- Symlinks.
+- `node_modules/`.
+
+(We deliberately do not reuse the loader's `target/` skip — the importer's skip set is Prisma-ecosystem-specific.)
+
+#### Conversion pipeline (parse → merge → split-emit)
+
+```
+Phase 1: parse + merge
+  for each prisma file:
+    parse_prisma_schema(content) → PrismaSchema   (per-file, no validation)
+    stamp each PrismaModel/PrismaEnum/PrismaDatasource/PrismaGenerator with a PrismaSourceId
+  merge per-file PrismaSchemas → one PrismaSchema with full provenance
+  cross-file rules:
+    - hard error on duplicate model/enum/type names across files
+    - hard error if more than one datasource block
+    - multiple generators allowed if distinctly named
+
+Phase 2: convert + emit
+  convert_prisma_to_prax on the merged PrismaSchema → one prax Schema
+  relation resolution runs once on the merged Schema (this is what makes
+  cross-file relations like `Post.author: User` work cleanly)
+  bucket each prax item by its PrismaSourceId
+  for each PrismaSourceId:
+    output_path = <output_dir>/<relative_path with .prax extension>
+    emit only the items in this bucket via format_schema()
+    create parent dirs as needed; write file
+```
+
+The key insight: **merge first, then split on emit**. Per-file conversion would fail on cross-file relation references (`Post` references `User` defined in `users.prisma`). Merging gives the converter the whole picture; bucketing by `PrismaSourceId` at emit time preserves the user's file organization.
+
+#### Mirroring rules
+
+- `prisma/schema.prisma` → `<output>/schema.prax`
+- `prisma/models/user.prisma` → `<output>/models/user.prax`
+- Datasource block stays in whichever output `.prax` mirrors the input `.prisma` that contained it.
+- `.prisma` files containing only comments / no declarations: no `.prax` emitted (logged in CLI output).
+- Empty `--input` directory: error.
+
+#### Result
+
+A Prisma project organized as:
+
+```
+prisma/
+  schema.prisma          # datasource + generator
+  models/
+    user.prisma
+    post.prisma
+  enums/
+    role.prisma
+```
+
+becomes, after `prax import --from prisma --input ./prisma --output ./prax/schema`:
+
+```
+prax/schema/
+  schema.prax            # datasource + generator
+  models/
+    user.prax
+    post.prax
+  enums/
+    role.prax
+```
+
+…which `prax load` then picks up directly because `[schema].path = "prax/schema"` is now a directory.
+
+#### Importer provenance is parallel, not unified
+
+`PrismaSourceId` in `prax-import` and `SourceId` in `prax-schema` are deliberately parallel types, not a single shared one. They operate on different ASTs (`PrismaSchema` vs `Schema`) and live in different crates. Unifying them would couple `prax-import` to `prax-schema`'s loader internals for no real gain.
+
+### What does **not** change
+
+- `prax-schema`'s `parse_schema(&str)` / `parse_schema_file(path)` public API.
+- `Schema` field shapes (only additive `source_id: Option<SourceId>` fields on top-level items).
+- `prax-query`, `prax-migrate`, all database engine crates — they consume `Schema`, agnostic to where it came from.
+- Generated client code shape — multi-file in, one cohesive output out.
+- Migration history / event log.
+
+## Testing strategy
+
+### `prax-schema` unit tests (`prax-schema/src/loader/` and `prax-schema/tests/`)
+
+**Discovery:**
+- Flat dir, three files: all picked up, sorted lexicographically.
+- Nested dirs: recursive descent finds files in `models/`, `enums/`.
+- `.git/`, `target/`, `.worktrees/`, hidden files: skipped.
+- Non-`.prax` files (`README.md`): ignored.
+- Empty directory → `EmptySchemaDirectory` error.
+- Single file (path is a file): single-file path still works.
+
+**Merge happy path:**
+- `User` in `users.prax`, `Post` in `posts.prax` with `User` relation across files → relation resolves.
+- `datasource` in one file, `generator` in another, models in a third → all present in merged schema.
+- `source_id` stamped correctly on each item.
+
+**Merge conflicts** (each produces `SchemaError::DuplicateAcrossFiles` with both `SourceLoc`s):
+- duplicate model name across files
+- duplicate enum / type / view / serverGroup / policy / generator / raw_sql
+- two datasource blocks → `MultipleDatasource`
+- multiple conflicts in one load → all reported in one error batch
+
+**Parse errors:**
+- Syntax error in one of many files → `ParseInFile` wraps it with the right `SourceId`.
+- File content retrievable through `SourceMap` for rendering.
+
+**Validation post-merge:**
+- Unknown type referenced across files: validator reports it.
+
+**Backward-compat regression snapshot:**
+- `load("examples/prax/schema.prax")` produces a `Schema` identical (modulo `source_id = Some(0)`) to today's `parse_schema_file("examples/prax/schema.prax")`.
+
+### Fixtures (`prax-schema/tests/fixtures/multi_file/`)
+
+```
+multi_file/
+  happy_path/          # models split across 3 files, all valid
+  duplicate_models/    # User in two files
+  nested/              # subdirs with models in them
+  empty/               # empty directory (with .gitkeep so git preserves it)
+  two_datasources/     # datasource block in two files
+  cross_file_relation/ # Post in one file, User in another
+```
+
+### CLI integration tests (`prax-cli/tests/`)
+
+- `prax generate --schema ./prax/schema` (directory) emits byte-identical output to `prax generate --schema ./schema.prax` for an equivalent concatenated layout.
+- `prax validate ./prax/schema` with a known duplicate model prints both file paths and line numbers.
+- `prax format ./prax/schema` reformats each file in place; total file count preserved.
+
+### Codegen tests (`prax-codegen/tests/`)
+
+- One trybuild case where the proc-macro receives a directory path and successfully generates a client.
+- Existing single-file trybuild cases stay as-is.
+
+### Importer tests (`prax-import/tests/`)
+
+- Single-file `.prisma` → single-file `.prax` (regression).
+- Multi-file `.prisma` directory → mirrored `.prax` directory; file count and relative paths match.
+- Cross-file relation in Prisma survives the round-trip and resolves cleanly when the output is then loaded via `prax_schema::load`.
+- `datasource` / `generator` stay in their original (mirrored) files.
+- A Prisma file with only comments → no `.prax` emitted.
+- `--input` directory, `--output` non-empty directory without `--force` → error.
+
+### Out of scope for tests
+
+- Live database round-trips for multi-file (covered by existing engine tests; they consume `Schema`, not files).
+- Performance benchmarks for very large directories. Realistic schemas have <100 files; this won't show up in profiles.
+
+## Migration & rollout
+
+- Single PR to `develop` containing all changes (loader, AST provenance, CLI integration, importer multi-file).
+- No CHANGELOG-visible breakage — all changes additive on the public API (single-file path preserved; `Schema::merge` deprecated but kept for one release).
+- A short docs note in the repo README + `examples/` showing the new directory layout.
+- `prax init --multi-file` lands in the same PR so users discovering multi-file have a one-command path.
+
+## Open questions deferred to the plan
+
+- Should `walkdir` be added directly to `prax-schema/Cargo.toml` or pulled in via a small bespoke walker (~30 LoC)? Plan decides based on existing dep tree.
+- Proc-macro error-rendering richness (option 1 vs option 2 above) — start with option 1; option 2 is a follow-up.
+- Whether the `--multi-file` flag on `prax init` is `--multi-file` or `--layout=directory`. Plan picks one.

--- a/prax-cli/src/cli.rs
+++ b/prax-cli/src/cli.rs
@@ -457,7 +457,7 @@ pub struct ImportArgs {
 }
 
 /// Source ORM for import
-#[derive(ValueEnum, Debug, Clone, Copy)]
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ImportSource {
     /// Prisma schema (.prisma files)
     Prisma,

--- a/prax-cli/src/commands/db.rs
+++ b/prax-cli/src/commands/db.rs
@@ -27,9 +27,13 @@ async fn run_push(args: crate::cli::DbPushArgs) -> CliResult<()> {
 
     let cwd = std::env::current_dir()?;
     let config = load_config(&cwd)?;
-    let schema_path = args.schema.unwrap_or_else(|| cwd.join(SCHEMA_FILE_PATH));
 
-    output::kv("Schema", &schema_path.display().to_string());
+    let display_path = args
+        .schema
+        .as_deref()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| SCHEMA_FILE_PATH.to_string());
+    output::kv("Schema", &display_path);
     output::kv(
         "Database",
         config
@@ -42,8 +46,8 @@ async fn run_push(args: crate::cli::DbPushArgs) -> CliResult<()> {
 
     // Parse schema
     output::step(1, 4, "Parsing schema...");
-    let schema_content = std::fs::read_to_string(&schema_path)?;
-    let schema = parse_schema(&schema_content)?;
+    let loaded = crate::schema_loader::load_schema(args.schema.as_deref())?;
+    let schema = loaded.schema;
 
     // Introspect database
     output::step(2, 4, "Introspecting database...");
@@ -368,13 +372,6 @@ fn load_config(cwd: &Path) -> CliResult<Config> {
     } else {
         Ok(Config::default())
     }
-}
-
-fn parse_schema(content: &str) -> CliResult<prax_schema::Schema> {
-    // Use validate_schema to ensure field types are properly resolved
-    // (e.g., FieldType::Model -> FieldType::Enum for enum references)
-    prax_schema::validate_schema(content)
-        .map_err(|e| CliError::Schema(format!("Failed to parse/validate schema: {}", e)))
 }
 
 fn calculate_schema_changes(_schema: &prax_schema::ast::Schema) -> CliResult<Vec<SchemaChange>> {

--- a/prax-cli/src/commands/format.rs
+++ b/prax-cli/src/commands/format.rs
@@ -1,9 +1,7 @@
 //! `prax format` command - Format Prax schema file(s).
 //!
-//! Note: `format` is the one CLI command that does NOT go through
-//! `prax_schema::load()`. Loading merges and validates across files; formatting
-//! is purely syntactic and per-file, so it operates on each `.prax` file
-//! independently to preserve the user's file layout.
+//! Bypasses `prax_schema::load` deliberately: formatting is per-file and
+//! syntactic, so cross-file merge/validation would only get in the way.
 
 use std::path::Path;
 
@@ -30,8 +28,7 @@ pub async fn run(args: FormatArgs) -> CliResult<()> {
     output::newline();
 
     let files: Vec<std::path::PathBuf> = if schema_path.is_dir() {
-        let discovered =
-            prax_schema::loader::discovery::discover(&schema_path).map_err(CliError::from)?;
+        let discovered = prax_schema::loader::discover(&schema_path).map_err(CliError::from)?;
         if discovered.is_empty() {
             return Err(CliError::Config(format!(
                 "No .prax files found under {}",

--- a/prax-cli/src/commands/format.rs
+++ b/prax-cli/src/commands/format.rs
@@ -1,4 +1,11 @@
-//! `prax format` command - Format Prax schema file.
+//! `prax format` command - Format Prax schema file(s).
+//!
+//! Note: `format` is the one CLI command that does NOT go through
+//! `prax_schema::load()`. Loading merges and validates across files; formatting
+//! is purely syntactic and per-file, so it operates on each `.prax` file
+//! independently to preserve the user's file layout.
+
+use std::path::Path;
 
 use crate::cli::FormatArgs;
 use crate::config::SCHEMA_FILE_PATH;
@@ -14,7 +21,7 @@ pub async fn run(args: FormatArgs) -> CliResult<()> {
 
     if !schema_path.exists() {
         return Err(CliError::Config(format!(
-            "Schema file not found: {}",
+            "Schema path not found: {}",
             schema_path.display()
         )));
     }
@@ -22,47 +29,83 @@ pub async fn run(args: FormatArgs) -> CliResult<()> {
     output::kv("Schema", &schema_path.display().to_string());
     output::newline();
 
-    // Read schema
-    output::step(1, 3, "Reading schema...");
-    let schema_content = std::fs::read_to_string(&schema_path)?;
+    let files: Vec<std::path::PathBuf> = if schema_path.is_dir() {
+        let discovered =
+            prax_schema::loader::discovery::discover(&schema_path).map_err(CliError::from)?;
+        if discovered.is_empty() {
+            return Err(CliError::Config(format!(
+                "No .prax files found under {}",
+                schema_path.display()
+            )));
+        }
+        discovered.into_iter().map(|d| d.absolute).collect()
+    } else {
+        vec![schema_path.clone()]
+    };
 
-    // Parse schema to validate it first
-    let schema = parse_schema(&schema_content)?;
-
-    // Format schema
-    output::step(2, 3, "Formatting...");
-    let formatted = format_schema(&schema);
-
-    // Check if formatting changed anything
-    let changed = formatted != schema_content;
-
-    if args.check {
-        // Check mode - just report if formatting is needed
-        if changed {
-            output::newline();
-            output::error("Schema is not formatted correctly!");
-            output::info("Run `prax format` to fix formatting.");
-            return Err(CliError::Format("Schema needs formatting".to_string()));
-        } else {
-            output::newline();
-            success("Schema is already formatted!");
-            return Ok(());
+    let mut any_changed = false;
+    let mut any_needs_format = false;
+    for file in &files {
+        match format_one(file, args.check)? {
+            FormatOutcome::Unchanged => {}
+            FormatOutcome::Reformatted => any_changed = true,
+            FormatOutcome::NeedsFormatting => any_needs_format = true,
         }
     }
 
-    // Write formatted schema
-    output::step(3, 3, "Writing formatted schema...");
-
-    if changed {
-        std::fs::write(&schema_path, &formatted)?;
-        output::newline();
-        success("Schema formatted successfully!");
+    output::newline();
+    if args.check {
+        if any_needs_format {
+            output::error("Some schema files are not formatted correctly.");
+            output::info("Run `prax format` to fix formatting.");
+            return Err(CliError::Format(
+                "One or more schema files need formatting".to_string(),
+            ));
+        }
+        success(&format!(
+            "All {} schema file(s) are formatted!",
+            files.len()
+        ));
+    } else if any_changed {
+        success(&format!("Formatted {} schema file(s).", files.len()));
     } else {
-        output::newline();
-        success("Schema is already formatted!");
+        success(&format!(
+            "All {} schema file(s) are already formatted!",
+            files.len()
+        ));
     }
 
     Ok(())
+}
+
+enum FormatOutcome {
+    Unchanged,
+    Reformatted,
+    NeedsFormatting,
+}
+
+fn format_one(path: &Path, check: bool) -> CliResult<FormatOutcome> {
+    let content = std::fs::read_to_string(path)?;
+    let schema = parse_schema(&content)?;
+    let formatted = format_schema(&schema);
+    let changed = formatted != content;
+
+    if check {
+        return Ok(if changed {
+            output::error(&format!("Needs formatting: {}", path.display()));
+            FormatOutcome::NeedsFormatting
+        } else {
+            FormatOutcome::Unchanged
+        });
+    }
+
+    if changed {
+        std::fs::write(path, &formatted)?;
+        output::list_item(&format!("Formatted {}", path.display()));
+        Ok(FormatOutcome::Reformatted)
+    } else {
+        Ok(FormatOutcome::Unchanged)
+    }
 }
 
 fn parse_schema(content: &str) -> CliResult<prax_schema::Schema> {

--- a/prax-cli/src/commands/generate.rs
+++ b/prax-cli/src/commands/generate.rs
@@ -5,8 +5,9 @@ use std::path::{Path, PathBuf};
 
 use crate::cli::GenerateArgs;
 use crate::config::{CONFIG_FILE_NAME, Config, SCHEMA_FILE_PATH};
-use crate::error::{CliError, CliResult};
+use crate::error::CliResult;
 use crate::output::{self, success};
+use crate::schema_loader::load_schema;
 
 /// Run the generate command
 pub async fn run(args: GenerateArgs) -> CliResult<()> {
@@ -22,38 +23,31 @@ pub async fn run(args: GenerateArgs) -> CliResult<()> {
         Config::default()
     };
 
-    // Resolve schema path
-    let schema_path = args
-        .schema
-        .clone()
-        .unwrap_or_else(|| cwd.join(SCHEMA_FILE_PATH));
-    if !schema_path.exists() {
-        return Err(CliError::Config(format!(
-            "Schema file not found: {}",
-            schema_path.display()
-        )));
-    }
-
     // Resolve output directory
     let output_dir = args
         .output
         .clone()
         .unwrap_or_else(|| PathBuf::from(&config.generator.output));
 
-    output::kv("Schema", &schema_path.display().to_string());
+    let display_path = args
+        .schema
+        .as_deref()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| SCHEMA_FILE_PATH.to_string());
+    output::kv("Schema", &display_path);
     output::kv("Output", &output_dir.display().to_string());
     output::newline();
 
     output::step(1, 4, "Reading schema...");
 
-    // Parse schema
-    let schema_content = std::fs::read_to_string(&schema_path)?;
-    let schema = parse_schema(&schema_content)?;
+    let loaded = load_schema(args.schema.as_deref())?;
+    let schema = &loaded.schema;
+    if loaded.sources.len() > 1 {
+        output::kv("Source files", &loaded.sources.len().to_string());
+    }
 
     output::step(2, 4, "Validating schema...");
-
-    // Validate schema
-    validate_schema(&schema)?;
+    // Validation already happened inside load_schema.
 
     output::step(3, 4, "Generating code...");
 
@@ -61,7 +55,7 @@ pub async fn run(args: GenerateArgs) -> CliResult<()> {
     std::fs::create_dir_all(&output_dir)?;
 
     // Generate code
-    let generated_files = generate_code(&schema, &output_dir, &args, &config)?;
+    let generated_files = generate_code(schema, &output_dir, &args, &config)?;
 
     output::step(4, 4, "Writing files...");
 
@@ -79,26 +73,8 @@ pub async fn run(args: GenerateArgs) -> CliResult<()> {
     }
 
     output::newline();
-    success(&format!(
-        "Generated {} files in {:.2}s",
-        generated_files.len(),
-        0.0 // TODO: Add timing
-    ));
+    success(&format!("Generated {} files", generated_files.len()));
 
-    Ok(())
-}
-
-/// Parse and validate the schema file
-fn parse_schema(content: &str) -> CliResult<prax_schema::Schema> {
-    // Use validate_schema to ensure field types are properly resolved
-    // (e.g., FieldType::Model -> FieldType::Enum for enum references)
-    prax_schema::validate_schema(content)
-        .map_err(|e| CliError::Schema(format!("Failed to parse/validate schema: {}", e)))
-}
-
-/// Validate the schema (now a no-op since parse_schema does validation)
-fn validate_schema(_schema: &prax_schema::Schema) -> CliResult<()> {
-    // Validation is now done in parse_schema via validate_schema()
     Ok(())
 }
 

--- a/prax-cli/src/commands/import.rs
+++ b/prax-cli/src/commands/import.rs
@@ -25,15 +25,46 @@ pub async fn run(args: ImportArgs) -> CliResult<()> {
             .unwrap_or_else(|| "stdout".to_string())
     ));
 
-    // Check if input file exists
+    // Check if input file/directory exists
     if !args.input.exists() {
         return Err(CliError::Config(format!(
-            "Input file not found: {}",
+            "Input not found: {}",
             args.input.display()
         )));
     }
 
-    // Import the schema
+    // Multi-file Prisma input: auto-detect directory and mirror it.
+    if args.input.is_dir() {
+        if args.from != ImportSource::Prisma {
+            return Err(CliError::Config(
+                "Directory inputs are only supported with --from prisma".to_string(),
+            ));
+        }
+        let output_dir = args
+            .output
+            .clone()
+            .unwrap_or_else(|| std::path::PathBuf::from("./prax/schema"));
+        let count = prax_import::prisma::import_prisma_directory(
+            &args.input,
+            &output_dir,
+            format_schema,
+            args.force,
+        )
+        .map_err(|e| CliError::Config(format!("Import failed: {e}")))?;
+        output::success(&format!(
+            "✓ Imported {count} files into {}",
+            output_dir.display()
+        ));
+        output::newline();
+        output::info("Next steps:");
+        output::info("  1. Review the generated schema directory");
+        output::info("  2. Set `[schema].path = \"prax/schema\"` in prax.toml (if needed)");
+        output::info("  3. Run `prax validate` to check the merged schema");
+        output::info("  4. Run `prax generate` to generate Rust client code");
+        return Ok(());
+    }
+
+    // Import the schema (single-file path).
     let prax_schema = match args.from {
         ImportSource::Prisma => import_from_prisma(&args.input)?,
         ImportSource::Diesel => import_from_diesel(&args.input)?,

--- a/prax-cli/src/commands/import.rs
+++ b/prax-cli/src/commands/import.rs
@@ -185,10 +185,10 @@ fn format_schema(schema: &prax_schema::Schema) -> String {
             // dimension in `ScalarType::Vector(Option<u32>)` etc. The schema
             // parser expects the dimension as a separate `@dim(N)` attribute
             // rather than inline `Vector(N)` syntax, so emit it explicitly.
-            if let prax_schema::FieldType::Scalar(scalar) = &field.field_type {
-                if let Some(dim) = scalar.dimension() {
-                    output.push_str(&format!(" @dim({})", dim));
-                }
+            if let prax_schema::FieldType::Scalar(scalar) = &field.field_type
+                && let Some(dim) = scalar.dimension()
+            {
+                output.push_str(&format!(" @dim({})", dim));
             }
 
             // Add attributes

--- a/prax-cli/src/commands/migrate.rs
+++ b/prax-cli/src/commands/migrate.rs
@@ -29,13 +29,14 @@ async fn run_dev(args: crate::cli::MigrateDevArgs) -> CliResult<()> {
     let cwd = std::env::current_dir()?;
     let config = load_config(&cwd)?;
 
-    let schema_path = args
-        .schema
-        .clone()
-        .unwrap_or_else(|| cwd.join(SCHEMA_FILE_PATH));
     let migrations_dir = cwd.join(MIGRATIONS_DIR);
 
-    output::kv("Schema", &schema_path.display().to_string());
+    let display_path = args
+        .schema
+        .as_deref()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| SCHEMA_FILE_PATH.to_string());
+    output::kv("Schema", &display_path);
     output::kv("Migrations", &migrations_dir.display().to_string());
     output::newline();
 
@@ -44,8 +45,8 @@ async fn run_dev(args: crate::cli::MigrateDevArgs) -> CliResult<()> {
 
     // 1. Parse and validate schema
     output::step(1, total_steps, "Parsing schema...");
-    let schema_content = std::fs::read_to_string(&schema_path)?;
-    let schema = parse_schema(&schema_content)?;
+    let loaded = crate::schema_loader::load_schema(args.schema.as_deref())?;
+    let schema = loaded.schema;
 
     // 2. Check for pending migrations
     output::step(2, total_steps, "Checking migration status...");
@@ -319,13 +320,12 @@ async fn run_resolve(args: crate::cli::MigrateResolveArgs) -> CliResult<()> {
 async fn run_diff(args: crate::cli::MigrateDiffArgs) -> CliResult<()> {
     output::header("Migrate Diff");
 
-    let cwd = std::env::current_dir()?;
-    let schema_path = args.schema.unwrap_or_else(|| cwd.join(SCHEMA_FILE_PATH));
+    let _cwd = std::env::current_dir()?;
 
     // Parse schema
     output::step(1, 3, "Parsing schema...");
-    let schema_content = std::fs::read_to_string(&schema_path)?;
-    let schema = parse_schema(&schema_content)?;
+    let loaded = crate::schema_loader::load_schema(args.schema.as_deref())?;
+    let schema = loaded.schema;
 
     // Get current database state
     output::step(2, 3, "Introspecting database...");
@@ -437,13 +437,6 @@ fn load_config(cwd: &Path) -> CliResult<Config> {
     } else {
         Ok(Config::default())
     }
-}
-
-fn parse_schema(content: &str) -> CliResult<prax_schema::Schema> {
-    // Use validate_schema to ensure field types are properly resolved
-    // (e.g., FieldType::Model -> FieldType::Enum for enum references)
-    prax_schema::validate_schema(content)
-        .map_err(|e| CliError::Schema(format!("Failed to parse/validate schema: {}", e)))
 }
 
 fn check_pending_migrations(migrations_dir: &Path) -> CliResult<Vec<PathBuf>> {

--- a/prax-cli/src/commands/validate.rs
+++ b/prax-cli/src/commands/validate.rs
@@ -9,31 +9,29 @@ use crate::output::{self, success, warn};
 pub async fn run(args: ValidateArgs) -> CliResult<()> {
     output::header("Validate Schema");
 
-    let cwd = std::env::current_dir()?;
-    let schema_path = args.schema.unwrap_or_else(|| cwd.join(SCHEMA_FILE_PATH));
-
-    if !schema_path.exists() {
-        return Err(CliError::Config(format!(
-            "Schema file not found: {}",
-            schema_path.display()
-        )));
-    }
-
-    output::kv("Schema", &schema_path.display().to_string());
+    let display_path = args
+        .schema
+        .as_deref()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| SCHEMA_FILE_PATH.to_string());
+    output::kv("Schema", &display_path);
     output::newline();
 
     // Parse schema
     output::step(1, 3, "Parsing schema...");
-    let schema_content = std::fs::read_to_string(&schema_path)?;
-    let schema = parse_schema(&schema_content)?;
+    let loaded = crate::schema_loader::load_schema(args.schema.as_deref())?;
+    let schema = &loaded.schema;
+    if loaded.sources.len() > 1 {
+        output::kv("Source files", &loaded.sources.len().to_string());
+    }
 
     // Validate schema
     output::step(2, 3, "Running validation checks...");
-    let validation_result = validate_schema(&schema);
+    let validation_result = validate_schema(schema);
 
     // Check config
     output::step(3, 3, "Checking configuration...");
-    let config_warnings = check_config(&schema);
+    let config_warnings = check_config(schema);
 
     output::newline();
 
@@ -104,20 +102,6 @@ pub async fn run(args: ValidateArgs) -> CliResult<()> {
     output::kv("Relations", &relations.to_string());
 
     Ok(())
-}
-
-fn parse_schema(content: &str) -> CliResult<prax_schema::Schema> {
-    // Use validate_schema to ensure field types are properly resolved
-    // (e.g., FieldType::Model -> FieldType::Enum for enum references)
-    prax_schema::validate_schema(content).map_err(|e| {
-        // `e.to_string()` returns only the top-level `#[error("...")]` template;
-        // the useful detail (which model, which field, the inner message from
-        // `SyntaxError`, or the per-error list inside `ValidationFailed`) is on
-        // sub-fields and #[related]. Format via miette so the report shows the
-        // full diagnostic chain instead of a generic "syntax error in schema".
-        let report = miette::Report::from(e).with_source_code(content.to_string());
-        CliError::Schema(format!("{report:?}"))
-    })
 }
 
 fn validate_schema(schema: &prax_schema::ast::Schema) -> Result<(), Vec<String>> {

--- a/prax-cli/src/error.rs
+++ b/prax-cli/src/error.rs
@@ -66,3 +66,65 @@ impl From<toml::ser::Error> for CliError {
         CliError::Config(format!("Failed to serialize TOML: {}", err))
     }
 }
+
+impl From<prax_schema::LoadError> for CliError {
+    fn from(e: prax_schema::LoadError) -> Self {
+        use prax_schema::SchemaError;
+        // Resolve SourceId references to file paths for human-readable output.
+        let resolved = render_schema_error(&e.error, &e.sources);
+        match &e.error {
+            SchemaError::ValidationFailed { .. } => CliError::Validation(resolved),
+            _ => CliError::Schema(resolved),
+        }
+    }
+}
+
+impl From<prax_schema::SchemaError> for CliError {
+    fn from(e: prax_schema::SchemaError) -> Self {
+        use prax_schema::SchemaError;
+        match &e {
+            SchemaError::ValidationFailed { .. } => CliError::Validation(e.to_string()),
+            _ => CliError::Schema(e.to_string()),
+        }
+    }
+}
+
+/// Render a SchemaError with file paths resolved from the SourceMap.
+fn render_schema_error(err: &prax_schema::SchemaError, sources: &prax_schema::SourceMap) -> String {
+    use prax_schema::SchemaError;
+    use std::fmt::Write;
+
+    let mut out = err.to_string();
+    match err {
+        SchemaError::ParseInFile { source, inner } => {
+            if let Some(p) = sources.path_of(*source) {
+                let _ = write!(out, "\n  in: {}\n  detail: {}", p.display(), inner);
+            }
+        }
+        SchemaError::DuplicateAcrossFiles { first, second, .. }
+        | SchemaError::MultipleDatasource { first, second } => {
+            if let (Some(a), Some(b)) = (
+                sources.path_of(first.source),
+                sources.path_of(second.source),
+            ) {
+                let _ = write!(
+                    out,
+                    "\n  first:  {} (bytes {}..{})\n  second: {} (bytes {}..{})",
+                    a.display(),
+                    first.span.start,
+                    first.span.end,
+                    b.display(),
+                    second.span.start,
+                    second.span.end,
+                );
+            }
+        }
+        SchemaError::ValidationFailed { errors, .. } => {
+            for (i, e) in errors.iter().enumerate() {
+                let _ = write!(out, "\n  {}. {}", i + 1, render_schema_error(e, sources));
+            }
+        }
+        _ => {}
+    }
+    out
+}

--- a/prax-cli/src/lib.rs
+++ b/prax-cli/src/lib.rs
@@ -8,3 +8,4 @@ pub mod commands;
 pub mod config;
 pub mod error;
 pub mod output;
+pub mod schema_loader;

--- a/prax-cli/src/schema_loader.rs
+++ b/prax-cli/src/schema_loader.rs
@@ -1,0 +1,26 @@
+//! Shared schema-loading helper used by every CLI command.
+//!
+//! Resolves the schema path (from --schema arg or default), then delegates to
+//! `prax_schema::load` which auto-detects file vs. directory.
+
+use std::path::{Path, PathBuf};
+
+use prax_schema::{LoadedSchema, load};
+
+use crate::config::SCHEMA_FILE_PATH;
+use crate::error::{CliError, CliResult};
+
+/// Load the schema, preferring `args_path` if Some, falling back to the
+/// configured / default schema path.
+pub fn load_schema(args_path: Option<&Path>) -> CliResult<LoadedSchema> {
+    let path: PathBuf = args_path
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(SCHEMA_FILE_PATH));
+    if !path.exists() {
+        return Err(CliError::Config(format!(
+            "Schema not found: {}",
+            path.display()
+        )));
+    }
+    Ok(load(&path)?)
+}

--- a/prax-cli/src/schema_loader.rs
+++ b/prax-cli/src/schema_loader.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use prax_schema::{LoadedSchema, load};
 
 use crate::config::SCHEMA_FILE_PATH;
-use crate::error::{CliError, CliResult};
+use crate::error::CliResult;
 
 /// Load the schema, preferring `args_path` if Some, falling back to the
 /// configured / default schema path.
@@ -16,11 +16,5 @@ pub fn load_schema(args_path: Option<&Path>) -> CliResult<LoadedSchema> {
     let path: PathBuf = args_path
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from(SCHEMA_FILE_PATH));
-    if !path.exists() {
-        return Err(CliError::Config(format!(
-            "Schema not found: {}",
-            path.display()
-        )));
-    }
     Ok(load(&path)?)
 }

--- a/prax-cli/tests/cli_tests.rs
+++ b/prax-cli/tests/cli_tests.rs
@@ -433,3 +433,35 @@ enum Role {
         );
     }
 }
+
+#[test]
+fn test_import_prisma_directory_creates_mirrored_prax_directory() {
+    let input = TempDir::new().unwrap();
+    fs::create_dir_all(input.path().join("models")).unwrap();
+    fs::write(
+        input.path().join("schema.prisma"),
+        r#"datasource db { provider = "postgresql" url = env("X") }"#,
+    )
+    .unwrap();
+    fs::write(
+        input.path().join("models/u.prisma"),
+        "model U { id Int @id @default(autoincrement()) }",
+    )
+    .unwrap();
+
+    let output_dir = TempDir::new().unwrap();
+    prax_cmd()
+        .arg("import")
+        .arg("--from")
+        .arg("prisma")
+        .arg("--input")
+        .arg(input.path())
+        .arg("--output")
+        .arg(output_dir.path())
+        .arg("--force")
+        .assert()
+        .success();
+
+    assert!(output_dir.path().join("schema.prax").exists());
+    assert!(output_dir.path().join("models/u.prax").exists());
+}

--- a/prax-codegen/src/schema_reader.rs
+++ b/prax-codegen/src/schema_reader.rs
@@ -3,7 +3,7 @@
 use std::env;
 use std::path::{Path, PathBuf};
 
-use prax_schema::{ModelStyle, PraxConfig, Schema, validate_schema};
+use prax_schema::{ModelStyle, PraxConfig, Schema, load};
 
 /// Result of reading schema and config files.
 pub struct SchemaWithConfig {
@@ -14,6 +14,9 @@ pub struct SchemaWithConfig {
 }
 
 /// Read and parse a schema file, resolving the path relative to the crate root.
+///
+/// `path` may point at a single `.prax` file or a directory; in the latter case
+/// every `*.prax` is loaded recursively and merged (see `prax_schema::load`).
 #[allow(dead_code)]
 pub fn read_and_parse_schema(path: &str) -> Result<Schema, SchemaReadError> {
     let result = read_schema_with_config(path)?;
@@ -24,24 +27,20 @@ pub fn read_and_parse_schema(path: &str) -> Result<Schema, SchemaReadError> {
 pub fn read_schema_with_config(path: &str) -> Result<SchemaWithConfig, SchemaReadError> {
     let full_path = resolve_schema_path(path)?;
 
-    let content = std::fs::read_to_string(&full_path).map_err(|e| SchemaReadError::Io {
+    // load() handles both single-file and multi-file directory paths.
+    let loaded = load(&full_path).map_err(|e| SchemaReadError::Validation {
         path: full_path.display().to_string(),
-        error: e.to_string(),
+        error: e.error.to_string(),
     })?;
 
-    // validate_schema parses and validates in one step
-    let schema = validate_schema(&content).map_err(|e| SchemaReadError::Validation {
-        path: full_path.display().to_string(),
-        error: e.to_string(),
-    })?;
-
-    // Try to load prax.toml from the same directory or parent directories
+    // load_prax_config walks up from the schema path's parent looking for prax.toml,
+    // which works for both file paths and directory paths.
     let model_style = load_prax_config(&full_path)
         .map(|c| c.generator.client.model_style)
         .unwrap_or_default();
 
     Ok(SchemaWithConfig {
-        schema,
+        schema: loaded.schema,
         model_style,
     })
 }

--- a/prax-import/Cargo.toml
+++ b/prax-import/Cargo.toml
@@ -39,6 +39,9 @@ convert_case.workspace = true
 smol_str.workspace = true
 once_cell = "1.20"
 
+# Filesystem (multi-file Prisma input discovery)
+walkdir.workspace = true
+
 [dev-dependencies]
 insta.workspace = true
 pretty_assertions.workspace = true

--- a/prax-import/src/converter.rs
+++ b/prax-import/src/converter.rs
@@ -68,6 +68,7 @@ impl SchemaBuilder {
             extensions: vec![],
             properties: vec![],
             span: dummy_span(),
+            source_id: None,
         };
         self.schema.set_datasource(datasource);
         self

--- a/prax-import/src/error.rs
+++ b/prax-import/src/error.rs
@@ -48,4 +48,35 @@ pub enum ImportError {
     #[error("Invalid configuration: {0}")]
     #[diagnostic(code(prax_import::invalid_config))]
     InvalidConfig(String),
+
+    /// Duplicate Prisma model across files in a multi-file directory.
+    #[error("duplicate prisma model `{name}` across files (source {} vs {})", .first.0, .second.0)]
+    #[diagnostic(code(prax_import::prisma::duplicate_model))]
+    DuplicatePrismaModel {
+        name: String,
+        first: crate::prisma::types::PrismaSourceId,
+        second: crate::prisma::types::PrismaSourceId,
+    },
+
+    /// Duplicate Prisma enum across files.
+    #[error("duplicate prisma enum `{name}` across files (source {} vs {})", .first.0, .second.0)]
+    #[diagnostic(code(prax_import::prisma::duplicate_enum))]
+    DuplicatePrismaEnum {
+        name: String,
+        first: crate::prisma::types::PrismaSourceId,
+        second: crate::prisma::types::PrismaSourceId,
+    },
+
+    /// Multiple datasource blocks across Prisma files.
+    #[error("multiple datasource blocks across prisma files (source {} vs {})", .first.0, .second.0)]
+    #[diagnostic(code(prax_import::prisma::multiple_datasource))]
+    MultiplePrismaDatasource {
+        first: crate::prisma::types::PrismaSourceId,
+        second: crate::prisma::types::PrismaSourceId,
+    },
+
+    /// Multi-file Prisma input directory contained no `*.prisma` files.
+    #[error("no .prisma files found under `{}`", .path.display())]
+    #[diagnostic(code(prax_import::prisma::empty_directory))]
+    EmptyPrismaDirectory { path: std::path::PathBuf },
 }

--- a/prax-import/src/prisma/mod.rs
+++ b/prax-import/src/prisma/mod.rs
@@ -3,9 +3,11 @@
 //! This module provides utilities to parse Prisma schema files and convert
 //! them to Prax schema format.
 
+pub mod multi_file;
 mod parser;
 pub mod types;
 
+pub use multi_file::{PrismaFile, PrismaSourceMap, discover_prisma, parse_and_merge_directory};
 pub use parser::{
     import_prisma_schema, import_prisma_schema_file, parse_prisma_file, parse_prisma_schema,
 };

--- a/prax-import/src/prisma/mod.rs
+++ b/prax-import/src/prisma/mod.rs
@@ -7,7 +7,10 @@ pub mod multi_file;
 mod parser;
 pub mod types;
 
-pub use multi_file::{PrismaFile, PrismaSourceMap, discover_prisma, parse_and_merge_directory};
+pub use multi_file::{
+    PrismaFile, PrismaSourceMap, discover_prisma, import_prisma_directory,
+    parse_and_merge_directory,
+};
 pub use parser::{
     import_prisma_schema, import_prisma_schema_file, parse_prisma_file, parse_prisma_schema,
 };

--- a/prax-import/src/prisma/multi_file.rs
+++ b/prax-import/src/prisma/multi_file.rs
@@ -115,7 +115,7 @@ pub fn parse_and_merge_directory(root: &Path) -> ImportResult<(PrismaSchema, Pri
         });
     }
 
-    let mut sources = PrismaSourceMap {
+    let sources = PrismaSourceMap {
         files: files.clone(),
     };
     let mut merged = PrismaSchema::default();
@@ -128,7 +128,6 @@ pub fn parse_and_merge_directory(root: &Path) -> ImportResult<(PrismaSchema, Pri
         try_merge_prisma(&mut merged, per_file, sid)?;
     }
 
-    let _ = &mut sources; // sources is built in-place above; suppress unused-mut if any
     Ok((merged, sources))
 }
 

--- a/prax-import/src/prisma/multi_file.rs
+++ b/prax-import/src/prisma/multi_file.rs
@@ -13,6 +13,7 @@ use walkdir::WalkDir;
 use super::parser::parse_prisma_schema;
 use super::types::{PrismaSchema, PrismaSourceId};
 use crate::error::{ImportError, ImportResult};
+use prax_schema::Schema;
 
 /// A discovered `.prisma` file with absolute + relative paths.
 #[derive(Debug, Clone)]
@@ -180,6 +181,101 @@ fn try_merge_prisma(
     Ok(())
 }
 
+/// Convert a directory of `.prisma` files into a mirrored directory of `.prax`
+/// files. Each output file contains only the items that came from its
+/// corresponding input file (bucketed by `PrismaSourceId`), with the merged
+/// AST guaranteeing cross-file relations resolve cleanly.
+///
+/// `format_text` is the renderer that turns a per-file [`Schema`] back into
+/// `.prax` source text — the CLI's existing `format_schema` is a natural fit.
+///
+/// Returns the number of `.prax` files emitted. Skips source buckets that
+/// would produce an empty output (e.g. a `.prisma` file with only comments).
+///
+/// Pre-flight: if `output` exists and is non-empty, requires `force` to be
+/// true; otherwise errors with `ImportError::InvalidConfig`.
+pub fn import_prisma_directory<F>(
+    input: &Path,
+    output: &Path,
+    format_text: F,
+    force: bool,
+) -> ImportResult<usize>
+where
+    F: Fn(&Schema) -> String,
+{
+    if output.exists() {
+        let is_empty = output
+            .read_dir()
+            .map(|mut d| d.next().is_none())
+            .unwrap_or(true);
+        if !is_empty && !force {
+            return Err(ImportError::InvalidConfig(format!(
+                "output directory {} is not empty (pass --force to overwrite)",
+                output.display()
+            )));
+        }
+    }
+
+    let (merged_prisma, sources) = parse_and_merge_directory(input)?;
+    let merged_prax = super::parser::convert_prisma_to_prax(merged_prisma)?;
+
+    // Bucket prax items by their (translated) PrismaSourceId.
+    let mut buckets: std::collections::BTreeMap<PrismaSourceId, Schema> =
+        std::collections::BTreeMap::new();
+    bucket_prax_items(&merged_prax, &mut buckets);
+
+    std::fs::create_dir_all(output)?;
+
+    let mut emitted = 0usize;
+    for (sid, prax_for_file) in &buckets {
+        if is_empty_schema(prax_for_file) {
+            continue;
+        }
+        let Some(file) = sources.get(*sid) else {
+            continue;
+        };
+        let mut out_path = output.join(&file.relative);
+        out_path.set_extension("prax");
+        if let Some(parent) = out_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let text = format_text(prax_for_file);
+        std::fs::write(&out_path, text)?;
+        emitted += 1;
+    }
+    Ok(emitted)
+}
+
+fn is_empty_schema(s: &Schema) -> bool {
+    s.models.is_empty()
+        && s.enums.is_empty()
+        && s.types.is_empty()
+        && s.views.is_empty()
+        && s.datasource.is_none()
+        && s.generators.is_empty()
+}
+
+fn bucket_prax_items(
+    merged: &Schema,
+    out: &mut std::collections::BTreeMap<PrismaSourceId, Schema>,
+) {
+    use prax_schema::SourceId;
+    let to_prisma = |s: SourceId| PrismaSourceId(s.0);
+
+    for m in merged.models.values() {
+        let sid = m.source_id.map(to_prisma).unwrap_or(PrismaSourceId(0));
+        out.entry(sid).or_default().add_model(m.clone());
+    }
+    for e in merged.enums.values() {
+        let sid = e.source_id.map(to_prisma).unwrap_or(PrismaSourceId(0));
+        out.entry(sid).or_default().add_enum(e.clone());
+    }
+    if let Some(ds) = &merged.datasource {
+        let sid = ds.source_id.map(to_prisma).unwrap_or(PrismaSourceId(0));
+        out.entry(sid).or_default().set_datasource(ds.clone());
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -234,5 +330,84 @@ model A {
         let dir = tempdir().unwrap();
         let err = parse_and_merge_directory(dir.path()).unwrap_err();
         assert!(matches!(err, ImportError::EmptyPrismaDirectory { .. }));
+    }
+
+    /// Trivial test renderer — emits a marker so we can verify which models
+    /// landed in which file without depending on the CLI's format_schema.
+    fn debug_render(s: &Schema) -> String {
+        let mut out = String::new();
+        if let Some(ds) = &s.datasource {
+            out.push_str(&format!(
+                "// datasource provider={}\n",
+                ds.provider.as_str()
+            ));
+        }
+        for m in s.models.values() {
+            out.push_str(&format!("model {} {{}}\n", m.name.as_str()));
+        }
+        for e in s.enums.values() {
+            out.push_str(&format!("enum {} {{}}\n", e.name.as_str()));
+        }
+        out
+    }
+
+    #[test]
+    fn directory_round_trip_mirrors_layout() {
+        let input = tempdir().unwrap();
+        let output = tempdir().unwrap();
+
+        std::fs::create_dir_all(input.path().join("models")).unwrap();
+        std::fs::write(
+            input.path().join("schema.prisma"),
+            r#"datasource db { provider = "postgresql" url = env("DB") }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            input.path().join("models/user.prisma"),
+            "model User { id Int @id @default(autoincrement()) email String @unique }",
+        )
+        .unwrap();
+        std::fs::write(
+            input.path().join("models/post.prisma"),
+            "model Post { id Int @id @default(autoincrement()) author_id Int }",
+        )
+        .unwrap();
+
+        let count = import_prisma_directory(input.path(), output.path(), debug_render, false)
+            .expect("import should succeed");
+
+        assert_eq!(count, 3);
+        assert!(output.path().join("schema.prax").exists());
+        assert!(output.path().join("models/user.prax").exists());
+        assert!(output.path().join("models/post.prax").exists());
+
+        // Datasource lives in the mirrored schema.prax, not in the model files.
+        let schema_content = std::fs::read_to_string(output.path().join("schema.prax")).unwrap();
+        assert!(schema_content.contains("datasource"));
+        let user_content = std::fs::read_to_string(output.path().join("models/user.prax")).unwrap();
+        assert!(user_content.contains("model User"));
+        assert!(!user_content.contains("model Post"));
+    }
+
+    #[test]
+    fn refuses_to_overwrite_non_empty_output_without_force() {
+        let input = tempdir().unwrap();
+        let output = tempdir().unwrap();
+        std::fs::write(
+            input.path().join("a.prisma"),
+            "model A { id Int @id @default(autoincrement()) }",
+        )
+        .unwrap();
+        // Pre-populate output dir so it's non-empty.
+        std::fs::write(output.path().join("existing.txt"), "hi").unwrap();
+
+        let err =
+            import_prisma_directory(input.path(), output.path(), debug_render, false).unwrap_err();
+        assert!(matches!(err, ImportError::InvalidConfig(_)));
+
+        // With --force, it succeeds.
+        let count =
+            import_prisma_directory(input.path(), output.path(), debug_render, true).unwrap();
+        assert_eq!(count, 1);
     }
 }

--- a/prax-import/src/prisma/multi_file.rs
+++ b/prax-import/src/prisma/multi_file.rs
@@ -1,0 +1,238 @@
+//! Multi-file Prisma schema discovery, parse, and merge.
+//!
+//! Mirrors the design in `docs/superpowers/specs/2026-05-19-multi-file-schema-design.md`.
+//! Prisma's `prismaSchemaFolder` mode places multiple `*.prisma` files in one
+//! directory and treats them as a single logical schema. This module walks
+//! such a directory, parses each file, stamps provenance, and merges into a
+//! single [`PrismaSchema`] with conflict detection.
+
+use std::path::{Path, PathBuf};
+
+use walkdir::WalkDir;
+
+use super::parser::parse_prisma_schema;
+use super::types::{PrismaSchema, PrismaSourceId};
+use crate::error::{ImportError, ImportResult};
+
+/// A discovered `.prisma` file with absolute + relative paths.
+#[derive(Debug, Clone)]
+pub struct PrismaFile {
+    pub absolute: PathBuf,
+    pub relative: PathBuf,
+}
+
+/// Map of [`PrismaSourceId`] -> [`PrismaFile`], built during multi-file import.
+#[derive(Debug, Default)]
+pub struct PrismaSourceMap {
+    files: Vec<PrismaFile>,
+}
+
+impl PrismaSourceMap {
+    pub fn get(&self, id: PrismaSourceId) -> Option<&PrismaFile> {
+        self.files.get(id.0 as usize)
+    }
+    pub fn iter(&self) -> impl Iterator<Item = (PrismaSourceId, &PrismaFile)> {
+        self.files
+            .iter()
+            .enumerate()
+            .map(|(i, f)| (PrismaSourceId(i as u32), f))
+    }
+    pub fn len(&self) -> usize {
+        self.files.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.files.is_empty()
+    }
+}
+
+/// Discover all `*.prisma` files under `root`, sorted lexicographically by
+/// relative path.
+///
+/// Skips hidden entries, symlinks, and `node_modules/` directories. (We
+/// deliberately do not reuse the loader's `target/` skip — the importer's
+/// skip set is Prisma-ecosystem-specific.)
+pub fn discover_prisma(root: &Path) -> ImportResult<Vec<PrismaFile>> {
+    let canonical = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    let mut out = Vec::new();
+    for entry in WalkDir::new(&canonical)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|e| !is_skipped(e))
+    {
+        let entry = entry.map_err(|e| {
+            ImportError::IoError(
+                e.into_io_error()
+                    .unwrap_or_else(|| std::io::Error::other("walkdir error")),
+            )
+        })?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        if entry.path().extension().and_then(|s| s.to_str()) != Some("prisma") {
+            continue;
+        }
+        let relative = entry
+            .path()
+            .strip_prefix(&canonical)
+            .unwrap_or(entry.path())
+            .to_path_buf();
+        out.push(PrismaFile {
+            absolute: entry.path().to_path_buf(),
+            relative,
+        });
+    }
+    out.sort_by(|a, b| a.relative.cmp(&b.relative));
+    Ok(out)
+}
+
+fn is_skipped(entry: &walkdir::DirEntry) -> bool {
+    if entry.depth() == 0 {
+        return false;
+    }
+    if let Some(name) = entry.file_name().to_str() {
+        if name.starts_with('.') {
+            return true;
+        }
+        if entry.file_type().is_dir() && name == "node_modules" {
+            return true;
+        }
+    }
+    if entry.file_type().is_symlink() {
+        return true;
+    }
+    false
+}
+
+/// Parse every `.prisma` file under `root`, stamp source provenance, and
+/// merge into one [`PrismaSchema`]. Returns the merged schema and the source
+/// map; on conflict, returns an error.
+pub fn parse_and_merge_directory(root: &Path) -> ImportResult<(PrismaSchema, PrismaSourceMap)> {
+    let files = discover_prisma(root)?;
+    if files.is_empty() {
+        return Err(ImportError::EmptyPrismaDirectory {
+            path: root.to_path_buf(),
+        });
+    }
+
+    let mut sources = PrismaSourceMap {
+        files: files.clone(),
+    };
+    let mut merged = PrismaSchema::default();
+
+    for (idx, f) in files.iter().enumerate() {
+        let sid = PrismaSourceId(idx as u32);
+        let content = std::fs::read_to_string(&f.absolute)?;
+        let mut per_file = parse_prisma_schema(&content)?;
+        stamp_prisma(&mut per_file, sid);
+        try_merge_prisma(&mut merged, per_file, sid)?;
+    }
+
+    let _ = &mut sources; // sources is built in-place above; suppress unused-mut if any
+    Ok((merged, sources))
+}
+
+fn stamp_prisma(s: &mut PrismaSchema, sid: PrismaSourceId) {
+    for m in &mut s.models {
+        m.source_id = Some(sid);
+    }
+    for e in &mut s.enums {
+        e.source_id = Some(sid);
+    }
+    if let Some(ds) = &mut s.datasource {
+        ds.source_id = Some(sid);
+    }
+}
+
+fn try_merge_prisma(
+    into: &mut PrismaSchema,
+    other: PrismaSchema,
+    incoming_sid: PrismaSourceId,
+) -> ImportResult<()> {
+    for m in other.models {
+        if let Some(existing) = into.models.iter().find(|x| x.name == m.name) {
+            return Err(ImportError::DuplicatePrismaModel {
+                name: m.name.clone(),
+                first: existing.source_id.unwrap_or(PrismaSourceId(0)),
+                second: incoming_sid,
+            });
+        }
+        into.models.push(m);
+    }
+    for e in other.enums {
+        if let Some(existing) = into.enums.iter().find(|x| x.name == e.name) {
+            return Err(ImportError::DuplicatePrismaEnum {
+                name: e.name.clone(),
+                first: existing.source_id.unwrap_or(PrismaSourceId(0)),
+                second: incoming_sid,
+            });
+        }
+        into.enums.push(e);
+    }
+    if let Some(incoming) = other.datasource {
+        if let Some(existing) = &into.datasource {
+            return Err(ImportError::MultiplePrismaDatasource {
+                first: existing.source_id.unwrap_or(PrismaSourceId(0)),
+                second: incoming_sid,
+            });
+        }
+        into.datasource = Some(incoming);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn parses_and_merges_directory() {
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("a.prisma"),
+            r#"datasource db { provider = "postgresql" url = env("DB_URL") }
+
+model A {
+  id Int @id @default(autoincrement())
+}
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("b.prisma"),
+            "model B { id Int @id @default(autoincrement()) }",
+        )
+        .unwrap();
+
+        let (merged, sources) = parse_and_merge_directory(dir.path()).unwrap();
+        assert_eq!(merged.models.len(), 2);
+        assert!(merged.datasource.is_some());
+        assert_eq!(sources.len(), 2);
+    }
+
+    #[test]
+    fn duplicate_models_error() {
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("a.prisma"),
+            "model X { id Int @id @default(autoincrement()) }",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("b.prisma"),
+            "model X { id Int @id @default(autoincrement()) }",
+        )
+        .unwrap();
+
+        let err = parse_and_merge_directory(dir.path()).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("duplicate") && msg.contains("X"), "got: {msg}");
+    }
+
+    #[test]
+    fn empty_dir_errors() {
+        let dir = tempdir().unwrap();
+        let err = parse_and_merge_directory(dir.path()).unwrap_err();
+        assert!(matches!(err, ImportError::EmptyPrismaDirectory { .. }));
+    }
+}

--- a/prax-import/src/prisma/parser.rs
+++ b/prax-import/src/prisma/parser.rs
@@ -103,7 +103,11 @@ fn parse_datasource(input: &str) -> ImportResult<Option<PrismaDatasource>> {
         let provider = caps.get(1).unwrap().as_str().to_string();
         let url = caps.get(2).unwrap().as_str().to_string();
 
-        Ok(Some(PrismaDatasource { provider, url }))
+        Ok(Some(PrismaDatasource {
+            provider,
+            url,
+            source_id: None,
+        }))
     } else {
         Ok(None)
     }
@@ -147,6 +151,7 @@ fn parse_models(input: &str) -> ImportResult<Vec<PrismaModel>> {
             fields,
             attributes,
             documentation: None,
+            source_id: None,
         });
 
         search_from = end + 1;
@@ -514,6 +519,7 @@ fn parse_enums(input: &str) -> ImportResult<Vec<PrismaEnum>> {
             name,
             values,
             documentation: None,
+            source_id: None,
         });
     }
 

--- a/prax-import/src/prisma/parser.rs
+++ b/prax-import/src/prisma/parser.rs
@@ -527,27 +527,45 @@ fn parse_enums(input: &str) -> ImportResult<Vec<PrismaEnum>> {
 }
 
 /// Convert Prisma schema to Prax schema.
-fn convert_prisma_to_prax(prisma_schema: PrismaSchema) -> ImportResult<Schema> {
+///
+/// Translates `PrismaSourceId(n)` provenance onto each emitted Prax item as
+/// `prax_schema::SourceId(n)` so a downstream emitter can bucket the merged
+/// schema by source file.
+pub(crate) fn convert_prisma_to_prax(prisma_schema: PrismaSchema) -> ImportResult<Schema> {
     let mut builder = SchemaBuilder::new();
 
-    // Convert datasource
+    // Convert datasource (with provenance)
+    let ds_source = prisma_schema.datasource.as_ref().and_then(|d| d.source_id);
     if let Some(datasource) = prisma_schema.datasource {
         builder = builder.with_datasource(datasource.provider, datasource.url);
     }
 
-    // Convert models
+    // Convert models, carrying source provenance
     for model in prisma_schema.models {
-        let prax_model = convert_model(model)?;
+        let sid = model.source_id;
+        let mut prax_model = convert_model(model)?;
+        if let Some(s) = sid {
+            prax_model.source_id = Some(prax_schema::SourceId(s.0));
+        }
         builder.add_model(prax_model);
     }
 
-    // Convert enums
+    // Convert enums, carrying source provenance
     for enum_def in prisma_schema.enums {
-        let prax_enum = convert_enum(enum_def);
+        let sid = enum_def.source_id;
+        let mut prax_enum = convert_enum(enum_def);
+        if let Some(s) = sid {
+            prax_enum.source_id = Some(prax_schema::SourceId(s.0));
+        }
         builder.add_enum(prax_enum);
     }
 
-    Ok(builder.build())
+    let mut schema = builder.build();
+    if let (Some(ds), Some(s)) = (schema.datasource.as_mut(), ds_source) {
+        ds.source_id = Some(prax_schema::SourceId(s.0));
+    }
+
+    Ok(schema)
 }
 
 /// Convert a Prisma model to a Prax model.

--- a/prax-import/src/prisma/types.rs
+++ b/prax-import/src/prisma/types.rs
@@ -2,6 +2,12 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Opaque identifier for a `.prisma` source file when importing multi-file
+/// Prisma schemas. Parallel to (but deliberately distinct from)
+/// `prax_schema::SourceId`.
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Ord, PartialOrd, Serialize, Deserialize)]
+pub struct PrismaSourceId(pub u32);
+
 /// Prisma datasource configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PrismaDatasource {
@@ -9,6 +15,9 @@ pub struct PrismaDatasource {
     pub provider: String,
     /// The database connection URL.
     pub url: String,
+    /// Source file this datasource was parsed from (None for single-file path).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<PrismaSourceId>,
 }
 
 /// Prisma model definition.
@@ -22,6 +31,9 @@ pub struct PrismaModel {
     pub attributes: Vec<PrismaModelAttribute>,
     /// Documentation comment.
     pub documentation: Option<String>,
+    /// Source file this model was parsed from (None for single-file path).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<PrismaSourceId>,
 }
 
 /// Prisma field definition.
@@ -137,10 +149,13 @@ pub struct PrismaEnum {
     pub values: Vec<String>,
     /// Documentation comment.
     pub documentation: Option<String>,
+    /// Source file this enum was parsed from (None for single-file path).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<PrismaSourceId>,
 }
 
 /// Complete Prisma schema.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct PrismaSchema {
     /// Datasource configuration.
     pub datasource: Option<PrismaDatasource>,

--- a/prax-schema/Cargo.toml
+++ b/prax-schema/Cargo.toml
@@ -30,6 +30,9 @@ smol_str = { workspace = true }
 regex-lite = { workspace = true }
 parking_lot = { workspace = true }
 
+# Filesystem (multi-file schema discovery)
+walkdir = { workspace = true }
+
 # Logging
 tracing = { workspace = true }
 
@@ -37,6 +40,7 @@ tracing = { workspace = true }
 insta = { workspace = true }
 pretty_assertions = { workspace = true }
 criterion = { workspace = true }
+tempfile = { workspace = true }
 
 [[bench]]
 name = "schema_parsing"

--- a/prax-schema/src/ast/datasource.rs
+++ b/prax-schema/src/ast/datasource.rs
@@ -236,6 +236,9 @@ pub struct Datasource {
     pub properties: Vec<(SmolStr, SmolStr)>,
     /// Source span for error reporting.
     pub span: Span,
+    /// Source file this datasource was parsed from (None for single-file path).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<crate::loader::SourceId>,
 }
 
 impl Datasource {
@@ -249,6 +252,7 @@ impl Datasource {
             extensions: Vec::new(),
             properties: Vec::new(),
             span,
+            source_id: None,
         }
     }
 
@@ -305,6 +309,7 @@ impl Default for Datasource {
             extensions: Vec::new(),
             properties: Vec::new(),
             span: Span::new(0, 0),
+            source_id: None,
         }
     }
 }

--- a/prax-schema/src/ast/generator.rs
+++ b/prax-schema/src/ast/generator.rs
@@ -31,6 +31,9 @@ pub struct Generator {
     pub properties: IndexMap<SmolStr, GeneratorValue>,
     /// Source location.
     pub span: Span,
+    /// Source file this generator was parsed from (None for single-file path).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<crate::loader::SourceId>,
 }
 
 impl Generator {
@@ -42,6 +45,7 @@ impl Generator {
             generate: GeneratorToggle::Always,
             properties: IndexMap::new(),
             span,
+            source_id: None,
         }
     }
 

--- a/prax-schema/src/ast/model.rs
+++ b/prax-schema/src/ast/model.rs
@@ -19,6 +19,9 @@ pub struct Model {
     pub documentation: Option<Documentation>,
     /// Source location.
     pub span: Span,
+    /// Source file this model was parsed from (None for single-file path).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<crate::loader::SourceId>,
 }
 
 impl Model {
@@ -30,6 +33,7 @@ impl Model {
             attributes: vec![],
             documentation: None,
             span,
+            source_id: None,
         }
     }
 
@@ -101,6 +105,9 @@ pub struct Enum {
     pub documentation: Option<Documentation>,
     /// Source location.
     pub span: Span,
+    /// Source file this enum was parsed from (None for single-file path).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<crate::loader::SourceId>,
 }
 
 impl Enum {
@@ -112,6 +119,7 @@ impl Enum {
             attributes: vec![],
             documentation: None,
             span,
+            source_id: None,
         }
     }
 
@@ -198,6 +206,9 @@ pub struct CompositeType {
     pub documentation: Option<Documentation>,
     /// Source location.
     pub span: Span,
+    /// Source file this type was parsed from (None for single-file path).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<crate::loader::SourceId>,
 }
 
 impl CompositeType {
@@ -208,6 +219,7 @@ impl CompositeType {
             fields: IndexMap::new(),
             documentation: None,
             span,
+            source_id: None,
         }
     }
 
@@ -246,6 +258,9 @@ pub struct View {
     pub documentation: Option<Documentation>,
     /// Source location.
     pub span: Span,
+    /// Source file this view was parsed from (None for single-file path).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<crate::loader::SourceId>,
 }
 
 impl View {
@@ -257,6 +272,7 @@ impl View {
             attributes: vec![],
             documentation: None,
             span,
+            source_id: None,
         }
     }
 

--- a/prax-schema/src/ast/policy.rs
+++ b/prax-schema/src/ast/policy.rs
@@ -81,6 +81,9 @@ pub struct Policy {
     pub documentation: Option<Documentation>,
     /// Source location.
     pub span: Span,
+    /// Source file this policy was parsed from (None for single-file path).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<crate::loader::SourceId>,
 }
 
 impl Policy {
@@ -97,6 +100,7 @@ impl Policy {
             mssql_schema: None,
             mssql_block_operations: vec![],
             documentation: None,
+            source_id: None,
             span,
         }
     }

--- a/prax-schema/src/ast/schema.rs
+++ b/prax-schema/src/ast/schema.rs
@@ -209,7 +209,11 @@ impl Schema {
             .collect()
     }
 
-    /// Merge another schema into this one.
+    /// Merge another schema into this one (deprecated: use [`Schema::try_merge`]).
+    ///
+    /// Silently overwrites duplicates. Kept for backward compatibility; will be
+    /// removed in a future release.
+    #[deprecated(since = "0.9.8", note = "use try_merge for collision-aware merging")]
     pub fn merge(&mut self, other: Schema) {
         self.models.extend(other.models);
         self.enums.extend(other.enums);
@@ -218,6 +222,132 @@ impl Schema {
         self.server_groups.extend(other.server_groups);
         self.policies.extend(other.policies);
         self.raw_sql.extend(other.raw_sql);
+    }
+
+    /// Merge `other` into `self`, returning every collision found rather than
+    /// silently overwriting.
+    ///
+    /// Items whose `source_id` is `None` (built outside the loader, e.g. in
+    /// tests) are reported with `SourceId(u32::MAX)`. In production usage the
+    /// loader stamps every item via [`crate::loader::stamp_source`] first.
+    pub fn try_merge(&mut self, other: Schema) -> Result<(), Vec<crate::loader::MergeConflict>> {
+        use crate::loader::MergeConflict;
+        use crate::loader::merge::loc;
+
+        let mut conflicts: Vec<MergeConflict> = Vec::new();
+
+        for (name, m) in other.models {
+            if let Some(existing) = self.models.get(&name) {
+                conflicts.push(MergeConflict::DuplicateModel {
+                    name: name.clone(),
+                    existing: loc(existing.source_id, existing.span),
+                    incoming: loc(m.source_id, m.span),
+                });
+            } else {
+                self.models.insert(name, m);
+            }
+        }
+
+        for (name, e) in other.enums {
+            if let Some(existing) = self.enums.get(&name) {
+                conflicts.push(MergeConflict::DuplicateEnum {
+                    name: name.clone(),
+                    existing: loc(existing.source_id, existing.span),
+                    incoming: loc(e.source_id, e.span),
+                });
+            } else {
+                self.enums.insert(name, e);
+            }
+        }
+
+        for (name, t) in other.types {
+            if let Some(existing) = self.types.get(&name) {
+                conflicts.push(MergeConflict::DuplicateType {
+                    name: name.clone(),
+                    existing: loc(existing.source_id, existing.span),
+                    incoming: loc(t.source_id, t.span),
+                });
+            } else {
+                self.types.insert(name, t);
+            }
+        }
+
+        for (name, v) in other.views {
+            if let Some(existing) = self.views.get(&name) {
+                conflicts.push(MergeConflict::DuplicateView {
+                    name: name.clone(),
+                    existing: loc(existing.source_id, existing.span),
+                    incoming: loc(v.source_id, v.span),
+                });
+            } else {
+                self.views.insert(name, v);
+            }
+        }
+
+        for (name, sg) in other.server_groups {
+            if let Some(existing) = self.server_groups.get(&name) {
+                conflicts.push(MergeConflict::DuplicateServerGroup {
+                    name: name.clone(),
+                    existing: loc(existing.source_id, existing.span),
+                    incoming: loc(sg.source_id, sg.span),
+                });
+            } else {
+                self.server_groups.insert(name, sg);
+            }
+        }
+
+        for (name, g) in other.generators {
+            if let Some(existing) = self.generators.get(&name) {
+                conflicts.push(MergeConflict::DuplicateGenerator {
+                    name: name.clone(),
+                    existing: loc(existing.source_id, existing.span),
+                    incoming: loc(g.source_id, g.span),
+                });
+            } else {
+                self.generators.insert(name, g);
+            }
+        }
+
+        for p in other.policies {
+            if let Some(existing) = self.policies.iter().find(|x| x.name() == p.name()) {
+                conflicts.push(MergeConflict::DuplicatePolicy {
+                    name: SmolStr::new(p.name()),
+                    existing: loc(existing.source_id, existing.span),
+                    incoming: loc(p.source_id, p.span),
+                });
+            } else {
+                self.policies.push(p);
+            }
+        }
+
+        for r in other.raw_sql {
+            if let Some(existing) = self.raw_sql.iter().find(|x| x.name == r.name) {
+                conflicts.push(MergeConflict::DuplicateRawSql {
+                    name: r.name.clone(),
+                    existing: loc(existing.source_id, super::Span::new(0, 0)),
+                    incoming: loc(r.source_id, super::Span::new(0, 0)),
+                });
+            } else {
+                self.raw_sql.push(r);
+            }
+        }
+
+        match (&self.datasource, other.datasource) {
+            (Some(existing), Some(incoming)) => {
+                conflicts.push(MergeConflict::MultipleDatasource {
+                    existing: loc(existing.source_id, existing.span),
+                    incoming: loc(incoming.source_id, incoming.span),
+                });
+            }
+            (None, Some(incoming)) => self.datasource = Some(incoming),
+            (_, None) => {}
+        }
+
+        if conflicts.is_empty() {
+            Ok(())
+        } else {
+            Err(conflicts)
+        }
     }
 }
 
@@ -604,6 +734,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_schema_merge() {
         let mut schema1 = Schema::new();
         schema1.add_model(make_model("User"));
@@ -847,6 +978,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_schema_merge_with_policies() {
         let mut schema1 = Schema::new();
         schema1.add_policy(Policy::new(

--- a/prax-schema/src/ast/schema.rs
+++ b/prax-schema/src/ast/schema.rs
@@ -228,6 +228,9 @@ pub struct RawSql {
     pub name: SmolStr,
     /// The raw SQL content.
     pub sql: String,
+    /// Source file this raw SQL was parsed from (None for single-file path).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<crate::loader::SourceId>,
 }
 
 impl RawSql {
@@ -236,6 +239,7 @@ impl RawSql {
         Self {
             name: name.into(),
             sql: sql.into(),
+            source_id: None,
         }
     }
 }

--- a/prax-schema/src/ast/server_group.rs
+++ b/prax-schema/src/ast/server_group.rs
@@ -53,6 +53,9 @@ pub struct ServerGroup {
     pub documentation: Option<Documentation>,
     /// Source location.
     pub span: Span,
+    /// Source file this server group was parsed from (None for single-file path).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<crate::loader::SourceId>,
 }
 
 impl ServerGroup {
@@ -64,6 +67,7 @@ impl ServerGroup {
             attributes: vec![],
             documentation: None,
             span,
+            source_id: None,
         }
     }
 

--- a/prax-schema/src/error.rs
+++ b/prax-schema/src/error.rs
@@ -134,6 +134,38 @@ pub enum SchemaError {
         /// Supplied index value.
         value: String,
     },
+
+    /// Parse failure in a specific file within a multi-file schema directory.
+    #[error("parse error in source {}", .source.0)]
+    #[diagnostic(code(prax::schema::parse_in_file))]
+    ParseInFile {
+        source: crate::loader::SourceId,
+        #[source]
+        inner: Box<SchemaError>,
+    },
+
+    /// Same-named item declared in two source files.
+    #[error("duplicate {kind} `{name}` declared in two files")]
+    #[diagnostic(code(prax::schema::duplicate_across_files))]
+    DuplicateAcrossFiles {
+        kind: &'static str,
+        name: String,
+        first: crate::loader::SourceLoc,
+        second: crate::loader::SourceLoc,
+    },
+
+    /// More than one `datasource` block across source files.
+    #[error("multiple datasource blocks declared (exactly one allowed across all files)")]
+    #[diagnostic(code(prax::schema::multiple_datasource))]
+    MultipleDatasource {
+        first: crate::loader::SourceLoc,
+        second: crate::loader::SourceLoc,
+    },
+
+    /// Schema directory contained no `*.prax` files.
+    #[error("schema directory `{}` contains no .prax files", .path.display())]
+    #[diagnostic(code(prax::schema::empty_directory))]
+    EmptySchemaDirectory { path: std::path::PathBuf },
 }
 
 impl SchemaError {
@@ -470,5 +502,29 @@ mod tests {
         } else {
             panic!("Expected InvalidField");
         }
+    }
+
+    #[test]
+    fn duplicate_across_files_displays_name_and_kind() {
+        use crate::ast::Span;
+        use crate::loader::{SourceId, SourceLoc};
+
+        let err = SchemaError::DuplicateAcrossFiles {
+            kind: "model",
+            name: "User".to_string(),
+            first: SourceLoc::new(SourceId(0), Span::new(0, 10)),
+            second: SourceLoc::new(SourceId(1), Span::new(0, 10)),
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("duplicate model"), "got: {msg}");
+        assert!(msg.contains("User"), "got: {msg}");
+    }
+
+    #[test]
+    fn empty_directory_displays_path() {
+        let err = SchemaError::EmptySchemaDirectory {
+            path: std::path::PathBuf::from("/tmp/empty"),
+        };
+        assert!(format!("{err}").contains("/tmp/empty"));
     }
 }

--- a/prax-schema/src/error.rs
+++ b/prax-schema/src/error.rs
@@ -148,7 +148,7 @@ pub enum SchemaError {
     #[error("duplicate {kind} `{name}` declared in two files")]
     #[diagnostic(code(prax::schema::duplicate_across_files))]
     DuplicateAcrossFiles {
-        kind: &'static str,
+        kind: DuplicateKind,
         name: String,
         first: crate::loader::SourceLoc,
         second: crate::loader::SourceLoc,
@@ -166,6 +166,35 @@ pub enum SchemaError {
     #[error("schema directory `{}` contains no .prax files", .path.display())]
     #[diagnostic(code(prax::schema::empty_directory))]
     EmptySchemaDirectory { path: std::path::PathBuf },
+}
+
+/// The kind of top-level item involved in a cross-file duplicate-name error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DuplicateKind {
+    Model,
+    Enum,
+    Type,
+    View,
+    ServerGroup,
+    Policy,
+    Generator,
+    RawSql,
+}
+
+impl std::fmt::Display for DuplicateKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            DuplicateKind::Model => "model",
+            DuplicateKind::Enum => "enum",
+            DuplicateKind::Type => "type",
+            DuplicateKind::View => "view",
+            DuplicateKind::ServerGroup => "serverGroup",
+            DuplicateKind::Policy => "policy",
+            DuplicateKind::Generator => "generator",
+            DuplicateKind::RawSql => "rawSql",
+        };
+        f.write_str(s)
+    }
 }
 
 impl SchemaError {
@@ -510,7 +539,7 @@ mod tests {
         use crate::loader::{SourceId, SourceLoc};
 
         let err = SchemaError::DuplicateAcrossFiles {
-            kind: "model",
+            kind: DuplicateKind::Model,
             name: "User".to_string(),
             first: SourceLoc::new(SourceId(0), Span::new(0, 10)),
             second: SourceLoc::new(SourceId(1), Span::new(0, 10)),

--- a/prax-schema/src/lib.rs
+++ b/prax-schema/src/lib.rs
@@ -243,6 +243,7 @@ pub mod ast;
 pub mod cache;
 pub mod config;
 pub mod error;
+pub mod loader;
 pub mod parser;
 pub mod validator;
 
@@ -252,6 +253,7 @@ pub use cache::{
 };
 pub use config::{ModelStyle, PraxConfig};
 pub use error::{SchemaError, SchemaResult};
+pub use loader::{SourceFile, SourceId, SourceMap};
 pub use parser::{parse_schema, parse_schema_file};
 pub use validator::{Validator, validate_schema};
 

--- a/prax-schema/src/lib.rs
+++ b/prax-schema/src/lib.rs
@@ -253,7 +253,9 @@ pub use cache::{
 };
 pub use config::{ModelStyle, PraxConfig};
 pub use error::{SchemaError, SchemaResult};
-pub use loader::{SourceFile, SourceId, SourceLoc, SourceMap};
+pub use loader::{
+    LoadError, LoadedSchema, MergeConflict, SourceFile, SourceId, SourceLoc, SourceMap, load,
+};
 pub use parser::{parse_schema, parse_schema_file};
 pub use validator::{Validator, validate_schema};
 

--- a/prax-schema/src/lib.rs
+++ b/prax-schema/src/lib.rs
@@ -253,7 +253,7 @@ pub use cache::{
 };
 pub use config::{ModelStyle, PraxConfig};
 pub use error::{SchemaError, SchemaResult};
-pub use loader::{SourceFile, SourceId, SourceMap};
+pub use loader::{SourceFile, SourceId, SourceLoc, SourceMap};
 pub use parser::{parse_schema, parse_schema_file};
 pub use validator::{Validator, validate_schema};
 

--- a/prax-schema/src/loader/discovery.rs
+++ b/prax-schema/src/loader/discovery.rs
@@ -1,0 +1,157 @@
+//! Recursive `*.prax` discovery for multi-file schema directories.
+
+use std::path::{Path, PathBuf};
+
+use walkdir::WalkDir;
+
+use crate::error::{SchemaError, SchemaResult};
+
+/// A discovered `*.prax` file with its absolute and relative paths.
+#[derive(Debug, Clone)]
+pub struct Discovered {
+    /// Absolute path on disk.
+    pub absolute: PathBuf,
+    /// Path relative to the discovery root (used for sort order + emit mirroring).
+    pub relative: PathBuf,
+}
+
+/// Recursively find all `*.prax` files under `root`, sorted lexicographically
+/// by the relative path.
+///
+/// Skipped:
+/// - Hidden entries (filename starts with `.`)
+/// - Symlinks (not followed)
+/// - Any directory named `target`
+pub fn discover(root: impl AsRef<Path>) -> SchemaResult<Vec<Discovered>> {
+    let root = root.as_ref();
+    let canonical_root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+
+    let mut out = Vec::new();
+    for entry in WalkDir::new(&canonical_root)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|e| !is_skipped(e))
+    {
+        let entry = entry.map_err(|e| SchemaError::IoError {
+            path: e
+                .path()
+                .map(|p| p.display().to_string())
+                .unwrap_or_default(),
+            source: e
+                .into_io_error()
+                .unwrap_or_else(|| std::io::Error::other("walkdir error")),
+        })?;
+
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        if entry.path().extension().and_then(|s| s.to_str()) != Some("prax") {
+            continue;
+        }
+
+        let relative = entry
+            .path()
+            .strip_prefix(&canonical_root)
+            .unwrap_or(entry.path())
+            .to_path_buf();
+
+        out.push(Discovered {
+            absolute: entry.path().to_path_buf(),
+            relative,
+        });
+    }
+
+    out.sort_by(|a, b| a.relative.cmp(&b.relative));
+    Ok(out)
+}
+
+fn is_skipped(entry: &walkdir::DirEntry) -> bool {
+    // Always allow the root itself.
+    if entry.depth() == 0 {
+        return false;
+    }
+    if let Some(name) = entry.file_name().to_str() {
+        if name.starts_with('.') {
+            return true;
+        }
+        if entry.file_type().is_dir() && name == "target" {
+            return true;
+        }
+    }
+    if entry.file_type().is_symlink() {
+        return true;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn write(dir: &Path, name: &str, content: &str) {
+        let p = dir.join(name);
+        if let Some(parent) = p.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(p, content).unwrap();
+    }
+
+    #[test]
+    fn flat_directory_returns_sorted_prax_files() {
+        let dir = tempdir().unwrap();
+        write(dir.path(), "b.prax", "// b");
+        write(dir.path(), "a.prax", "// a");
+        write(dir.path(), "c.prax", "// c");
+
+        let found = discover(dir.path()).unwrap();
+        let names: Vec<_> = found.iter().map(|d| d.relative.to_str().unwrap()).collect();
+        assert_eq!(names, vec!["a.prax", "b.prax", "c.prax"]);
+    }
+
+    #[test]
+    fn recursive_descent_finds_nested_files() {
+        let dir = tempdir().unwrap();
+        write(dir.path(), "schema.prax", "// root");
+        write(dir.path(), "models/user.prax", "model U {}");
+        write(dir.path(), "models/post.prax", "model P {}");
+        write(dir.path(), "enums/role.prax", "enum R {}");
+
+        let found = discover(dir.path()).unwrap();
+        assert_eq!(found.len(), 4);
+    }
+
+    #[test]
+    fn hidden_dirs_are_skipped() {
+        let dir = tempdir().unwrap();
+        write(dir.path(), "ok.prax", "// ok");
+        write(dir.path(), ".git/HEAD", "// not prax");
+        write(dir.path(), ".cache/bad.prax", "// skipped");
+
+        let found = discover(dir.path()).unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].relative.to_str().unwrap(), "ok.prax");
+    }
+
+    #[test]
+    fn target_directory_is_skipped() {
+        let dir = tempdir().unwrap();
+        write(dir.path(), "ok.prax", "// ok");
+        write(dir.path(), "target/build.prax", "// skipped");
+
+        let found = discover(dir.path()).unwrap();
+        assert_eq!(found.len(), 1);
+    }
+
+    #[test]
+    fn non_prax_files_ignored() {
+        let dir = tempdir().unwrap();
+        write(dir.path(), "ok.prax", "// ok");
+        write(dir.path(), "README.md", "# readme");
+        write(dir.path(), "schema.prisma", "// wrong ext");
+
+        let found = discover(dir.path()).unwrap();
+        assert_eq!(found.len(), 1);
+    }
+}

--- a/prax-schema/src/loader/merge.rs
+++ b/prax-schema/src/loader/merge.rs
@@ -1,0 +1,132 @@
+//! Schema merging with cross-file collision detection.
+
+use smol_str::SmolStr;
+
+use super::source::{SourceId, SourceLoc};
+use crate::ast::Span;
+
+/// A single conflict found while merging two [`Schema`](crate::ast::Schema)s.
+///
+/// Collected without short-circuiting so the loader can report every duplicate
+/// in one pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MergeConflict {
+    DuplicateModel {
+        name: SmolStr,
+        existing: SourceLoc,
+        incoming: SourceLoc,
+    },
+    DuplicateEnum {
+        name: SmolStr,
+        existing: SourceLoc,
+        incoming: SourceLoc,
+    },
+    DuplicateType {
+        name: SmolStr,
+        existing: SourceLoc,
+        incoming: SourceLoc,
+    },
+    DuplicateView {
+        name: SmolStr,
+        existing: SourceLoc,
+        incoming: SourceLoc,
+    },
+    DuplicateServerGroup {
+        name: SmolStr,
+        existing: SourceLoc,
+        incoming: SourceLoc,
+    },
+    DuplicatePolicy {
+        name: SmolStr,
+        existing: SourceLoc,
+        incoming: SourceLoc,
+    },
+    DuplicateGenerator {
+        name: SmolStr,
+        existing: SourceLoc,
+        incoming: SourceLoc,
+    },
+    DuplicateRawSql {
+        name: SmolStr,
+        existing: SourceLoc,
+        incoming: SourceLoc,
+    },
+    MultipleDatasource {
+        existing: SourceLoc,
+        incoming: SourceLoc,
+    },
+}
+
+/// Build a SourceLoc from any item that has `source_id: Option<SourceId>` and `span: Span`.
+///
+/// Items whose `source_id` is `None` (i.e., constructed outside the loader,
+/// such as in unit tests) get `SourceId(u32::MAX)`.
+pub(crate) fn loc(source_id: Option<SourceId>, span: Span) -> SourceLoc {
+    SourceLoc::new(source_id.unwrap_or(SourceId(u32::MAX)), span)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::Schema;
+    use crate::loader::{SourceId, stamp_source};
+    use crate::parser::parse_schema;
+
+    fn stamped(input: &str, sid: u32) -> Schema {
+        let mut s = parse_schema(input).unwrap();
+        stamp_source(&mut s, SourceId(sid));
+        s
+    }
+
+    #[test]
+    fn merge_distinct_models_succeeds() {
+        let mut a = stamped("model A { id Int @id @auto }", 0);
+        let b = stamped("model B { id Int @id @auto }", 1);
+        assert!(a.try_merge(b).is_ok());
+        assert!(a.get_model("A").is_some());
+        assert!(a.get_model("B").is_some());
+        assert_eq!(a.get_model("B").unwrap().source_id, Some(SourceId(1)));
+    }
+
+    #[test]
+    fn merge_duplicate_models_reports_both_locations() {
+        let mut a = stamped("model User { id Int @id @auto }", 0);
+        let b = stamped("model User { id Int @id @auto }", 1);
+        let err = a.try_merge(b).unwrap_err();
+        assert_eq!(err.len(), 1);
+        match &err[0] {
+            MergeConflict::DuplicateModel {
+                name,
+                existing,
+                incoming,
+            } => {
+                assert_eq!(name.as_str(), "User");
+                assert_eq!(existing.source, SourceId(0));
+                assert_eq!(incoming.source, SourceId(1));
+            }
+            other => panic!("unexpected conflict: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn merge_collects_all_conflicts_without_short_circuit() {
+        let mut a = stamped(
+            "model A { id Int @id @auto } model B { id Int @id @auto }",
+            0,
+        );
+        let b = stamped(
+            "model A { id Int @id @auto } model B { id Int @id @auto }",
+            1,
+        );
+        let err = a.try_merge(b).unwrap_err();
+        assert_eq!(err.len(), 2);
+    }
+
+    #[test]
+    fn merge_two_datasources_errors() {
+        let mut a = stamped(r#"datasource db { provider = "postgresql" url = "x" }"#, 0);
+        let b = stamped(r#"datasource db { provider = "postgresql" url = "y" }"#, 1);
+        let err = a.try_merge(b).unwrap_err();
+        assert!(matches!(err[0], MergeConflict::MultipleDatasource { .. }));
+    }
+}

--- a/prax-schema/src/loader/mod.rs
+++ b/prax-schema/src/loader/mod.rs
@@ -5,3 +5,63 @@
 pub mod source;
 
 pub use source::{SourceFile, SourceId, SourceMap};
+
+use crate::ast::Schema;
+
+/// Stamp every top-level item in `schema` with `source`.
+///
+/// Called by the loader right after parsing a per-file [`Schema`], before merging.
+#[allow(dead_code)] // wired into load() in a later task
+pub(crate) fn stamp_source(schema: &mut Schema, source: SourceId) {
+    for m in schema.models.values_mut() {
+        m.source_id = Some(source);
+    }
+    for e in schema.enums.values_mut() {
+        e.source_id = Some(source);
+    }
+    for t in schema.types.values_mut() {
+        t.source_id = Some(source);
+    }
+    for v in schema.views.values_mut() {
+        v.source_id = Some(source);
+    }
+    for sg in schema.server_groups.values_mut() {
+        sg.source_id = Some(source);
+    }
+    for p in &mut schema.policies {
+        p.source_id = Some(source);
+    }
+    for g in schema.generators.values_mut() {
+        g.source_id = Some(source);
+    }
+    if let Some(ds) = &mut schema.datasource {
+        ds.source_id = Some(source);
+    }
+    for r in &mut schema.raw_sql {
+        r.source_id = Some(source);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::parse_schema;
+
+    #[test]
+    fn stamp_marks_all_items() {
+        let mut schema = parse_schema(
+            r#"
+            datasource db { provider = "postgresql" url = "x" }
+            generator client { provider = "prax-client" }
+            enum Role { User Admin }
+            model User { id Int @id @auto role Role }
+            "#,
+        )
+        .unwrap();
+        stamp_source(&mut schema, SourceId(7));
+        assert_eq!(schema.models["User"].source_id, Some(SourceId(7)));
+        assert_eq!(schema.enums["Role"].source_id, Some(SourceId(7)));
+        assert_eq!(schema.datasource.unwrap().source_id, Some(SourceId(7)));
+        assert_eq!(schema.generators["client"].source_id, Some(SourceId(7)));
+    }
+}

--- a/prax-schema/src/loader/mod.rs
+++ b/prax-schema/src/loader/mod.rs
@@ -2,9 +2,11 @@
 //!
 //! See `docs/superpowers/specs/2026-05-19-multi-file-schema-design.md`.
 
+pub mod discovery;
 pub mod merge;
 pub mod source;
 
+pub use discovery::Discovered;
 pub use merge::MergeConflict;
 pub use source::{SourceFile, SourceId, SourceLoc, SourceMap};
 

--- a/prax-schema/src/loader/mod.rs
+++ b/prax-schema/src/loader/mod.rs
@@ -1,14 +1,12 @@
 //! Multi-file schema loader.
-//!
-//! See `docs/superpowers/specs/2026-05-19-multi-file-schema-design.md`.
 
-pub mod discovery;
-pub mod merge;
-pub mod source;
+mod discovery;
+pub(crate) mod merge;
+mod source;
 
 use std::path::Path;
 
-pub use discovery::Discovered;
+pub use discovery::{Discovered, discover};
 pub use merge::MergeConflict;
 pub use source::{SourceFile, SourceId, SourceLoc, SourceMap};
 
@@ -92,14 +90,17 @@ fn load_single(path: &Path) -> Result<LoadedSchema, LoadError> {
             });
         }
     };
-    let sid = sources.insert(path.to_path_buf(), content.clone());
 
     let mut schema = match parse_schema(&content) {
         Ok(s) => s,
         Err(e) => {
+            // Insert into the map before returning so the renderer can resolve
+            // SourceId(0) back to file content.
+            sources.insert(path.to_path_buf(), content);
             return Err(LoadError { error: e, sources });
         }
     };
+    let sid = sources.insert(path.to_path_buf(), content);
     stamp_source(&mut schema, sid);
 
     let validated = match Validator::new().validate(schema) {
@@ -130,7 +131,6 @@ fn load_directory(root: &Path) -> Result<LoadedSchema, LoadError> {
         });
     }
 
-    // Phase 1: read + parse each file (fail-fast on syntax error)
     let mut per_file: Vec<(SourceId, Schema)> = Vec::with_capacity(files.len());
     for f in files {
         let content = match std::fs::read_to_string(&f.absolute) {
@@ -145,9 +145,11 @@ fn load_directory(root: &Path) -> Result<LoadedSchema, LoadError> {
                 });
             }
         };
-        let sid = sources.insert(f.absolute.clone(), content.clone());
-
-        let mut schema_i = match parse_schema(&content) {
+        let sid = sources.insert(f.absolute, content);
+        // Borrow content back through the map; per-file syntax errors are
+        // fail-fast (no useful partial schema if file N of M is malformed).
+        let file_content = &sources.get(sid).expect("just inserted").content;
+        let mut schema_i = match parse_schema(file_content) {
             Ok(s) => s,
             Err(inner) => {
                 return Err(LoadError {
@@ -163,7 +165,6 @@ fn load_directory(root: &Path) -> Result<LoadedSchema, LoadError> {
         per_file.push((sid, schema_i));
     }
 
-    // Phase 2: merge with conflict collection
     let mut merged = Schema::new();
     let mut all_conflicts: Vec<MergeConflict> = Vec::new();
     for (_, schema_i) in per_file {
@@ -179,7 +180,6 @@ fn load_directory(root: &Path) -> Result<LoadedSchema, LoadError> {
         });
     }
 
-    // Phase 3: validate merged schema
     let validated = match Validator::new().validate(merged) {
         Ok(s) => s,
         Err(e) => return Err(LoadError { error: e, sources }),
@@ -205,93 +205,40 @@ fn from_conflicts(conflicts: Vec<MergeConflict>) -> SchemaError {
 }
 
 fn conflict_to_error(c: MergeConflict) -> SchemaError {
-    match c {
-        MergeConflict::DuplicateModel {
-            name,
-            existing,
-            incoming,
-        } => SchemaError::DuplicateAcrossFiles {
-            kind: "model",
-            name: name.to_string(),
-            first: existing,
-            second: incoming,
-        },
-        MergeConflict::DuplicateEnum {
-            name,
-            existing,
-            incoming,
-        } => SchemaError::DuplicateAcrossFiles {
-            kind: "enum",
-            name: name.to_string(),
-            first: existing,
-            second: incoming,
-        },
-        MergeConflict::DuplicateType {
-            name,
-            existing,
-            incoming,
-        } => SchemaError::DuplicateAcrossFiles {
-            kind: "type",
-            name: name.to_string(),
-            first: existing,
-            second: incoming,
-        },
-        MergeConflict::DuplicateView {
-            name,
-            existing,
-            incoming,
-        } => SchemaError::DuplicateAcrossFiles {
-            kind: "view",
-            name: name.to_string(),
-            first: existing,
-            second: incoming,
-        },
-        MergeConflict::DuplicateServerGroup {
-            name,
-            existing,
-            incoming,
-        } => SchemaError::DuplicateAcrossFiles {
-            kind: "serverGroup",
-            name: name.to_string(),
-            first: existing,
-            second: incoming,
-        },
-        MergeConflict::DuplicatePolicy {
-            name,
-            existing,
-            incoming,
-        } => SchemaError::DuplicateAcrossFiles {
-            kind: "policy",
-            name: name.to_string(),
-            first: existing,
-            second: incoming,
-        },
-        MergeConflict::DuplicateGenerator {
-            name,
-            existing,
-            incoming,
-        } => SchemaError::DuplicateAcrossFiles {
-            kind: "generator",
-            name: name.to_string(),
-            first: existing,
-            second: incoming,
-        },
-        MergeConflict::DuplicateRawSql {
-            name,
-            existing,
-            incoming,
-        } => SchemaError::DuplicateAcrossFiles {
-            kind: "rawSql",
-            name: name.to_string(),
-            first: existing,
-            second: incoming,
-        },
-        MergeConflict::MultipleDatasource { existing, incoming } => {
-            SchemaError::MultipleDatasource {
-                first: existing,
-                second: incoming,
+    use crate::error::DuplicateKind;
+
+    macro_rules! dispatch {
+        ($($variant:ident => $kind:ident),+ $(,)?) => {
+            match c {
+                $(
+                    MergeConflict::$variant { name, existing, incoming } => {
+                        SchemaError::DuplicateAcrossFiles {
+                            kind: DuplicateKind::$kind,
+                            name: name.to_string(),
+                            first: existing,
+                            second: incoming,
+                        }
+                    }
+                ),+,
+                MergeConflict::MultipleDatasource { existing, incoming } => {
+                    SchemaError::MultipleDatasource {
+                        first: existing,
+                        second: incoming,
+                    }
+                }
             }
-        }
+        };
+    }
+
+    dispatch! {
+        DuplicateModel => Model,
+        DuplicateEnum => Enum,
+        DuplicateType => Type,
+        DuplicateView => View,
+        DuplicateServerGroup => ServerGroup,
+        DuplicatePolicy => Policy,
+        DuplicateGenerator => Generator,
+        DuplicateRawSql => RawSql,
     }
 }
 

--- a/prax-schema/src/loader/mod.rs
+++ b/prax-schema/src/loader/mod.rs
@@ -2,8 +2,10 @@
 //!
 //! See `docs/superpowers/specs/2026-05-19-multi-file-schema-design.md`.
 
+pub mod merge;
 pub mod source;
 
+pub use merge::MergeConflict;
 pub use source::{SourceFile, SourceId, SourceLoc, SourceMap};
 
 use crate::ast::Schema;

--- a/prax-schema/src/loader/mod.rs
+++ b/prax-schema/src/loader/mod.rs
@@ -1,0 +1,7 @@
+//! Multi-file schema loader.
+//!
+//! See `docs/superpowers/specs/2026-05-19-multi-file-schema-design.md`.
+
+pub mod source;
+
+pub use source::{SourceFile, SourceId, SourceMap};

--- a/prax-schema/src/loader/mod.rs
+++ b/prax-schema/src/loader/mod.rs
@@ -6,16 +6,298 @@ pub mod discovery;
 pub mod merge;
 pub mod source;
 
+use std::path::Path;
+
 pub use discovery::Discovered;
 pub use merge::MergeConflict;
 pub use source::{SourceFile, SourceId, SourceLoc, SourceMap};
 
 use crate::ast::Schema;
+use crate::error::SchemaError;
+use crate::parser::parse_schema;
+use crate::validator::Validator;
+
+/// A successfully loaded multi-file (or single-file) schema, paired with the
+/// source map needed for downstream diagnostics rendering.
+#[derive(Debug, Clone)]
+pub struct LoadedSchema {
+    pub schema: Schema,
+    pub sources: SourceMap,
+}
+
+/// Error returned by [`load`], carrying the partial source map built up to the
+/// point of failure so the renderer can resolve [`SourceId`]s back to file
+/// content.
+#[derive(Debug)]
+pub struct LoadError {
+    pub error: SchemaError,
+    pub sources: SourceMap,
+}
+
+impl std::fmt::Display for LoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.error.fmt(f)
+    }
+}
+
+impl std::error::Error for LoadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.error)
+    }
+}
+
+/// Load a schema from a file or directory.
+///
+/// - If `path` is a file: parse the single file.
+/// - If `path` is a directory: recursively find `*.prax`, parse each, merge
+///   with collision detection, then validate the merged AST.
+pub fn load(path: impl AsRef<Path>) -> Result<LoadedSchema, LoadError> {
+    let path = path.as_ref();
+    let meta = std::fs::metadata(path).map_err(|e| LoadError {
+        error: SchemaError::IoError {
+            path: path.display().to_string(),
+            source: e,
+        },
+        sources: SourceMap::new(),
+    })?;
+
+    if meta.is_file() {
+        load_single(path)
+    } else if meta.is_dir() {
+        load_directory(path)
+    } else {
+        Err(LoadError {
+            error: SchemaError::ConfigError {
+                message: format!(
+                    "schema path `{}` is neither a file nor a directory",
+                    path.display()
+                ),
+            },
+            sources: SourceMap::new(),
+        })
+    }
+}
+
+fn load_single(path: &Path) -> Result<LoadedSchema, LoadError> {
+    let mut sources = SourceMap::new();
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) => {
+            return Err(LoadError {
+                error: SchemaError::IoError {
+                    path: path.display().to_string(),
+                    source: e,
+                },
+                sources,
+            });
+        }
+    };
+    let sid = sources.insert(path.to_path_buf(), content.clone());
+
+    let mut schema = match parse_schema(&content) {
+        Ok(s) => s,
+        Err(e) => {
+            return Err(LoadError { error: e, sources });
+        }
+    };
+    stamp_source(&mut schema, sid);
+
+    let validated = match Validator::new().validate(schema) {
+        Ok(s) => s,
+        Err(e) => return Err(LoadError { error: e, sources }),
+    };
+
+    Ok(LoadedSchema {
+        schema: validated,
+        sources,
+    })
+}
+
+fn load_directory(root: &Path) -> Result<LoadedSchema, LoadError> {
+    let mut sources = SourceMap::new();
+
+    let files = match discovery::discover(root) {
+        Ok(v) => v,
+        Err(e) => return Err(LoadError { error: e, sources }),
+    };
+
+    if files.is_empty() {
+        return Err(LoadError {
+            error: SchemaError::EmptySchemaDirectory {
+                path: root.to_path_buf(),
+            },
+            sources,
+        });
+    }
+
+    // Phase 1: read + parse each file (fail-fast on syntax error)
+    let mut per_file: Vec<(SourceId, Schema)> = Vec::with_capacity(files.len());
+    for f in files {
+        let content = match std::fs::read_to_string(&f.absolute) {
+            Ok(c) => c,
+            Err(e) => {
+                return Err(LoadError {
+                    error: SchemaError::IoError {
+                        path: f.absolute.display().to_string(),
+                        source: e,
+                    },
+                    sources,
+                });
+            }
+        };
+        let sid = sources.insert(f.absolute.clone(), content.clone());
+
+        let mut schema_i = match parse_schema(&content) {
+            Ok(s) => s,
+            Err(inner) => {
+                return Err(LoadError {
+                    error: SchemaError::ParseInFile {
+                        source: sid,
+                        inner: Box::new(inner),
+                    },
+                    sources,
+                });
+            }
+        };
+        stamp_source(&mut schema_i, sid);
+        per_file.push((sid, schema_i));
+    }
+
+    // Phase 2: merge with conflict collection
+    let mut merged = Schema::new();
+    let mut all_conflicts: Vec<MergeConflict> = Vec::new();
+    for (_, schema_i) in per_file {
+        if let Err(conflicts) = merged.try_merge(schema_i) {
+            all_conflicts.extend(conflicts);
+        }
+    }
+
+    if !all_conflicts.is_empty() {
+        return Err(LoadError {
+            error: from_conflicts(all_conflicts),
+            sources,
+        });
+    }
+
+    // Phase 3: validate merged schema
+    let validated = match Validator::new().validate(merged) {
+        Ok(s) => s,
+        Err(e) => return Err(LoadError { error: e, sources }),
+    };
+
+    Ok(LoadedSchema {
+        schema: validated,
+        sources,
+    })
+}
+
+/// Bundle a batch of [`MergeConflict`]s into a single [`SchemaError`].
+fn from_conflicts(conflicts: Vec<MergeConflict>) -> SchemaError {
+    let mut errors: Vec<SchemaError> = conflicts.into_iter().map(conflict_to_error).collect();
+    if errors.len() == 1 {
+        errors.remove(0)
+    } else {
+        SchemaError::ValidationFailed {
+            count: errors.len(),
+            errors,
+        }
+    }
+}
+
+fn conflict_to_error(c: MergeConflict) -> SchemaError {
+    match c {
+        MergeConflict::DuplicateModel {
+            name,
+            existing,
+            incoming,
+        } => SchemaError::DuplicateAcrossFiles {
+            kind: "model",
+            name: name.to_string(),
+            first: existing,
+            second: incoming,
+        },
+        MergeConflict::DuplicateEnum {
+            name,
+            existing,
+            incoming,
+        } => SchemaError::DuplicateAcrossFiles {
+            kind: "enum",
+            name: name.to_string(),
+            first: existing,
+            second: incoming,
+        },
+        MergeConflict::DuplicateType {
+            name,
+            existing,
+            incoming,
+        } => SchemaError::DuplicateAcrossFiles {
+            kind: "type",
+            name: name.to_string(),
+            first: existing,
+            second: incoming,
+        },
+        MergeConflict::DuplicateView {
+            name,
+            existing,
+            incoming,
+        } => SchemaError::DuplicateAcrossFiles {
+            kind: "view",
+            name: name.to_string(),
+            first: existing,
+            second: incoming,
+        },
+        MergeConflict::DuplicateServerGroup {
+            name,
+            existing,
+            incoming,
+        } => SchemaError::DuplicateAcrossFiles {
+            kind: "serverGroup",
+            name: name.to_string(),
+            first: existing,
+            second: incoming,
+        },
+        MergeConflict::DuplicatePolicy {
+            name,
+            existing,
+            incoming,
+        } => SchemaError::DuplicateAcrossFiles {
+            kind: "policy",
+            name: name.to_string(),
+            first: existing,
+            second: incoming,
+        },
+        MergeConflict::DuplicateGenerator {
+            name,
+            existing,
+            incoming,
+        } => SchemaError::DuplicateAcrossFiles {
+            kind: "generator",
+            name: name.to_string(),
+            first: existing,
+            second: incoming,
+        },
+        MergeConflict::DuplicateRawSql {
+            name,
+            existing,
+            incoming,
+        } => SchemaError::DuplicateAcrossFiles {
+            kind: "rawSql",
+            name: name.to_string(),
+            first: existing,
+            second: incoming,
+        },
+        MergeConflict::MultipleDatasource { existing, incoming } => {
+            SchemaError::MultipleDatasource {
+                first: existing,
+                second: incoming,
+            }
+        }
+    }
+}
 
 /// Stamp every top-level item in `schema` with `source`.
 ///
-/// Called by the loader right after parsing a per-file [`Schema`], before merging.
-#[allow(dead_code)] // wired into load() in a later task
+/// Called by [`load`] right after parsing a per-file [`Schema`], before merging.
 pub(crate) fn stamp_source(schema: &mut Schema, source: SourceId) {
     for m in schema.models.values_mut() {
         m.source_id = Some(source);
@@ -50,6 +332,60 @@ pub(crate) fn stamp_source(schema: &mut Schema, source: SourceId) {
 mod tests {
     use super::*;
     use crate::parser::parse_schema;
+
+    #[test]
+    fn load_directory_merges_files_and_resolves_cross_file_relations() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("datasource.prax"),
+            r#"datasource db { provider = "postgresql" url = "x" }"#,
+        )
+        .unwrap();
+        std::fs::create_dir_all(dir.path().join("models")).unwrap();
+        std::fs::write(
+            dir.path().join("models/user.prax"),
+            "model User { id Int @id @auto email String @unique posts Post[] }",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("models/post.prax"),
+            "model Post { id Int @id @auto author_id Int author User @relation(fields: [author_id], references: [id]) }",
+        )
+        .unwrap();
+
+        let loaded = load(dir.path()).expect("load should succeed");
+        assert!(loaded.schema.get_model("User").is_some());
+        assert!(loaded.schema.get_model("Post").is_some());
+        assert!(loaded.schema.datasource.is_some());
+        assert_eq!(loaded.sources.len(), 3);
+    }
+
+    #[test]
+    fn load_directory_duplicate_model_errors() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("a.prax"), "model User { id Int @id @auto }").unwrap();
+        std::fs::write(dir.path().join("b.prax"), "model User { id Int @id @auto }").unwrap();
+
+        let err = load(dir.path()).unwrap_err();
+        let msg = format!("{}", err.error);
+        assert!(msg.contains("duplicate model"), "got: {msg}");
+        assert_eq!(err.sources.len(), 2);
+    }
+
+    #[test]
+    fn load_empty_directory_errors() {
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        let err = load(dir.path()).unwrap_err();
+        assert!(matches!(
+            err.error,
+            crate::error::SchemaError::EmptySchemaDirectory { .. }
+        ));
+    }
 
     #[test]
     fn stamp_marks_all_items() {

--- a/prax-schema/src/loader/mod.rs
+++ b/prax-schema/src/loader/mod.rs
@@ -4,7 +4,7 @@
 
 pub mod source;
 
-pub use source::{SourceFile, SourceId, SourceMap};
+pub use source::{SourceFile, SourceId, SourceLoc, SourceMap};
 
 use crate::ast::Schema;
 

--- a/prax-schema/src/loader/source.rs
+++ b/prax-schema/src/loader/source.rs
@@ -4,9 +4,24 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
+use crate::ast::Span;
+
 /// Opaque, dense identifier for a source file in a [`SourceMap`].
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct SourceId(pub u32);
+
+/// A (source file id, span) pair used in cross-file diagnostics.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct SourceLoc {
+    pub source: SourceId,
+    pub span: Span,
+}
+
+impl SourceLoc {
+    pub fn new(source: SourceId, span: Span) -> Self {
+        Self { source, span }
+    }
+}
 
 /// A single source file (path + content) loaded into the schema.
 #[derive(Debug, Clone)]

--- a/prax-schema/src/loader/source.rs
+++ b/prax-schema/src/loader/source.rs
@@ -2,8 +2,10 @@
 
 use std::path::{Path, PathBuf};
 
+use serde::{Deserialize, Serialize};
+
 /// Opaque, dense identifier for a source file in a [`SourceMap`].
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Ord, PartialOrd)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct SourceId(pub u32);
 
 /// A single source file (path + content) loaded into the schema.

--- a/prax-schema/src/loader/source.rs
+++ b/prax-schema/src/loader/source.rs
@@ -1,0 +1,92 @@
+//! Source provenance tracking for multi-file schemas.
+
+use std::path::{Path, PathBuf};
+
+/// Opaque, dense identifier for a source file in a [`SourceMap`].
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Ord, PartialOrd)]
+pub struct SourceId(pub u32);
+
+/// A single source file (path + content) loaded into the schema.
+#[derive(Debug, Clone)]
+pub struct SourceFile {
+    pub path: PathBuf,
+    pub content: String,
+}
+
+/// Map of [`SourceId`] -> [`SourceFile`].
+///
+/// Built incrementally during loading. Empty by default.
+#[derive(Debug, Clone, Default)]
+pub struct SourceMap {
+    files: Vec<SourceFile>,
+}
+
+impl SourceMap {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a new source file and return its [`SourceId`].
+    pub fn insert(&mut self, path: impl Into<PathBuf>, content: impl Into<String>) -> SourceId {
+        let id = SourceId(self.files.len() as u32);
+        self.files.push(SourceFile {
+            path: path.into(),
+            content: content.into(),
+        });
+        id
+    }
+
+    pub fn get(&self, id: SourceId) -> Option<&SourceFile> {
+        self.files.get(id.0 as usize)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (SourceId, &SourceFile)> {
+        self.files
+            .iter()
+            .enumerate()
+            .map(|(i, f)| (SourceId(i as u32), f))
+    }
+
+    pub fn len(&self) -> usize {
+        self.files.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.files.is_empty()
+    }
+
+    /// Convenience: path for a given id.
+    pub fn path_of(&self, id: SourceId) -> Option<&Path> {
+        self.get(id).map(|f| f.path.as_path())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_assigns_monotonic_ids() {
+        let mut map = SourceMap::new();
+        let a = map.insert("a.prax", "model A {}");
+        let b = map.insert("b.prax", "model B {}");
+        assert_eq!(a, SourceId(0));
+        assert_eq!(b, SourceId(1));
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn get_returns_inserted_file() {
+        let mut map = SourceMap::new();
+        let id = map.insert("/tmp/x.prax", "content");
+        let f = map.get(id).unwrap();
+        assert_eq!(f.path.to_str().unwrap(), "/tmp/x.prax");
+        assert_eq!(f.content, "content");
+    }
+
+    #[test]
+    fn get_unknown_id_returns_none() {
+        let map = SourceMap::new();
+        assert!(map.get(SourceId(42)).is_none());
+    }
+}

--- a/tests/schema_integration.rs
+++ b/tests/schema_integration.rs
@@ -451,7 +451,7 @@ fn test_schema_merging() {
     .expect("Failed to parse schema 2");
 
     let mut merged = schema1;
-    merged.merge(schema2);
+    merged.try_merge(schema2).expect("merge should succeed");
 
     assert_eq!(merged.model_names().count(), 2);
     assert!(merged.get_model("User").is_some());


### PR DESCRIPTION
## Summary

- **Multi-file schema loading.** `prax.toml`'s `[schema].path` may now point at a directory; `prax_schema::load(path)` auto-detects file vs. directory, walks `*.prax` recursively (sorted, hidden/symlink/`target/` skip), and merges into one cohesive `Schema` with hard-error duplicate detection across all top-level items (models, enums, types, views, server groups, policies, generators, raw_sql, datasource). `LoadedSchema` / `LoadError` both carry a `SourceMap` so diagnostics resolve `SourceId` → file path.
- **Wired through every consumer.** `prax-cli` (`generate`, `migrate`, `validate`, `db` all route through a shared `schema_loader::load_schema` helper; `format` walks per-file). `prax-codegen`'s `schema_reader` delegates to `prax_schema::load`, so the `prax::client!` macro now accepts directory paths.
- **Multi-file Prisma import.** `prax import --from prisma --input <dir>` auto-detects directory inputs and mirrors Prisma's `prismaSchemaFolder` layouts into a Prax directory tree (default `./prax/schema`, `--force` required to overwrite a non-empty output). Cross-file relations resolve cleanly because we merge → convert → bucket → emit per source. Single-file `prax import` behavior unchanged.
- **Old `Schema::merge` deprecated** in favor of `Schema::try_merge`, which collects every `MergeConflict` rather than silently overwriting. Top-level AST items gained an additive `source_id: Option<SourceId>`; the new `DuplicateKind` enum replaces stringly-typed error dispatch.

Spec: `docs/superpowers/specs/2026-05-19-multi-file-schema-design.md`. Plan: `docs/superpowers/plans/2026-05-19-multi-file-schema.md`.

## Test plan

- [x] `cargo test --workspace` — **2769 passing**, 0 failing (was 2750 on develop; +19 new tests).
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] Pre-push hook (full build + test suite) — passed.
- [x] New tests cover: SourceMap, stamp_source, try_merge (4 conflict variants + collect-all), recursive discovery (5 cases), `prax_schema::load` happy path / duplicate model / empty dir, Prisma `parse_and_merge_directory`, Prisma round-trip mirror, `--force` gate, CLI `prax import --from prisma --input <dir>` end-to-end.
- [ ] Manual smoke: `prax init`-style scaffold, validate / generate / migrate on a multi-file directory schema.
- [ ] Manual smoke: round-trip an existing Prisma project's `prismaSchemaFolder` directory through `prax import`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)