### PR TITLE
feat: aggregate macros (phase 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Aggregate macros (phase 6).** Three new macros over the existing
+  `AggregateOperation` / `GroupByOperation` runtime:
+  - `count!` gains a `select:` block for Prisma-style per-column
+    non-null counts (`count!(c.user, { select: { _all: true, email:
+    true } })`). Without `select:`, behavior is unchanged (returns
+    `i64`).
+  - `aggregate!` — returns a per-model `<Model>AggregateResult` with
+    `_sum` / `_avg` / `_min` / `_max` / `_count` substructs populated
+    only when their `_<agg>:` block is supplied. Requires at least one
+    aggregate block.
+  - `group_by!` — `by:`, `where:`, the five aggregate blocks, and
+    `having:`. Returns `Vec<<Model>GroupByResult>`.
+- Per-model codegen surface: `<Model>{Count,Sum,Avg,Min,Max}Select`
+  inputs, matching `*Result` outputs, `<Model>AggregateResult`,
+  `<Model>GroupByResult`, `<Model>GroupByColumn` enum,
+  `<Model>AggregateArgs`, `<Model>GroupByArgs`, plus `aggregate()` /
+  `group_by_columns()` accessors and `with_aggregate_args` /
+  `with_group_by_args` extension methods.
+- `HavingCondition` gained `{count,sum,avg,min,max}_{gt,gte,lt,lte,eq,ne}`
+  constructors (previously only a partial `count_*` set).
+- Macro-time diagnostics: `_sum`/`_avg` on a non-numeric column,
+  aggregate on a relation or another aggregate field, unknown column
+  (did-you-mean), empty `by:`, unknown by-column, empty aggregate
+  block, `aggregate!` with no aggregate blocks, unsupported `having`
+  operator, and `group_by!`'s `order_by:` (deferred). Locked via
+  trybuild fixtures.
+
+### Known limitations
+
+- The aggregate macros lower into per-model `AggregateArgs` /
+  `GroupByArgs` structs emitted by the schema-path codegen
+  (`prax_schema!`). The schema-path `relation_helpers` bug (documented
+  since phase 5b) prevents exercising the macro DSL end-to-end against
+  models defined in a workspace test crate, so the e2e and live-PG
+  tests drive the runtime `AggregateOperation` / `GroupByOperation`
+  directly. The macro front-end is covered by trybuild fixtures and
+  codegen unit tests.
+- `AggregateResult::from_row` does not yet hydrate per-column
+  `_count_<col>` aliases, so the per-column count *values* from
+  `count!`'s `select:` are emitted in SQL but not read back into a
+  typed `<Model>CountSelectResult` until that runtime gap is closed.
+  `COUNT(*)` (the `_all` count) works.
+- `having:` thresholds are inlined as numeric literals (SQL-safe — they
+  are `f64`, never user strings), not bound parameters.
+- MongoDB (`$group`) and CQL (`GROUP BY`) engines are out of scope —
+  separate follow-ups.
+- `count_distinct` exists in the runtime but is not exposed via the
+  macro shape; `_min`/`_max` against multiple columns in one call and
+  `group_by!`'s `order_by:` are deferred follow-ups.
+
 ### Changed
 
 - **`NestedWriteOp::Upsert` now emits a single statement on dialects

--- a/docs/superpowers/plans/2026-05-23-aggregate-macros.md
+++ b/docs/superpowers/plans/2026-05-23-aggregate-macros.md
@@ -1,0 +1,1859 @@
+# Aggregate Macros Implementation Plan (Phase 6)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Ship phase 6 — Prisma-style `count!` `select:` extension, `aggregate!`, and `group_by!` macros — in a single PR on top of the existing runtime `AggregateOperation` / `GroupByOperation`.
+
+**Architecture:** Codegen emits per-model input structs (`<Model>{Count,Sum,Avg,Min,Max}Select`), result structs (`<Model>{Count,Sum,Avg,Min,Max}Result`, `<Model>AggregateResult`, `<Model>GroupByResult`), an args struct family, a `<Model>GroupByColumn` enum, plus `aggregate()` / `group_by()` accessors and `with_aggregate_args()` / `with_group_by_args()` extension methods. Three macro entry points (`count!` extended, `aggregate!` new, `group_by!` new) parse brace-block DSL via shared lowering helpers (`aggregate_select.rs`, `having.rs`) and emit typed-input + builder-method tokens.
+
+**Tech Stack:** Rust 2024, Cargo workspace. Codegen via `syn` 2.x / `proc-macro2` / `quote`. Lowering helpers live in `prax-codegen/src/macros/lower/`, macro entry points in `prax-codegen/src/macros/ops/`. Runtime is the existing `prax-query/src/operations/aggregate.rs` (already provides `AggregateOperation`, `GroupByOperation`, `AggregateResult`, `HavingCondition`).
+
+**Spec:** `docs/superpowers/specs/2026-05-23-aggregate-macros-design.md`.
+
+**Worktree:** `/home/joseph/Projects/prax/.worktrees/aggregate-macros/`, branch `feature/aggregate-macros`.
+
+---
+
+## Task 1: Baseline check
+
+- [ ] **Step 1:** Confirm worktree state:
+  ```
+  cd /home/joseph/Projects/prax/.worktrees/aggregate-macros
+  git rev-parse --abbrev-ref HEAD    # feature/aggregate-macros
+  git log --oneline -2               # 4ad0292 docs(query): design spec + c916afa develop tip
+  ```
+- [ ] **Step 2:** `cargo check --workspace --all-features` — zero errors.
+- [ ] **Step 3:** `cargo test -p prax-query --lib operations::aggregate` — green baseline (existing AggregateOperation/GroupByOperation tests).
+- [ ] **Step 4:** No commit.
+
+---
+
+## Task 2: Codegen — per-model select-shape input structs
+
+**Files:**
+- Create: `prax-codegen/src/generators/aggregate.rs`
+- Modify: `prax-codegen/src/generators/mod.rs` — `pub mod aggregate;`
+- Modify: `prax-codegen/src/generators/derive.rs` — call `aggregate::emit_select_inputs(...)` and splice output into the model's input module
+
+- [ ] **Step 1: Create the new module** `prax-codegen/src/generators/aggregate.rs`:
+
+  ```rust
+  //! Aggregate-macro support: per-model select-shape input structs,
+  //! result structs, args structs, GroupByColumn enum, and the
+  //! `aggregate()` / `group_by()` accessor + `with_aggregate_args` /
+  //! `with_group_by_args` extension methods on AggregateOperation /
+  //! GroupByOperation. Used by `count!` (extended in phase 6),
+  //! `aggregate!`, and `group_by!`.
+
+  use proc_macro2::TokenStream;
+  use quote::{format_ident, quote};
+
+  /// Information about one scalar (non-relation, non-aggregate) field
+  /// on a model. Built by the caller from the existing FieldInfo loop.
+  pub struct ScalarFieldMeta<'a> {
+      pub ident: &'a syn::Ident,
+      pub ty: &'a syn::Type,
+      pub column_name: &'a str,
+      pub is_numeric: bool,
+      pub is_sortable: bool,
+  }
+
+  /// Emit the five per-model select-shape input structs.
+  pub fn emit_select_inputs(
+      model_ident: &syn::Ident,
+      scalars: &[ScalarFieldMeta<'_>],
+  ) -> TokenStream {
+      let count_name = format_ident!("{}CountSelect", model_ident);
+      let sum_name = format_ident!("{}SumSelect", model_ident);
+      let avg_name = format_ident!("{}AvgSelect", model_ident);
+      let min_name = format_ident!("{}MinSelect", model_ident);
+      let max_name = format_ident!("{}MaxSelect", model_ident);
+
+      // All scalars are eligible for Count and Min/Max if sortable.
+      // Numeric scalars are eligible for Sum/Avg.
+      let count_fields = scalars.iter().map(|f| {
+          let ident = f.ident;
+          quote! { pub #ident: ::core::option::Option<bool> }
+      });
+      let sortable_fields = scalars.iter().filter(|f| f.is_sortable).map(|f| {
+          let ident = f.ident;
+          quote! { pub #ident: ::core::option::Option<bool> }
+      });
+      let numeric_fields: Vec<_> = scalars.iter().filter(|f| f.is_numeric).map(|f| {
+          let ident = f.ident;
+          quote! { pub #ident: ::core::option::Option<bool> }
+      }).collect();
+      let sortable_for_min_max: Vec<_> = scalars.iter().filter(|f| f.is_sortable).map(|f| {
+          let ident = f.ident;
+          quote! { pub #ident: ::core::option::Option<bool> }
+      }).collect();
+
+      quote! {
+          #[derive(Debug, Default, Clone)]
+          pub struct #count_name {
+              pub _all: ::core::option::Option<bool>,
+              #(#count_fields,)*
+          }
+
+          #[derive(Debug, Default, Clone)]
+          pub struct #sum_name {
+              #(#numeric_fields,)*
+          }
+
+          #[derive(Debug, Default, Clone)]
+          pub struct #avg_name {
+              #(#numeric_fields,)*
+          }
+
+          #[derive(Debug, Default, Clone)]
+          pub struct #min_name {
+              #(#sortable_for_min_max,)*
+          }
+
+          #[derive(Debug, Default, Clone)]
+          pub struct #max_name {
+              #(#sortable_for_min_max,)*
+          }
+      }
+  }
+  ```
+
+  Note: the `numeric_fields` and `sortable_for_min_max` iterators are collected first because they're used twice (Sum+Avg and Min+Max respectively); `quote!` consumes them once.
+
+- [ ] **Step 2: Register the module** in `prax-codegen/src/generators/mod.rs`:
+
+  Add `pub mod aggregate;` next to the existing `pub mod count_struct;` (or wherever the existing per-model emitters are registered).
+
+- [ ] **Step 3: Wire into derive emit path**.
+
+  In `prax-codegen/src/generators/derive.rs`, locate where per-model input structs are assembled (look for where `count_struct::emit_count_struct(...)` from phase 5.5 is called). After that call, build a `Vec<ScalarFieldMeta>` from the existing `FieldInfo` collection:
+
+  ```rust
+  let scalar_meta: Vec<aggregate::ScalarFieldMeta> = fields
+      .iter()
+      .filter(|f| !f.is_relation && f.aggregate.is_none())
+      .map(|f| aggregate::ScalarFieldMeta {
+          ident: &f.ident,
+          ty: &f.ty,
+          column_name: f.column_name.as_str(),
+          is_numeric: rust_type_is_numeric(&f.ty),
+          is_sortable: rust_type_is_sortable(&f.ty),
+      })
+      .collect();
+  let aggregate_select_inputs = aggregate::emit_select_inputs(&model_ident, &scalar_meta);
+  ```
+
+  Splice `aggregate_select_inputs` into the model's input module (alongside where `<Model>WhereInput`/etc. land).
+
+- [ ] **Step 4: Add the type-classification helpers** at the top of `aggregate.rs`:
+
+  ```rust
+  /// True for Rust types we know are numeric. Recognises i8/16/32/64,
+  /// u8/16/32/64, i128/u128, f32/f64, usize/isize, and Option<...>
+  /// wrapping any of the above. Heuristic — codegen would need richer
+  /// type info to handle Decimal / BigDecimal etc.
+  pub fn rust_type_is_numeric(ty: &syn::Type) -> bool {
+      let name = type_leaf_ident(ty);
+      matches!(
+          name.as_deref(),
+          Some("i8" | "i16" | "i32" | "i64" | "i128"
+              | "u8" | "u16" | "u32" | "u64" | "u128"
+              | "f32" | "f64"
+              | "isize" | "usize"
+              | "Decimal" | "BigDecimal")
+      )
+  }
+
+  /// True for Rust types eligible as MIN/MAX target. Numerics, strings,
+  /// DateTime/NaiveDateTime/Date/Time, Uuid. Excludes JSON, bytes,
+  /// vectors.
+  pub fn rust_type_is_sortable(ty: &syn::Type) -> bool {
+      if rust_type_is_numeric(ty) {
+          return true;
+      }
+      let name = type_leaf_ident(ty);
+      matches!(
+          name.as_deref(),
+          Some("String" | "str"
+              | "DateTime" | "NaiveDateTime" | "NaiveDate" | "NaiveTime" | "Date" | "Time"
+              | "Uuid")
+      )
+  }
+
+  /// For `Foo`, returns Some("Foo"). For `Option<Foo>` returns Some("Foo").
+  /// For path types like `std::time::SystemTime`, returns the last segment.
+  fn type_leaf_ident(ty: &syn::Type) -> Option<String> {
+      if let syn::Type::Path(tp) = ty {
+          if let Some(seg) = tp.path.segments.last() {
+              // Unwrap Option<T>
+              if seg.ident == "Option" {
+                  if let syn::PathArguments::AngleBracketed(args) = &seg.arguments {
+                      if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
+                          return type_leaf_ident(inner);
+                      }
+                  }
+              }
+              return Some(seg.ident.to_string());
+          }
+      }
+      None
+  }
+  ```
+
+- [ ] **Step 5:** Add unit tests in `aggregate.rs::tests`:
+
+  ```rust
+  #[cfg(test)]
+  mod tests {
+      use super::*;
+      use syn::parse_quote;
+
+      #[test]
+      fn numeric_detects_basic_ints_and_floats() {
+          let ty: syn::Type = parse_quote!(i32);
+          assert!(rust_type_is_numeric(&ty));
+          let ty: syn::Type = parse_quote!(Option<f64>);
+          assert!(rust_type_is_numeric(&ty));
+          let ty: syn::Type = parse_quote!(u128);
+          assert!(rust_type_is_numeric(&ty));
+          let ty: syn::Type = parse_quote!(String);
+          assert!(!rust_type_is_numeric(&ty));
+      }
+
+      #[test]
+      fn sortable_includes_string_and_datetime() {
+          let ty: syn::Type = parse_quote!(String);
+          assert!(rust_type_is_sortable(&ty));
+          let ty: syn::Type = parse_quote!(DateTime<Utc>);
+          assert!(rust_type_is_sortable(&ty));
+          let ty: syn::Type = parse_quote!(Option<NaiveDateTime>);
+          assert!(rust_type_is_sortable(&ty));
+          let ty: syn::Type = parse_quote!(serde_json::Value);
+          assert!(!rust_type_is_sortable(&ty));
+      }
+  }
+  ```
+
+- [ ] **Step 6:** Run `cargo test -p prax-codegen --lib generators::aggregate` — both unit tests pass. Then `cargo build --workspace --all-features` to confirm the emit doesn't break existing per-model codegen.
+
+- [ ] **Step 7: Commit**
+
+  ```
+  feat(codegen): emit per-model aggregate-select input structs
+  ```
+
+  Body: notes the new `generators/aggregate.rs` module, `ScalarFieldMeta` parameter shape, type-classification helpers, and that emit is wired into the derive path.
+
+---
+
+## Task 3: Codegen — per-model result-shape output structs
+
+**Files:**
+- Modify: `prax-codegen/src/generators/aggregate.rs`
+- Modify: `prax-codegen/src/generators/derive.rs` (splice into per-model output)
+
+- [ ] **Step 1:** Extend `aggregate.rs` with `emit_result_structs`:
+
+  ```rust
+  /// Emit the five per-model result-shape output structs plus the
+  /// composite UserAggregateResult / UserGroupByResult.
+  pub fn emit_result_structs(
+      model_ident: &syn::Ident,
+      scalars: &[ScalarFieldMeta<'_>],
+  ) -> TokenStream {
+      let count_result = format_ident!("{}CountSelectResult", model_ident);
+      let sum_result = format_ident!("{}SumResult", model_ident);
+      let avg_result = format_ident!("{}AvgResult", model_ident);
+      let min_result = format_ident!("{}MinResult", model_ident);
+      let max_result = format_ident!("{}MaxResult", model_ident);
+      let agg_result = format_ident!("{}AggregateResult", model_ident);
+      let gb_result = format_ident!("{}GroupByResult", model_ident);
+
+      let count_fields = scalars.iter().map(|f| {
+          let ident = f.ident;
+          quote! { pub #ident: i64 }
+      });
+
+      let numeric_fields_owned: Vec<_> = scalars.iter().filter(|f| f.is_numeric).map(|f| {
+          let ident = f.ident;
+          // Sum widens to i64 / f64 depending on input; simplification:
+          // use Option<f64> for all sum results to handle int+float uniformly.
+          // (Aggregate result types are dialect-coerced at runtime via FilterValue.)
+          quote! { pub #ident: ::core::option::Option<f64> }
+      }).collect();
+
+      let avg_fields: Vec<_> = scalars.iter().filter(|f| f.is_numeric).map(|f| {
+          let ident = f.ident;
+          quote! { pub #ident: ::core::option::Option<f64> }
+      }).collect();
+
+      let min_max_fields: Vec<_> = scalars.iter().filter(|f| f.is_sortable).map(|f| {
+          let ident = f.ident;
+          let ty = f.ty;
+          // Wrap T in Option<T>. If already Option<T>, leave as-is.
+          let outer_ty = if is_option_type(ty) {
+              quote! { #ty }
+          } else {
+              quote! { ::core::option::Option<#ty> }
+          };
+          quote! { pub #ident: #outer_ty }
+      }).collect();
+
+      // Every scalar appears in the GroupByResult as Option<T> so callers
+      // can `by:` on any subset.
+      let gb_scalar_fields = scalars.iter().map(|f| {
+          let ident = f.ident;
+          let ty = f.ty;
+          let outer_ty = if is_option_type(ty) {
+              quote! { #ty }
+          } else {
+              quote! { ::core::option::Option<#ty> }
+          };
+          quote! { pub #ident: #outer_ty }
+      });
+
+      quote! {
+          #[derive(Debug, Default, Clone)]
+          pub struct #count_result {
+              pub _all: i64,
+              #(#count_fields,)*
+          }
+
+          #[derive(Debug, Default, Clone)]
+          pub struct #sum_result {
+              #(#numeric_fields_owned,)*
+          }
+
+          #[derive(Debug, Default, Clone)]
+          pub struct #avg_result {
+              #(#avg_fields,)*
+          }
+
+          #[derive(Debug, Default, Clone)]
+          pub struct #min_result {
+              #(#min_max_fields,)*
+          }
+
+          #[derive(Debug, Default, Clone)]
+          pub struct #max_result {
+              #(#min_max_fields,)*
+          }
+
+          #[derive(Debug, Default, Clone)]
+          pub struct #agg_result {
+              pub _sum:   ::core::option::Option<#sum_result>,
+              pub _avg:   ::core::option::Option<#avg_result>,
+              pub _min:   ::core::option::Option<#min_result>,
+              pub _max:   ::core::option::Option<#max_result>,
+              pub _count: ::core::option::Option<#count_result>,
+          }
+
+          #[derive(Debug, Default, Clone)]
+          pub struct #gb_result {
+              #(#gb_scalar_fields,)*
+              pub _sum:   ::core::option::Option<#sum_result>,
+              pub _avg:   ::core::option::Option<#avg_result>,
+              pub _min:   ::core::option::Option<#min_result>,
+              pub _max:   ::core::option::Option<#max_result>,
+              pub _count: ::core::option::Option<#count_result>,
+          }
+      }
+  }
+
+  fn is_option_type(ty: &syn::Type) -> bool {
+      if let syn::Type::Path(tp) = ty {
+          if let Some(seg) = tp.path.segments.last() {
+              return seg.ident == "Option";
+          }
+      }
+      false
+  }
+  ```
+
+- [ ] **Step 2:** In `derive.rs`, after the `emit_select_inputs` call, add:
+
+  ```rust
+  let aggregate_result_structs = aggregate::emit_result_structs(&model_ident, &scalar_meta);
+  ```
+
+  Splice both `aggregate_select_inputs` and `aggregate_result_structs` into the model's input/output module.
+
+- [ ] **Step 3:** Add tests at `aggregate.rs::tests`:
+
+  ```rust
+  #[test]
+  fn count_result_has_i64_all_and_one_field_per_scalar() {
+      // Build a synthetic ScalarFieldMeta slice for a 2-column model.
+      // Run emit_result_structs. Parse the output as a syn::File.
+      // Assert that the emitted CountSelectResult struct contains `_all: i64`
+      // and exactly two additional fields.
+      use syn::parse_quote;
+      let ident: syn::Ident = parse_quote!(User);
+      let scalars = sample_scalars(&[
+          ("id", parse_quote!(i32), true, true),
+          ("email", parse_quote!(String), false, true),
+      ]);
+      let tokens = emit_result_structs(&ident, &scalars);
+      let s = tokens.to_string();
+      assert!(s.contains("struct UserCountSelectResult"));
+      assert!(s.contains("_all : i64"));
+      assert!(s.contains("id : i64"));
+      assert!(s.contains("email : i64"));
+      assert!(s.contains("struct UserSumResult"));
+      // SumResult should only contain numeric fields (id), not email.
+      let sum_block_idx = s.find("struct UserSumResult").unwrap();
+      let next_close = s[sum_block_idx..].find('}').unwrap();
+      let sum_body = &s[sum_block_idx..sum_block_idx + next_close];
+      assert!(sum_body.contains("id :"));
+      assert!(!sum_body.contains("email :"));
+  }
+
+  // Helper to build ScalarFieldMeta from a tuple slice.
+  #[cfg(test)]
+  fn sample_scalars(items: &[(&str, syn::Type, bool, bool)]) -> Vec<ScalarFieldMeta<'_>> {
+      // Note: lifetime gymnastics — for tests, prefer building owned Vec then
+      // returning references via a helper that lives in the test fn scope.
+      // Simplest workable approach: write the helper inline in the test, not as a
+      // module-level fn.
+      unimplemented!()
+  }
+  ```
+
+  The `sample_scalars` helper is awkward because of lifetimes — inline the build in each test instead. Trim to:
+
+  ```rust
+  #[test]
+  fn count_result_has_i64_all_and_one_field_per_scalar() {
+      use syn::parse_quote;
+      let ident: syn::Ident = parse_quote!(User);
+      let id_ident: syn::Ident = parse_quote!(id);
+      let email_ident: syn::Ident = parse_quote!(email);
+      let id_ty: syn::Type = parse_quote!(i32);
+      let email_ty: syn::Type = parse_quote!(String);
+      let scalars = vec![
+          ScalarFieldMeta { ident: &id_ident, ty: &id_ty, column_name: "id", is_numeric: true, is_sortable: true },
+          ScalarFieldMeta { ident: &email_ident, ty: &email_ty, column_name: "email", is_numeric: false, is_sortable: true },
+      ];
+      let s = emit_result_structs(&ident, &scalars).to_string();
+      assert!(s.contains("struct UserCountSelectResult"));
+      assert!(s.contains("_all : i64"));
+      assert!(s.contains("struct UserSumResult"));
+      let sum_idx = s.find("struct UserSumResult").unwrap();
+      let close = s[sum_idx..].find('}').unwrap();
+      let sum_body = &s[sum_idx..sum_idx + close];
+      assert!(sum_body.contains("id :"));
+      assert!(!sum_body.contains("email :"), "Sum body should not include non-numeric `email`: {sum_body}");
+  }
+  ```
+
+- [ ] **Step 4:** Run `cargo test -p prax-codegen --lib generators::aggregate`. Pass.
+
+- [ ] **Step 5: Commit**
+
+  ```
+  feat(codegen): emit per-model aggregate-result output structs
+  ```
+
+---
+
+## Task 4: Codegen — `<Model>GroupByColumn` enum, args structs, `having`/`order_by` value types
+
+**Files:**
+- Modify: `prax-codegen/src/generators/aggregate.rs`
+- Modify: `prax-codegen/src/generators/derive.rs`
+
+- [ ] **Step 1:** Extend `aggregate.rs` with `emit_args_and_columns_enum`:
+
+  ```rust
+  pub fn emit_args_and_columns_enum(
+      model_ident: &syn::Ident,
+      scalars: &[ScalarFieldMeta<'_>],
+  ) -> TokenStream {
+      let columns_enum = format_ident!("{}GroupByColumn", model_ident);
+      let args_agg = format_ident!("{}AggregateArgs", model_ident);
+      let args_gb = format_ident!("{}GroupByArgs", model_ident);
+      let where_input = format_ident!("{}WhereInput", model_ident);
+      let count_select = format_ident!("{}CountSelect", model_ident);
+      let sum_select = format_ident!("{}SumSelect", model_ident);
+      let avg_select = format_ident!("{}AvgSelect", model_ident);
+      let min_select = format_ident!("{}MinSelect", model_ident);
+      let max_select = format_ident!("{}MaxSelect", model_ident);
+      let having_ty = format_ident!("{}GroupByHaving", model_ident);
+      let order_by_ty = format_ident!("{}GroupByOrderBy", model_ident);
+
+      // Each scalar becomes a variant of the GroupByColumn enum;
+      // method `column_name()` returns the SQL column string.
+      let variants = scalars.iter().map(|f| {
+          let v = format_ident!("{}", to_pascal_case(&f.ident.to_string()));
+          quote! { #v }
+      });
+      let column_arms = scalars.iter().map(|f| {
+          let v = format_ident!("{}", to_pascal_case(&f.ident.to_string()));
+          let col = f.column_name;
+          quote! { Self::#v => #col }
+      });
+
+      quote! {
+          #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+          pub enum #columns_enum {
+              #(#variants,)*
+          }
+
+          impl #columns_enum {
+              pub fn column_name(&self) -> &'static str {
+                  match self {
+                      #(#column_arms,)*
+                  }
+              }
+          }
+
+          #[derive(Debug, Default, Clone)]
+          pub struct #args_agg {
+              pub where_input: ::core::option::Option<#where_input>,
+              pub _sum:   ::core::option::Option<#sum_select>,
+              pub _avg:   ::core::option::Option<#avg_select>,
+              pub _min:   ::core::option::Option<#min_select>,
+              pub _max:   ::core::option::Option<#max_select>,
+              pub _count: ::core::option::Option<#count_select>,
+          }
+
+          #[derive(Debug, Default, Clone)]
+          pub struct #args_gb {
+              pub by:           ::std::vec::Vec<#columns_enum>,
+              pub where_input:  ::core::option::Option<#where_input>,
+              pub _sum:         ::core::option::Option<#sum_select>,
+              pub _avg:         ::core::option::Option<#avg_select>,
+              pub _min:         ::core::option::Option<#min_select>,
+              pub _max:         ::core::option::Option<#max_select>,
+              pub _count:       ::core::option::Option<#count_select>,
+              pub having:       ::core::option::Option<#having_ty>,
+              pub order_by:     ::core::option::Option<#order_by_ty>,
+          }
+
+          // Sketch types for having and order_by — concrete fields land in
+          // Task 9 / Task 10. For now, define empty structs so the args
+          // struct compiles end-to-end and the macros can populate them
+          // later.
+          #[derive(Debug, Default, Clone)]
+          pub struct #having_ty {
+              pub conditions: ::std::vec::Vec<::prax_query::operations::aggregate::HavingCondition>,
+          }
+
+          #[derive(Debug, Default, Clone)]
+          pub struct #order_by_ty {
+              pub items: ::std::vec::Vec<(::std::string::String, ::prax_query::operations::aggregate::SortDirection)>,
+          }
+      }
+  }
+
+  fn to_pascal_case(snake: &str) -> String {
+      let mut out = String::with_capacity(snake.len());
+      let mut upper = true;
+      for c in snake.chars() {
+          if c == '_' {
+              upper = true;
+          } else if upper {
+              out.push(c.to_ascii_uppercase());
+              upper = false;
+          } else {
+              out.push(c);
+          }
+      }
+      out
+  }
+  ```
+
+  Note on `HavingCondition` and `SortDirection`: these are runtime types in `prax-query/src/operations/aggregate.rs`. Check the actual type and module path with `grep -nE "pub struct HavingCondition\|pub enum SortDirection\|pub enum Sort" prax-query/src/operations/aggregate.rs` before committing — adjust the `::prax_query::operations::aggregate::...` path if it's `Sort` instead of `SortDirection`, or if `HavingCondition` lives at a different module path.
+
+- [ ] **Step 2:** Wire into `derive.rs`:
+
+  ```rust
+  let aggregate_args = aggregate::emit_args_and_columns_enum(&model_ident, &scalar_meta);
+  ```
+
+  Splice into the model's input module alongside the select inputs and result structs.
+
+- [ ] **Step 3:** Add a test:
+
+  ```rust
+  #[test]
+  fn group_by_column_enum_has_variant_per_scalar() {
+      use syn::parse_quote;
+      let ident: syn::Ident = parse_quote!(User);
+      let id_ident: syn::Ident = parse_quote!(team_id);
+      let region_ident: syn::Ident = parse_quote!(region);
+      let i32_ty: syn::Type = parse_quote!(i32);
+      let str_ty: syn::Type = parse_quote!(String);
+      let scalars = vec![
+          ScalarFieldMeta { ident: &id_ident, ty: &i32_ty, column_name: "team_id", is_numeric: true, is_sortable: true },
+          ScalarFieldMeta { ident: &region_ident, ty: &str_ty, column_name: "region", is_numeric: false, is_sortable: true },
+      ];
+      let s = emit_args_and_columns_enum(&ident, &scalars).to_string();
+      assert!(s.contains("enum UserGroupByColumn"));
+      assert!(s.contains("TeamId"));
+      assert!(s.contains("Region"));
+      assert!(s.contains("Self :: TeamId => \"team_id\""));
+      assert!(s.contains("struct UserAggregateArgs"));
+      assert!(s.contains("struct UserGroupByArgs"));
+  }
+  ```
+
+- [ ] **Step 4:** Run tests, fix anything that doesn't quote as expected (whitespace in `quote!` output is normalized — use `s.replace(' ', "")` for tighter assertions if needed).
+
+- [ ] **Step 5: Commit**
+
+  ```
+  feat(codegen): emit per-model GroupByColumn enum and aggregate args structs
+  ```
+
+---
+
+## Task 5: Codegen — `aggregate()` / `group_by()` accessors + `with_*_args` extensions
+
+**Files:**
+- Modify: `prax-codegen/src/generators/aggregate.rs`
+- Modify: `prax-codegen/src/generators/derive.rs`
+
+- [ ] **Step 1:** Add `emit_accessors_and_extensions`:
+
+  ```rust
+  pub fn emit_accessors_and_extensions(
+      model_ident: &syn::Ident,
+      scalars: &[ScalarFieldMeta<'_>],
+  ) -> TokenStream {
+      let accessor_ty = format_ident!("{}Accessor", model_ident);   // existing per-model accessor
+      let agg_args = format_ident!("{}AggregateArgs", model_ident);
+      let gb_args = format_ident!("{}GroupByArgs", model_ident);
+      let count_select = format_ident!("{}CountSelect", model_ident);
+      let sum_select = format_ident!("{}SumSelect", model_ident);
+      let avg_select = format_ident!("{}AvgSelect", model_ident);
+      let min_select = format_ident!("{}MinSelect", model_ident);
+      let max_select = format_ident!("{}MaxSelect", model_ident);
+      let columns_enum = format_ident!("{}GroupByColumn", model_ident);
+
+      // Build `fields_set()` impls for each select struct: returns
+      // Vec<&'static str> of the column names whose Option<bool> is Some(true).
+      let count_fields_set = scalars.iter().map(|f| {
+          let ident = f.ident;
+          let col = f.column_name;
+          quote! {
+              if matches!(self.#ident, ::core::option::Option::Some(true)) {
+                  out.push(#col);
+              }
+          }
+      });
+      let numeric_fields_set = scalars.iter().filter(|f| f.is_numeric).map(|f| {
+          let ident = f.ident;
+          let col = f.column_name;
+          quote! {
+              if matches!(self.#ident, ::core::option::Option::Some(true)) {
+                  out.push(#col);
+              }
+          }
+      });
+      let sortable_fields_set = scalars.iter().filter(|f| f.is_sortable).map(|f| {
+          let ident = f.ident;
+          let col = f.column_name;
+          quote! {
+              if matches!(self.#ident, ::core::option::Option::Some(true)) {
+                  out.push(#col);
+              }
+          }
+      });
+
+      let numeric_fields_set_2 = numeric_fields_set.clone(); // used twice (Sum + Avg)
+      let sortable_fields_set_2 = sortable_fields_set.clone(); // Min + Max
+
+      quote! {
+          impl #count_select {
+              /// Column names whose Option<bool> is Some(true), excluding `_all`.
+              pub fn fields_set(&self) -> ::std::vec::Vec<&'static str> {
+                  let mut out = ::std::vec::Vec::new();
+                  #(#count_fields_set)*
+                  out
+              }
+              pub fn all_set(&self) -> bool {
+                  matches!(self._all, ::core::option::Option::Some(true))
+              }
+          }
+          impl #sum_select {
+              pub fn fields_set(&self) -> ::std::vec::Vec<&'static str> {
+                  let mut out = ::std::vec::Vec::new();
+                  #(#numeric_fields_set)*
+                  out
+              }
+          }
+          impl #avg_select {
+              pub fn fields_set(&self) -> ::std::vec::Vec<&'static str> {
+                  let mut out = ::std::vec::Vec::new();
+                  #(#numeric_fields_set_2)*
+                  out
+              }
+          }
+          impl #min_select {
+              pub fn fields_set(&self) -> ::std::vec::Vec<&'static str> {
+                  let mut out = ::std::vec::Vec::new();
+                  #(#sortable_fields_set)*
+                  out
+              }
+          }
+          impl #max_select {
+              pub fn fields_set(&self) -> ::std::vec::Vec<&'static str> {
+                  let mut out = ::std::vec::Vec::new();
+                  #(#sortable_fields_set_2)*
+                  out
+              }
+          }
+
+          impl<E: ::prax_query::traits::QueryEngine> #accessor_ty<E> {
+              pub fn aggregate(&self) -> ::prax_query::operations::aggregate::AggregateOperation<#model_ident, E> {
+                  ::prax_query::operations::aggregate::AggregateOperation::with_engine(self.engine.clone())
+              }
+              pub fn group_by(&self, by: ::std::vec::Vec<#columns_enum>) -> ::prax_query::operations::aggregate::GroupByOperation<#model_ident, E> {
+                  let cols: ::std::vec::Vec<::std::string::String> =
+                      by.iter().map(|c| c.column_name().to_string()).collect();
+                  ::prax_query::operations::aggregate::GroupByOperation::with_engine(self.engine.clone(), cols)
+              }
+          }
+
+          impl<E: ::prax_query::traits::QueryEngine + ::core::clone::Clone> ::prax_query::operations::aggregate::AggregateOperation<#model_ident, E> {
+              pub fn with_aggregate_args(mut self, args: #agg_args) -> Self {
+                  if let ::core::option::Option::Some(w) = args.where_input {
+                      self = self.with_where_input(w);
+                  }
+                  if let ::core::option::Option::Some(c) = args._count {
+                      if c.all_set() { self = self.count(); }
+                      for col in c.fields_set() { self = self.count_column(col); }
+                  }
+                  if let ::core::option::Option::Some(s) = args._sum {
+                      for col in s.fields_set() { self = self.sum(col); }
+                  }
+                  if let ::core::option::Option::Some(a) = args._avg {
+                      for col in a.fields_set() { self = self.avg(col); }
+                  }
+                  if let ::core::option::Option::Some(m) = args._min {
+                      for col in m.fields_set() { self = self.min(col); }
+                  }
+                  if let ::core::option::Option::Some(m) = args._max {
+                      for col in m.fields_set() { self = self.max(col); }
+                  }
+                  self
+              }
+          }
+
+          impl<E: ::prax_query::traits::QueryEngine + ::core::clone::Clone> ::prax_query::operations::aggregate::GroupByOperation<#model_ident, E> {
+              pub fn with_group_by_args(mut self, args: #gb_args) -> Self {
+                  if let ::core::option::Option::Some(w) = args.where_input {
+                      self = self.with_where_input(w);
+                  }
+                  if let ::core::option::Option::Some(c) = args._count {
+                      if c.all_set() { self = self.count(); }
+                      for col in c.fields_set() { self = self.count_column(col); }
+                  }
+                  if let ::core::option::Option::Some(s) = args._sum {
+                      for col in s.fields_set() { self = self.sum(col); }
+                  }
+                  if let ::core::option::Option::Some(a) = args._avg {
+                      for col in a.fields_set() { self = self.avg(col); }
+                  }
+                  if let ::core::option::Option::Some(m) = args._min {
+                      for col in m.fields_set() { self = self.min(col); }
+                  }
+                  if let ::core::option::Option::Some(m) = args._max {
+                      for col in m.fields_set() { self = self.max(col); }
+                  }
+                  if let ::core::option::Option::Some(h) = args.having {
+                      for cond in h.conditions { self = self.having(cond); }
+                  }
+                  // order_by lowering lands when Task 8 wires the macro DSL.
+                  let _ = args.order_by;
+                  self
+              }
+          }
+      }
+  }
+  ```
+
+  **Verify** before committing:
+  - `GroupByOperation` actually accepts `Vec<String>` for columns (or `Vec<&str>` — check signature). Adapt if needed.
+  - `AggregateOperation::with_where_input` and `count_column` / `count_distinct` actually exist with those names. If `count_column` doesn't take `impl Into<String>`, adapt the call.
+  - The accessor field is named `engine` and is `Clone`-able (or use a different binding name per existing patterns in `prax-codegen/src/generators/relation_accessors.rs`).
+
+- [ ] **Step 2:** Wire `emit_accessors_and_extensions` into `derive.rs`:
+
+  ```rust
+  let aggregate_accessors = aggregate::emit_accessors_and_extensions(&model_ident, &scalar_meta);
+  ```
+
+  Splice into the model's output module **outside** the input mod block (these are `impl` blocks for the engine accessor and operation types).
+
+- [ ] **Step 3:** Add an integration smoke test in `tests/aggregate_macros_e2e.rs` (created in Task 13 — placeholder for now):
+
+  Or skip and rely on the compile-check sweep:
+
+  ```bash
+  cd /home/joseph/Projects/prax/.worktrees/aggregate-macros
+  cargo build --workspace --all-features
+  ```
+
+  All emitted impls compile.
+
+- [ ] **Step 4: Commit**
+
+  ```
+  feat(codegen): emit aggregate/group_by accessors + with_*_args extension impls
+  ```
+
+---
+
+## Task 6: Lowering helper — `aggregate_select.rs`
+
+**Files:**
+- Create: `prax-codegen/src/macros/lower/aggregate_select.rs`
+- Modify: `prax-codegen/src/macros/lower/mod.rs` — `pub mod aggregate_select;`
+
+- [ ] **Step 1:** Create `aggregate_select.rs`:
+
+  ```rust
+  //! Lower a `_<agg>: { col: true, ... }` DSL brace block to a typed
+  //! `<Model><Agg>Select` constructor TokenStream. Shared between
+  //! `count!`, `aggregate!`, and `group_by!`.
+
+  use proc_macro2::TokenStream;
+  use quote::{format_ident, quote};
+
+  use super::LowerCtx;
+  use crate::macros::dsl::ast::{DslBlock, DslField, DslValue};
+
+  /// Aggregate kinds the lowering recognises.
+  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  pub enum AggKind {
+      Count,
+      Sum,
+      Avg,
+      Min,
+      Max,
+  }
+
+  impl AggKind {
+      pub fn select_struct_suffix(&self) -> &'static str {
+          match self {
+              Self::Count => "CountSelect",
+              Self::Sum => "SumSelect",
+              Self::Avg => "AvgSelect",
+              Self::Min => "MinSelect",
+              Self::Max => "MaxSelect",
+          }
+      }
+      pub fn key(&self) -> &'static str {
+          match self {
+              Self::Count => "_count",
+              Self::Sum => "_sum",
+              Self::Avg => "_avg",
+              Self::Min => "_min",
+              Self::Max => "_max",
+          }
+      }
+  }
+
+  /// Lower one `_<agg>: { col: true, ... }` block to a tokens expression
+  /// that constructs `<Model><Agg>Select { <col>: Some(true), ... }`.
+  pub fn lower_agg_select(
+      kind: AggKind,
+      block: &DslBlock,
+      ctx: &LowerCtx<'_>,
+  ) -> syn::Result<TokenStream> {
+      let struct_ident = format_ident!("{}{}", ctx.model.name(), kind.select_struct_suffix());
+
+      let mut setters: Vec<TokenStream> = Vec::new();
+
+      for entry in &block.fields {
+          let DslField::Pair { key, value, .. } = entry else {
+              return Err(syn::Error::new(
+                  proc_macro2::Span::call_site(),
+                  format!("`{}` block does not support spread or conditional fields", kind.key()),
+              ));
+          };
+          let key_str = key.to_string();
+
+          // Validate value is `true` literal.
+          if !matches!(value, DslValue::Bool(true)) {
+              return Err(syn::Error::new(
+                  key.span(),
+                  format!(
+                      "value for `{}.{}` must be `true` (only opt-in is supported)",
+                      kind.key(), key_str
+                  ),
+              ));
+          }
+
+          // Special: `_all` only valid in Count blocks.
+          if key_str == "_all" {
+              if kind != AggKind::Count {
+                  return Err(syn::Error::new(
+                      key.span(),
+                      format!("`_all` is only valid inside `_count`, not `{}`", kind.key()),
+                  ));
+              }
+              setters.push(quote! { __s._all = ::core::option::Option::Some(true); });
+              continue;
+          }
+
+          // Validate column exists on the model and is appropriate for kind.
+          let field = ctx.model.get_field(&key_str).ok_or_else(|| {
+              let candidates: Vec<String> =
+                  ctx.model.fields.keys().map(|k| k.to_string()).collect();
+              let suggestion = crate::macros::validate::suggest(&key_str, &candidates);
+              let msg = match suggestion {
+                  Some(s) => format!(
+                      "unknown column `{}` on model `{}`; did you mean `{}`?",
+                      key_str, ctx.model.name(), s
+                  ),
+                  None => format!(
+                      "unknown column `{}` on model `{}`",
+                      key_str, ctx.model.name()
+                  ),
+              };
+              syn::Error::new(key.span(), msg)
+          })?;
+
+          if field.is_relation() {
+              return Err(syn::Error::new(
+                  key.span(),
+                  format!(
+                      "field `{}` is a relation; aggregates require a scalar column",
+                      key_str
+                  ),
+              ));
+          }
+          if field.aggregate().is_some() {
+              return Err(syn::Error::new(
+                  key.span(),
+                  format!(
+                      "field `{}` is itself an aggregate; cannot aggregate an aggregate",
+                      key_str
+                  ),
+              ));
+          }
+
+          // For Sum/Avg, the field must be numeric (rough heuristic at codegen).
+          if matches!(kind, AggKind::Sum | AggKind::Avg) {
+              if !field_is_numeric_scalar(field) {
+                  return Err(syn::Error::new(
+                      key.span(),
+                      format!(
+                          "field `{}` is not numeric; `{}` requires a numeric column",
+                          key_str, kind.key()
+                      ),
+                  ));
+              }
+          }
+
+          let col_ident = format_ident!("{}", key_str);
+          setters.push(quote! {
+              __s.#col_ident = ::core::option::Option::Some(true);
+          });
+      }
+
+      if setters.is_empty() {
+          return Err(syn::Error::new(
+              proc_macro2::Span::call_site(),
+              format!("`{}` block is empty; specify at least one column or remove the block", kind.key()),
+          ));
+      }
+
+      let module_ident = format_ident!("{}", ctx.model.name().to_case(convert_case::Case::Snake));
+      Ok(quote! {{
+          let mut __s: #module_ident::#struct_ident =
+              <#module_ident::#struct_ident as ::core::default::Default>::default();
+          #(#setters)*
+          __s
+      }})
+  }
+
+  /// Determine whether a schema field's type is numeric. Look at
+  /// `field.field_type` — `FieldType::Scalar(ScalarType::Int|BigInt|Float|...)`.
+  fn field_is_numeric_scalar(field: &prax_schema::ast::Field) -> bool {
+      use prax_schema::ast::{FieldType, ScalarType};
+      matches!(
+          field.field_type,
+          FieldType::Scalar(ScalarType::Int)
+              | FieldType::Scalar(ScalarType::BigInt)
+              | FieldType::Scalar(ScalarType::Float)
+              | FieldType::Scalar(ScalarType::Decimal)
+      )
+  }
+  ```
+
+  Adjust the `ScalarType` variant names to whatever the actual enum has (`grep -n "pub enum ScalarType" prax-schema/src/ast/types.rs`).
+
+- [ ] **Step 2:** Register the module in `prax-codegen/src/macros/lower/mod.rs`: `pub mod aggregate_select;`.
+
+- [ ] **Step 3:** Unit tests in `aggregate_select.rs::tests`:
+
+  ```rust
+  #[cfg(test)]
+  mod tests {
+      // Build a minimal LowerCtx with a fake Model that has a numeric `id`
+      // and a string `email` field. Verify:
+      //  - lower_agg_select(Count, { _all: true, email: true }) → success
+      //  - lower_agg_select(Sum, { email: true }) → Err "is not numeric"
+      //  - lower_agg_select(Min, { unknown: true }) → Err "unknown column"
+      //  - lower_agg_select(Count, { _all: false }) → Err "must be true"
+      //
+      // The exact mechanics depend on how other lowering tests build a
+      // LowerCtx — copy the pattern from
+      // prax-codegen/src/macros/lower/select_input.rs::tests.
+  }
+  ```
+
+- [ ] **Step 4:** `cargo test -p prax-codegen --lib macros::lower::aggregate_select` — all pass.
+
+- [ ] **Step 5: Commit**
+
+  ```
+  feat(codegen): aggregate_select lowering helper
+  ```
+
+---
+
+## Task 7: Lowering helper — `having.rs`
+
+**Files:**
+- Create: `prax-codegen/src/macros/lower/having.rs`
+- Modify: `prax-codegen/src/macros/lower/mod.rs` — `pub mod having;`
+
+- [ ] **Step 1:** Create `having.rs`:
+
+  ```rust
+  //! Lower a `having: { _count: { _all: { gt: 5 } }, _sum: { views: { gte: 100 } } }`
+  //! block to a Vec<HavingCondition> token expression.
+
+  use proc_macro2::TokenStream;
+  use quote::{format_ident, quote};
+
+  use super::LowerCtx;
+  use crate::macros::dsl::ast::{DslBlock, DslField, DslValue};
+  use crate::macros::lower::aggregate_select::AggKind;
+
+  /// Lower the having block into a Vec<HavingCondition> expression.
+  pub fn lower_having(
+      block: &DslBlock,
+      ctx: &LowerCtx<'_>,
+  ) -> syn::Result<TokenStream> {
+      let mut conditions: Vec<TokenStream> = Vec::new();
+
+      for entry in &block.fields {
+          let DslField::Pair { key, value, .. } = entry else {
+              return Err(syn::Error::new(
+                  proc_macro2::Span::call_site(),
+                  "having block does not support spread or conditional fields",
+              ));
+          };
+          let agg_key = key.to_string();
+          let kind = match agg_key.as_str() {
+              "_count" => AggKind::Count,
+              "_sum" => AggKind::Sum,
+              "_avg" => AggKind::Avg,
+              "_min" => AggKind::Min,
+              "_max" => AggKind::Max,
+              other => return Err(syn::Error::new(
+                  key.span(),
+                  format!("unknown having key `{}`; use one of _count/_sum/_avg/_min/_max", other),
+              )),
+          };
+          let DslValue::Block(inner) = value else {
+              return Err(syn::Error::new(
+                  key.span(),
+                  format!("having `{}` value must be a `{{ col: {{ op: value }} }}` block", agg_key),
+              ));
+          };
+
+          // Inner: { col_name: { op: value } }, e.g. _all: { gt: 5 }
+          for col_entry in &inner.fields {
+              let DslField::Pair { key: col_key, value: col_val, .. } = col_entry else {
+                  return Err(syn::Error::new(
+                      proc_macro2::Span::call_site(),
+                      "having column block does not support spread",
+                  ));
+              };
+              let col = col_key.to_string();
+              let DslValue::Block(op_block) = col_val else {
+                  return Err(syn::Error::new(
+                      col_key.span(),
+                      format!("having `{}.{}` must be a `{{ op: value }}` block", agg_key, col),
+                  ));
+              };
+              // Inner-inner: { op: value }, e.g. { gt: 5 }
+              for op_entry in &op_block.fields {
+                  let DslField::Pair { key: op_key, value: op_val, .. } = op_entry else { continue; };
+                  let op = op_key.to_string();
+                  // Convert the DSL value to a Rust expression.
+                  let expr = dsl_value_to_expr(op_val)?;
+                  let ctor = match (kind, op.as_str()) {
+                      (AggKind::Count, "gt") => quote! { ::prax_query::operations::aggregate::HavingCondition::count_gt(#expr as f64) },
+                      (AggKind::Count, "gte") => quote! { ::prax_query::operations::aggregate::HavingCondition::count_gte(#expr as f64) },
+                      (AggKind::Count, "lt") => quote! { ::prax_query::operations::aggregate::HavingCondition::count_lt(#expr as f64) },
+                      (AggKind::Count, "lte") => quote! { ::prax_query::operations::aggregate::HavingCondition::count_lte(#expr as f64) },
+                      (AggKind::Count, "equals") => quote! { ::prax_query::operations::aggregate::HavingCondition::count_eq(#expr as f64) },
+                      // Add other (Sum, Avg, Min, Max) × (op) variants by mirroring the
+                      // existing HavingCondition constructor names — inspect
+                      // prax-query/src/operations/aggregate.rs for the actual list.
+                      _ => return Err(syn::Error::new(
+                          op_key.span(),
+                          format!("unsupported having operator `{}` for `{}`", op, agg_key),
+                      )),
+                  };
+                  conditions.push(ctor);
+              }
+          }
+      }
+
+      let _ = ctx;  // future: schema-aware col validation against the agg block
+      Ok(quote! {
+          {
+              let mut __conds: ::std::vec::Vec<::prax_query::operations::aggregate::HavingCondition> = ::std::vec::Vec::new();
+              #( __conds.push(#conditions); )*
+              __conds
+          }
+      })
+  }
+
+  fn dsl_value_to_expr(v: &DslValue) -> syn::Result<TokenStream> {
+      match v {
+          DslValue::Int(i) => Ok(quote! { #i }),
+          DslValue::Float(f) => Ok(quote! { #f }),
+          DslValue::String(s) => Ok(quote! { #s }),
+          _ => Err(syn::Error::new(
+              proc_macro2::Span::call_site(),
+              "having operator value must be a numeric or string literal",
+          )),
+      }
+  }
+  ```
+
+  **IMPORTANT**: inspect `prax-query/src/operations/aggregate.rs` for the actual `HavingCondition` constructor names. They likely cover only `count_*` currently — if `sum_gt`, `avg_gt`, etc. don't exist, extend `HavingCondition` with the missing constructors as part of this task (small additive change to the runtime crate). Document any added constructors in the commit.
+
+- [ ] **Step 2:** Register module in `lower/mod.rs`.
+
+- [ ] **Step 3:** Tests:
+
+  ```rust
+  #[cfg(test)]
+  mod tests {
+      // - lower_having({ _count: { _all: { gt: 5 } } }) → contains count_gt(5_f64)
+      // - lower_having({ _bad_key: ... }) → Err "unknown having key"
+      // - lower_having({ _count: { _all: { like: 5 } } }) → Err "unsupported having operator"
+  }
+  ```
+
+- [ ] **Step 4: Commit**
+
+  ```
+  feat(codegen): having lowering helper
+  ```
+
+  If you had to add `HavingCondition::sum_gt` etc., split into two commits with `feat(query): expand HavingCondition for non-count aggregates` first.
+
+---
+
+## Task 8: Extend `count!` with `select:` block
+
+**Files:**
+- Modify: `prax-codegen/src/macros/ops/count.rs`
+
+- [ ] **Step 1:** Locate the existing `count!` lowering. There's a rejection at "select: on count! is a phase-6 feature" — replace it with real parsing using `aggregate_select::lower_agg_select(AggKind::Count, ...)`.
+
+- [ ] **Step 2:** Sketch:
+
+  ```rust
+  // Top-level count! block parser:
+  let mut where_block: Option<&DslBlock> = None;
+  let mut select_block: Option<&DslBlock> = None;
+  for field in &input.fields {
+      let DslField::Pair { key, value, .. } = field else { continue; };
+      match key.to_string().as_str() {
+          "where" => { /* existing handling */ where_block = ... }
+          "select" => {
+              let DslValue::Block(b) = value else { return Err(...); };
+              select_block = Some(b);
+          }
+          other => return Err(syn::Error::new(key.span(), format!("unknown key `{}`", other))),
+      }
+  }
+
+  if let Some(select) = select_block {
+      // Lower to: client.<accessor>.aggregate().with_aggregate_args(UserAggregateArgs { _count: Some(<select>), where_input: <where>, ..Default::default() })
+      // Result type: <Model>CountSelectResult
+      let select_ts = crate::macros::lower::aggregate_select::lower_agg_select(
+          crate::macros::lower::aggregate_select::AggKind::Count,
+          select,
+          &ctx,
+      )?;
+      // Wrap as Some(..) and place in UserAggregateArgs._count.
+      // Lower where_block if present.
+      let where_ts = match where_block {
+          Some(w) => {
+              let wts = crate::macros::lower::where_input::lower_where_input(w, &ctx)?.where_input;
+              quote! { ::core::option::Option::Some(#wts) }
+          }
+          None => quote! { ::core::option::Option::None },
+      };
+      let args_ident = format_ident!("{}AggregateArgs", ctx.model.name());
+      let module_ident = format_ident!("{}", ctx.model.name().to_case(convert_case::Case::Snake));
+
+      return Ok(quote! {
+          {
+              let __args: #module_ident::#args_ident = #module_ident::#args_ident {
+                  where_input: #where_ts,
+                  _count: ::core::option::Option::Some(#select_ts),
+                  ..::core::default::Default::default()
+              };
+              <#accessor_expr>.aggregate().with_aggregate_args(__args)
+          }
+      });
+  }
+  // Fall through to existing plain-i64 count! lowering.
+  ```
+
+  The exact accessor-expression form depends on the existing `count!` plumbing — match the pattern (probably `ctx.accessor_expr`).
+
+- [ ] **Step 3:** A small unit test in `ops/count.rs::tests` (or wherever existing count tests live) that the `select:` path emits a `with_aggregate_args` call. Use the `lower_macro_input_to_string` helper if one exists, else add one.
+
+- [ ] **Step 4: Commit**
+
+  ```
+  feat(codegen): count! select: block (phase 6 Prisma-style per-column counts)
+  ```
+
+---
+
+## Task 9: New `aggregate!` macro entry point
+
+**Files:**
+- Create: `prax-codegen/src/macros/ops/aggregate.rs`
+- Modify: `prax-codegen/src/macros/ops/mod.rs` — `pub mod aggregate;`
+- Modify: `prax-codegen/src/lib.rs` — register `#[proc_macro] pub fn aggregate(...)` re-export
+- Modify: `prax-orm/src/lib.rs` — re-export `aggregate!` from `prax_codegen`
+
+- [ ] **Step 1:** Create `ops/aggregate.rs`:
+
+  ```rust
+  //! `aggregate!` proc-macro entry point.
+
+  use proc_macro2::TokenStream;
+  use quote::{format_ident, quote};
+  use convert_case::{Case, Casing};
+
+  use crate::macros::accessor::AccessorCall;
+  use crate::macros::dsl::ast::{DslBlock, DslField, DslValue};
+  use crate::macros::lower::aggregate_select::{AggKind, lower_agg_select};
+  use crate::macros::lower::where_input;
+  use crate::macros::schema_resolve::resolve_model_for_accessor;
+  use crate::macros::validate;
+
+  pub fn aggregate_macro_impl(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+      let parsed: AccessorCall = match syn::parse(input) {
+          Ok(x) => x,
+          Err(e) => return e.to_compile_error().into(),
+      };
+      match lower_aggregate(parsed) {
+          Ok(ts) => ts.into(),
+          Err(e) => e.to_compile_error().into(),
+      }
+  }
+
+  fn lower_aggregate(call: AccessorCall) -> syn::Result<TokenStream> {
+      let ctx = resolve_model_for_accessor(&call)?;
+      let block = &call.block;
+
+      let mut where_block: Option<&DslBlock> = None;
+      let mut count_block: Option<&DslBlock> = None;
+      let mut sum_block: Option<&DslBlock> = None;
+      let mut avg_block: Option<&DslBlock> = None;
+      let mut min_block: Option<&DslBlock> = None;
+      let mut max_block: Option<&DslBlock> = None;
+
+      for entry in &block.fields {
+          let DslField::Pair { key, value, .. } = entry else {
+              return Err(syn::Error::new(
+                  proc_macro2::Span::call_site(),
+                  "aggregate! does not support spread or conditional top-level fields",
+              ));
+          };
+          let key_str = key.to_string();
+          let block_opt = |v: &DslValue| {
+              if let DslValue::Block(b) = v { Ok(b) } else {
+                  Err(syn::Error::new(key.span(), format!("`{}` value must be a `{{ ... }}` block", key_str)))
+              }
+          };
+          match key_str.as_str() {
+              "where" => where_block = Some(block_opt(value)?),
+              "_count" => count_block = Some(block_opt(value)?),
+              "_sum" => sum_block = Some(block_opt(value)?),
+              "_avg" => avg_block = Some(block_opt(value)?),
+              "_min" => min_block = Some(block_opt(value)?),
+              "_max" => max_block = Some(block_opt(value)?),
+              other => return Err(syn::Error::new(
+                  key.span(),
+                  format!("unknown key `{}` in aggregate! — expected where/_count/_sum/_avg/_min/_max", other),
+              )),
+          }
+      }
+
+      if count_block.is_none() && sum_block.is_none() && avg_block.is_none()
+          && min_block.is_none() && max_block.is_none() {
+          return Err(syn::Error::new(
+              proc_macro2::Span::call_site(),
+              "aggregate! requires at least one of _count, _sum, _avg, _min, _max",
+          ));
+      }
+
+      let lower_opt = |k: AggKind, b: Option<&DslBlock>| -> syn::Result<TokenStream> {
+          match b {
+              Some(blk) => {
+                  let ts = lower_agg_select(k, blk, &ctx)?;
+                  Ok(quote! { ::core::option::Option::Some(#ts) })
+              }
+              None => Ok(quote! { ::core::option::Option::None }),
+          }
+      };
+
+      let count_ts = lower_opt(AggKind::Count, count_block)?;
+      let sum_ts = lower_opt(AggKind::Sum, sum_block)?;
+      let avg_ts = lower_opt(AggKind::Avg, avg_block)?;
+      let min_ts = lower_opt(AggKind::Min, min_block)?;
+      let max_ts = lower_opt(AggKind::Max, max_block)?;
+
+      let where_ts = match where_block {
+          Some(w) => {
+              let wts = where_input::lower_where_input(w, &ctx)?.where_input;
+              quote! { ::core::option::Option::Some(#wts) }
+          }
+          None => quote! { ::core::option::Option::None },
+      };
+
+      let module_ident = format_ident!("{}", ctx.model.name().to_case(Case::Snake));
+      let args_ident = format_ident!("{}AggregateArgs", ctx.model.name());
+      let accessor_expr = &call.accessor_expr;
+
+      Ok(quote! {
+          {
+              let __args: #module_ident::#args_ident = #module_ident::#args_ident {
+                  where_input: #where_ts,
+                  _count: #count_ts,
+                  _sum: #sum_ts,
+                  _avg: #avg_ts,
+                  _min: #min_ts,
+                  _max: #max_ts,
+              };
+              (#accessor_expr).aggregate().with_aggregate_args(__args)
+          }
+      })
+  }
+  ```
+
+- [ ] **Step 2:** Register the proc-macro entry. In `prax-codegen/src/lib.rs` find where `find_many` is registered and add:
+
+  ```rust
+  #[proc_macro]
+  pub fn aggregate(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+      crate::macros::ops::aggregate::aggregate_macro_impl(input)
+  }
+  ```
+
+- [ ] **Step 3:** Re-export from `prax-orm/src/lib.rs` next to other `pub use prax_codegen::*;` re-exports.
+
+- [ ] **Step 4:** Smoke test — workspace builds.
+
+  ```bash
+  cargo build --workspace --all-features
+  ```
+
+- [ ] **Step 5: Commit**
+
+  ```
+  feat(codegen): aggregate! macro entry point (phase 6)
+  ```
+
+---
+
+## Task 10: New `group_by!` macro entry point
+
+**Files:**
+- Create: `prax-codegen/src/macros/ops/group_by.rs`
+- Modify: `prax-codegen/src/macros/ops/mod.rs` — `pub mod group_by;`
+- Modify: `prax-codegen/src/lib.rs` — proc-macro registration
+- Modify: `prax-orm/src/lib.rs` — re-export
+
+- [ ] **Step 1:** Create `ops/group_by.rs` (mirrors `aggregate.rs` but adds parsing of `by:`, `having:`, `order_by:`):
+
+  ```rust
+  //! `group_by!` proc-macro entry point.
+
+  use proc_macro2::TokenStream;
+  use quote::{format_ident, quote};
+  use convert_case::{Case, Casing};
+
+  use crate::macros::accessor::AccessorCall;
+  use crate::macros::dsl::ast::{DslBlock, DslField, DslValue, DslList};
+  use crate::macros::lower::aggregate_select::{AggKind, lower_agg_select};
+  use crate::macros::lower::having::lower_having;
+  use crate::macros::lower::where_input;
+  use crate::macros::schema_resolve::resolve_model_for_accessor;
+
+  pub fn group_by_macro_impl(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+      let parsed: AccessorCall = match syn::parse(input) {
+          Ok(x) => x,
+          Err(e) => return e.to_compile_error().into(),
+      };
+      match lower_group_by(parsed) {
+          Ok(ts) => ts.into(),
+          Err(e) => e.to_compile_error().into(),
+      }
+  }
+
+  fn lower_group_by(call: AccessorCall) -> syn::Result<TokenStream> {
+      let ctx = resolve_model_for_accessor(&call)?;
+      let block = &call.block;
+
+      let mut by_list: Option<&DslList> = None;
+      let mut where_block: Option<&DslBlock> = None;
+      let mut count_block: Option<&DslBlock> = None;
+      let mut sum_block: Option<&DslBlock> = None;
+      let mut avg_block: Option<&DslBlock> = None;
+      let mut min_block: Option<&DslBlock> = None;
+      let mut max_block: Option<&DslBlock> = None;
+      let mut having_block: Option<&DslBlock> = None;
+      // order_by handling deferred (see TODO below).
+
+      for entry in &block.fields {
+          let DslField::Pair { key, value, .. } = entry else {
+              return Err(syn::Error::new(
+                  proc_macro2::Span::call_site(),
+                  "group_by! does not support spread or conditional top-level fields",
+              ));
+          };
+          let key_str = key.to_string();
+          match key_str.as_str() {
+              "by" => {
+                  let DslValue::List(l) = value else {
+                      return Err(syn::Error::new(key.span(), "`by:` value must be a `[col1, col2]` list"));
+                  };
+                  by_list = Some(l);
+              }
+              "where" => {
+                  let DslValue::Block(b) = value else {
+                      return Err(syn::Error::new(key.span(), "`where:` value must be a `{ ... }` block"));
+                  };
+                  where_block = Some(b);
+              }
+              "_count" | "_sum" | "_avg" | "_min" | "_max" => {
+                  let DslValue::Block(b) = value else {
+                      return Err(syn::Error::new(key.span(), format!("`{}` value must be a `{{ ... }}` block", key_str)));
+                  };
+                  match key_str.as_str() {
+                      "_count" => count_block = Some(b),
+                      "_sum" => sum_block = Some(b),
+                      "_avg" => avg_block = Some(b),
+                      "_min" => min_block = Some(b),
+                      "_max" => max_block = Some(b),
+                      _ => unreachable!(),
+                  }
+              }
+              "having" => {
+                  let DslValue::Block(b) = value else {
+                      return Err(syn::Error::new(key.span(), "`having:` value must be a `{ ... }` block"));
+                  };
+                  having_block = Some(b);
+              }
+              "order_by" => {
+                  // Deferred to follow-up; macro-time error.
+                  return Err(syn::Error::new(
+                      key.span(),
+                      "`order_by:` on group_by! is not yet implemented in phase 6 — track as follow-up",
+                  ));
+              }
+              other => return Err(syn::Error::new(
+                  key.span(),
+                  format!("unknown key `{}` in group_by!", other),
+              )),
+          }
+      }
+
+      let by_list = by_list.ok_or_else(|| syn::Error::new(
+          proc_macro2::Span::call_site(),
+          "group_by! requires a `by: [...]` list of columns",
+      ))?;
+      if by_list.items.is_empty() {
+          return Err(syn::Error::new(
+              proc_macro2::Span::call_site(),
+              "group_by! requires at least one column in `by:`",
+          ));
+      }
+
+      // Validate each by-column and build GroupByColumn variants.
+      let column_enum = format_ident!("{}GroupByColumn", ctx.model.name());
+      let module_ident = format_ident!("{}", ctx.model.name().to_case(Case::Snake));
+      let mut by_variants: Vec<TokenStream> = Vec::new();
+      for item in &by_list.items {
+          let DslValue::Ident(name) = item else {
+              return Err(syn::Error::new(
+                  proc_macro2::Span::call_site(),
+                  "`by:` items must be bare column identifiers",
+              ));
+          };
+          let col_str = name.to_string();
+          let field = ctx.model.get_field(&col_str).ok_or_else(|| {
+              let candidates: Vec<String> =
+                  ctx.model.fields.keys().map(|k| k.to_string()).collect();
+              let suggestion = crate::macros::validate::suggest(&col_str, &candidates);
+              let msg = match suggestion {
+                  Some(s) => format!(
+                      "unknown column `{}`; did you mean `{}`?", col_str, s
+                  ),
+                  None => format!("unknown column `{}`", col_str),
+              };
+              syn::Error::new(name.span(), msg)
+          })?;
+          if field.is_relation() {
+              return Err(syn::Error::new(
+                  name.span(),
+                  format!("by-column `{}` is a relation; group_by requires scalar columns", col_str),
+              ));
+          }
+          let variant = format_ident!("{}", to_pascal(&col_str));
+          by_variants.push(quote! { #module_ident::#column_enum::#variant });
+      }
+
+      let lower_opt = |k: AggKind, b: Option<&DslBlock>| -> syn::Result<TokenStream> {
+          match b {
+              Some(blk) => {
+                  let ts = lower_agg_select(k, blk, &ctx)?;
+                  Ok(quote! { ::core::option::Option::Some(#ts) })
+              }
+              None => Ok(quote! { ::core::option::Option::None }),
+          }
+      };
+      let count_ts = lower_opt(AggKind::Count, count_block)?;
+      let sum_ts = lower_opt(AggKind::Sum, sum_block)?;
+      let avg_ts = lower_opt(AggKind::Avg, avg_block)?;
+      let min_ts = lower_opt(AggKind::Min, min_block)?;
+      let max_ts = lower_opt(AggKind::Max, max_block)?;
+
+      let where_ts = match where_block {
+          Some(w) => {
+              let wts = where_input::lower_where_input(w, &ctx)?.where_input;
+              quote! { ::core::option::Option::Some(#wts) }
+          }
+          None => quote! { ::core::option::Option::None },
+      };
+
+      let having_ts = match having_block {
+          Some(h) => {
+              let conds = lower_having(h, &ctx)?;
+              let having_ty = format_ident!("{}GroupByHaving", ctx.model.name());
+              quote! {
+                  ::core::option::Option::Some(#module_ident::#having_ty { conditions: #conds })
+              }
+          }
+          None => quote! { ::core::option::Option::None },
+      };
+
+      let args_ident = format_ident!("{}GroupByArgs", ctx.model.name());
+      let accessor_expr = &call.accessor_expr;
+
+      Ok(quote! {
+          {
+              let __by: ::std::vec::Vec<#module_ident::#column_enum> = vec![#(#by_variants),*];
+              let __args: #module_ident::#args_ident = #module_ident::#args_ident {
+                  by: __by.clone(),
+                  where_input: #where_ts,
+                  _count: #count_ts,
+                  _sum: #sum_ts,
+                  _avg: #avg_ts,
+                  _min: #min_ts,
+                  _max: #max_ts,
+                  having: #having_ts,
+                  order_by: ::core::option::Option::None,
+              };
+              (#accessor_expr).group_by(__by).with_group_by_args(__args)
+          }
+      })
+  }
+
+  fn to_pascal(snake: &str) -> String {
+      let mut out = String::with_capacity(snake.len());
+      let mut upper = true;
+      for c in snake.chars() {
+          if c == '_' { upper = true; }
+          else if upper { out.push(c.to_ascii_uppercase()); upper = false; }
+          else { out.push(c); }
+      }
+      out
+  }
+  ```
+
+  Adjust `AccessorCall.accessor_expr` and `block` field names to match the actual struct (look at `prax-codegen/src/macros/accessor.rs`).
+
+- [ ] **Step 2:** Register proc-macro:
+
+  ```rust
+  #[proc_macro]
+  pub fn group_by(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+      crate::macros::ops::group_by::group_by_macro_impl(input)
+  }
+  ```
+
+- [ ] **Step 3:** Re-export from `prax-orm/src/lib.rs`.
+
+- [ ] **Step 4:** Workspace build:
+
+  ```bash
+  cargo build --workspace --all-features
+  ```
+
+- [ ] **Step 5: Commit**
+
+  ```
+  feat(codegen): group_by! macro entry point (phase 6)
+  ```
+
+---
+
+## Task 11: trybuild diagnostic fixtures
+
+**Files:**
+- Create fixtures under `prax-codegen/tests/ui/aggregate/`:
+  - `aggregate_no_blocks_fail.rs` + `.stderr`
+  - `aggregate_sum_on_string_fail.rs` + `.stderr`
+  - `aggregate_unknown_column_fail.rs` + `.stderr`
+  - `aggregate_relation_field_fail.rs` + `.stderr`
+  - `aggregate_select_value_not_true_fail.rs` + `.stderr`
+- Create fixtures under `prax-codegen/tests/ui/group_by/`:
+  - `group_by_empty_by_fail.rs` + `.stderr`
+  - `group_by_unknown_by_column_fail.rs` + `.stderr`
+  - `group_by_having_bad_operator_fail.rs` + `.stderr`
+- Create `count_select_with_value_5_fail.rs` + `.stderr` (in existing `tests/ui/computed_fields/` or new `tests/ui/count/` dir)
+- Modify the trybuild harness file (e.g., `tests/ui.rs`) to register the new directories
+
+- [ ] **Step 1:** Create each fixture. Each is a complete `.rs` file that uses derive-style models (since the macro DSL targets schema-defined models — derive-style works for trybuild because the model is in the same crate as the fixture).
+
+- [ ] **Step 2:** Run `TRYBUILD=overwrite cargo test -p prax-codegen --test ui` to materialise `.stderr` baselines. Inspect each baseline matches the expected diagnostic. Fix the macro emission if any baseline says something wrong (wrong span, wrong message).
+
+- [ ] **Step 3:** Run `cargo test -p prax-codegen --test ui` without `TRYBUILD=overwrite` to verify all fixtures match the locked baselines.
+
+- [ ] **Step 4: Commit**
+
+  ```
+  test(codegen): trybuild fixtures for aggregate! / group_by! / count! select diagnostics
+  ```
+
+---
+
+## Task 12: e2e RecordingEngine tests
+
+**Files:**
+- Create: `tests/aggregate_macros_e2e.rs`
+
+- [ ] **Step 1:** Mirror the structure of `tests/nested_writes_e2e.rs` (or `tests/computed_fields_e2e.rs` from phase 5.5). Copy the `RecordingEngine` boilerplate; add `impl SupportsScalarSubqueryInSelect` if relevant (probably not — aggregate queries don't use scalar projections).
+
+- [ ] **Step 2:** Derive models suitable for the tests:
+
+  ```rust
+  #[derive(prax_orm::Model, Debug, Clone, Default)]
+  #[prax(table = "users")]
+  pub struct User {
+      #[prax(id, auto)]
+      pub id: i32,
+      pub team_id: i32,
+      pub region: String,
+      pub active: bool,
+      pub views: i32,
+      pub score: i32,
+      pub created_at: i64,  // simplified — real DateTime in live tests
+  }
+
+  client!(User);
+  ```
+
+- [ ] **Step 3:** Tests (each ~25 lines):
+
+  - `count_with_select_emits_per_column_counts` — assert SQL contains
+    `COUNT(*) AS "_all"`, `COUNT("email") AS "email"` (use a User with email).
+  - `aggregate_emits_sum_avg_min_max_count` — single call with all five
+    blocks; assert all five aggregate functions appear in SELECT.
+  - `aggregate_where_filters_the_aggregate` — assert WHERE clause is
+    emitted on the underlying SELECT.
+  - `group_by_emits_by_columns_and_group_by_clause` — assert
+    `GROUP BY "team_id", "region"` in SQL.
+  - `group_by_having_emits_having_clause` — assert
+    `HAVING COUNT(*) > $1` and params include the threshold.
+  - `aggregate_omits_unspecified_blocks` — call with only `_sum: { views: true }`;
+    assert no `AVG`, `MIN`, `MAX`, `COUNT` appear in SQL.
+
+- [ ] **Step 4:** Run `cargo test --test aggregate_macros_e2e` — all green.
+
+- [ ] **Step 5: Commit**
+
+  ```
+  test(query): e2e RecordingEngine coverage for aggregate macros
+  ```
+
+---
+
+## Task 13: Live Postgres integration test (`--ignored`)
+
+**Files:**
+- Create: `prax-postgres/tests/aggregate_macros.rs`
+
+- [ ] **Step 1:** Mirror `prax-postgres/tests/computed_fields.rs` shape. Use the same `PRAX_E2E=1 + POSTGRES_URL` gating, `unique_table()` helper, `pool()` / `drop_table()` harness.
+
+- [ ] **Step 2:** Tests:
+
+  ```rust
+  #[tokio::test]
+  #[ignore = "requires postgres container or DATABASE_URL"]
+  async fn count_select_round_trip() {
+      // CREATE TABLE; INSERT 5 rows where 2 have NULL email;
+      // run prax::count!(c.user, { select: { _all: true, email: true } });
+      // assert _all == 5 and email == 3.
+  }
+
+  #[tokio::test]
+  #[ignore = "requires postgres container or DATABASE_URL"]
+  async fn aggregate_sum_avg_count_round_trip() {
+      // CREATE TABLE users (id, score INT);
+      // INSERT scores 10, 20, 30;
+      // run prax::aggregate!(c.user, {
+      //     _sum: { score: true }, _avg: { score: true }, _count: { _all: true }
+      // });
+      // assert _sum.score == 60, _avg.score == 20.0, _count._all == 3.
+  }
+
+  #[tokio::test]
+  #[ignore = "requires postgres container or DATABASE_URL"]
+  async fn group_by_with_having_round_trip() {
+      // CREATE TABLE users (team_id INT, score INT);
+      // INSERT mix where team A has 2 rows, team B has 4 rows;
+      // run prax::group_by!(c.user, {
+      //     by: [team_id], _count: { _all: true },
+      //     having: { _count: { _all: { gt: 3 } } }
+      // });
+      // assert single returned row, team_id == B, _count._all == 4.
+  }
+  ```
+
+- [ ] **Step 3:** Compile cleanly. `cargo test -p prax-postgres --test aggregate_macros` (no `--ignored`) should pass with all tests skipped.
+
+- [ ] **Step 4: Commit**
+
+  ```
+  test(postgres): live integration for aggregate macros (phase 6)
+  ```
+
+---
+
+## Task 14: CHANGELOG + workspace sweep
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1:** Add under `[Unreleased] > Added`:
+
+  ```
+  - **Aggregate macros (phase 6).** Three new macros sitting on top of
+    the existing `AggregateOperation` / `GroupByOperation` runtime:
+    - `count!` `select:` block — Prisma-style per-column non-null
+      counts. Returns `<Model>CountSelectResult { _all: i64, <col>: i64,
+      ... }`. Without `select:`, behavior is unchanged (returns
+      `i64`).
+    - `aggregate!` — new macro returning a per-model
+      `<Model>AggregateResult` with `_sum`, `_avg`, `_min`, `_max`,
+      `_count` substructs populated only when their `_<agg>:` block
+      is supplied.
+    - `group_by!` — new macro with `by:`, `where:`, `having:`, and
+      the same aggregate substructs. Returns
+      `Vec<<Model>GroupByResult>`. `order_by:` deferred to a
+      follow-up.
+  - Per-model codegen surface: `<Model>{Count,Sum,Avg,Min,Max}Select`,
+    matching `*Result`, `<Model>AggregateResult`, `<Model>GroupByResult`,
+    `<Model>GroupByColumn` enum, `<Model>AggregateArgs`,
+    `<Model>GroupByArgs`.
+  - Diagnostics: `_sum` / `_avg` on non-numeric column, aggregate on
+    relation, unknown by-column with did-you-mean, empty `by:`, empty
+    aggregate-block in `aggregate!`, unsupported having operator.
+
+  ### Known limitations
+  - The aggregate macros target schema-defined and derive-style models
+    that the engine implements `AggregateOperation` /
+    `GroupByOperation` for. MongoDB and CQL engines are excluded;
+    `$group` and partition-key GROUP BY lowering are separate
+    follow-ups.
+  - `count_distinct` is in the runtime but not yet exposed via the
+    macro shape; use the runtime API for now.
+  - `_min`/`_max` against multiple columns at once is not supported in
+    a single call.
+  - `group_by!` `order_by:` is rejected at macro expansion with a
+    follow-up tracking message.
+  ```
+
+- [ ] **Step 2:** Full sweep:
+
+  ```bash
+  cd /home/joseph/Projects/prax/.worktrees/aggregate-macros
+  cargo fmt --all -- --check
+  cargo clippy --workspace --all-targets --all-features -- -D warnings
+  cargo test --workspace --all-features --no-fail-fast
+  ```
+
+- [ ] **Step 3: Commit**
+
+  ```
+  docs(query): CHANGELOG for phase 6 aggregate macros
+  ```
+
+---
+
+## Task 15: Push + PR (manual)
+
+- [ ] `git push -u origin feature/aggregate-macros`
+- [ ] `gh pr create --base develop --title "feat: aggregate macros (phase 6)"`
+- [ ] `gh pr merge <PR#> --squash --auto`
+
+PR body sketch:
+
+```
+Closes phase 6 of the typed-query-traits initiative.
+
+## What ships
+- count!(...) with select: { _all, <col>, ... } per-column counts
+- aggregate!(...) with _sum / _avg / _min / _max / _count
+- group_by!(...) with by, where, having, aggregate blocks
+
+## Deferred follow-ups
+- MongoDB $group lowering
+- CQL GROUP BY
+- count_distinct macro shape
+- multi-column _min/_max in one call
+- group_by! order_by:
+- include: { _count } form
+
+## Test plan
+- prax-codegen unit + UI tests
+- e2e tests/aggregate_macros_e2e.rs
+- prax-postgres/tests/aggregate_macros.rs (--ignored)
+```
+
+---
+
+## Out of scope (deferred follow-ups, listed in spec §12)
+
+- MongoDB `$group` pipeline lowering
+- CQL `GROUP BY` (partition-key prefix only)
+- `count_distinct` shape on `_count`
+- Multi-column `_min`/`_max` in one call
+- Window-function aggregates, percentiles
+- `having:` support for non-aggregate fields
+- `include: { _count }` form (analogue of the phase 5.5 deferral)
+- `group_by!` `order_by:` (currently rejected at macro time)

--- a/docs/superpowers/specs/2026-05-23-aggregate-macros-design.md
+++ b/docs/superpowers/specs/2026-05-23-aggregate-macros-design.md
@@ -1,0 +1,413 @@
+# Aggregate Macros — Phase 6 Design
+
+> Companion to `2026-05-18-typed-query-traits-design.md` §8 phase 6.
+> Single PR covering `count!` `select:` extension, `aggregate!`, and
+> `group_by!`.
+
+## 1. Goals
+
+- Ship the three Prisma-style aggregate macros on top of the existing
+  `AggregateOperation` and `GroupByOperation` runtime builders in
+  `prax-query/src/operations/aggregate.rs`:
+  - **`count!` `select:` block** (extends the phase-3 `count!` which is
+    `where:`-only) — Prisma-style per-column non-null counts.
+  - **`aggregate!`** — new macro returning sum/avg/min/max/count
+    scalars.
+  - **`group_by!`** — new macro with `by:`, `having:`, `order_by:`.
+- All three target the five SQL engines that already implement
+  `AggregateOperation`/`GroupByOperation` (Postgres, MySQL, SQLite,
+  MSSQL, DuckDB).
+- Single PR matches the spec's "2-3 day" framing and the phase 5.5
+  precedent.
+
+## 2. Non-goals
+
+- MongoDB `$group` pipeline lowering — separate follow-up.
+- CQL `GROUP BY` (limited to partition-key prefixes; needs a separate
+  spec).
+- `_min`/`_max` against multiple columns in one builder call (Prisma
+  supports this; we ship one column per call for now).
+- Window-function aggregates, percentiles, cumulative counts.
+- `DISTINCT` variants on `_count` (the runtime already supports
+  `count_distinct`; macro DSL for it is a follow-up).
+
+## 3. Macro surface
+
+### 3.1 `count!` with `select:`
+
+Without `select:`, behavior is unchanged from phase 3 — returns plain
+`i64`:
+
+```rust
+let n: i64 = prax::count!(c.user, { where: { active: true } })
+    .exec()
+    .await?;
+```
+
+With `select:`, returns a per-model `<Model>CountSelectResult`:
+
+```rust
+let counts: UserCountSelectResult = prax::count!(c.user, {
+    where: { active: true },
+    select: { _all: true, email: true, deleted_at: true },
+})
+.exec()
+.await?;
+// counts._all          -> i64  (COUNT(*))
+// counts.email         -> i64  (COUNT("email") — null-skipping)
+// counts.deleted_at    -> i64  (COUNT("deleted_at"))
+```
+
+Lowered SQL on Postgres:
+```sql
+SELECT
+    COUNT(*) AS "_all",
+    COUNT("email") AS "email",
+    COUNT("deleted_at") AS "deleted_at"
+FROM "users" WHERE "active" = $1
+```
+
+### 3.2 `aggregate!`
+
+```rust
+let agg: UserAggregateResult = prax::aggregate!(c.user, {
+    where: { active: true },
+    _sum: { views: true, score: true },
+    _avg: { score: true },
+    _min: { created_at: true },
+    _max: { created_at: true },
+    _count: { _all: true, email: true },
+})
+.exec()
+.await?;
+
+// agg._sum.views       -> Option<i64>
+// agg._sum.score       -> Option<i64>
+// agg._avg.score       -> Option<f64>
+// agg._min.created_at  -> Option<DateTime<Utc>>
+// agg._max.created_at  -> Option<DateTime<Utc>>
+// agg._count._all      -> i64
+// agg._count.email     -> i64
+```
+
+Empty `_<agg>` blocks are skipped. The result struct shape is fixed per
+model (all five substructs exist as `Option<<Model><Agg>Result>` fields,
+populated `Some(_)` only when that agg block appeared in the call).
+
+Aggregate macros require at least one of `_count`, `_sum`, `_avg`,
+`_min`, `_max` — otherwise the macro errors with
+"aggregate! requires at least one of _count, _sum, _avg, _min, _max".
+
+### 3.3 `group_by!`
+
+```rust
+let rows: Vec<UserGroupByResult> = prax::group_by!(c.user, {
+    by: [team_id, region],
+    where: { active: true },
+    _sum: { views: true },
+    _count: { _all: true },
+    having: { _count: { _all: { gt: 5 } } },
+    order_by: { _sum: { views: desc } },
+})
+.exec()
+.await?;
+```
+
+Each row contains:
+- The group-by columns as scalar fields (`team_id: i32`, `region: String`)
+- The aggregate substructs (`_sum`, `_count`, etc.) populated according
+  to the call
+
+Lowered SQL on Postgres:
+```sql
+SELECT "team_id", "region",
+       SUM("views") AS "_sum_views",
+       COUNT(*) AS "_count__all"
+FROM "users"
+WHERE "active" = $1
+GROUP BY "team_id", "region"
+HAVING COUNT(*) > $2
+ORDER BY SUM("views") DESC
+```
+
+`by: []` is rejected at macro expansion with "group_by! requires at
+least one column in by:".
+
+`having:` operators support: `equals`, `not_equals`, `lt`, `lte`, `gt`,
+`gte`, `in`, `not_in`. Same as the aggregate-filter operators from
+phase 5.5.
+
+## 4. Codegen — per-model emit
+
+For every model the codegen emits the following types in the model's
+`inputs` module:
+
+### 4.1 Select-shape inputs
+
+```rust
+#[derive(Debug, Default, Clone)]
+pub struct UserCountSelect {
+    pub _all: Option<bool>,
+    pub id: Option<bool>,
+    pub email: Option<bool>,
+    pub deleted_at: Option<bool>,
+    // one Option<bool> per scalar column (no relations, no aggregates,
+    // no @generated columns are excluded from the count-select shape
+    // since COUNT(<column>) is meaningful for any scalar including
+    // @generated)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct UserSumSelect {
+    pub views: Option<bool>,
+    pub score: Option<bool>,
+    // one Option<bool> per *numeric* scalar column only
+}
+
+pub struct UserAvgSelect { /* same shape as UserSumSelect (numeric) */ }
+
+#[derive(Debug, Default, Clone)]
+pub struct UserMinSelect {
+    pub id: Option<bool>,
+    pub email: Option<bool>,
+    pub views: Option<bool>,
+    pub created_at: Option<bool>,
+    // one Option<bool> per *sortable* scalar column (excludes JSON,
+    // bytes, vector types)
+}
+
+pub struct UserMaxSelect { /* same shape as UserMinSelect */ }
+```
+
+### 4.2 Result-shape outputs
+
+```rust
+#[derive(Debug, Clone)]
+pub struct UserCountSelectResult {
+    pub _all: i64,
+    pub id: i64,
+    pub email: i64,
+    pub deleted_at: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct UserSumResult {
+    pub views: Option<i64>,
+    pub score: Option<i64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct UserAvgResult {
+    pub views: Option<f64>,
+    pub score: Option<f64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct UserMinResult {
+    pub id: Option<i32>,
+    pub email: Option<String>,
+    pub views: Option<i32>,
+    pub created_at: Option<DateTime<Utc>>,
+}
+
+pub struct UserMaxResult { /* same shape as UserMinResult */ }
+
+#[derive(Debug, Default, Clone)]
+pub struct UserAggregateResult {
+    pub _sum:   Option<UserSumResult>,
+    pub _avg:   Option<UserAvgResult>,
+    pub _min:   Option<UserMinResult>,
+    pub _max:   Option<UserMaxResult>,
+    pub _count: Option<UserCountSelectResult>,
+}
+
+#[derive(Debug, Clone)]
+pub struct UserGroupByResult {
+    pub team_id: i32,
+    pub region: String,
+    // ... one field per group-by column in the call
+    pub _sum:   Option<UserSumResult>,
+    pub _avg:   Option<UserAvgResult>,
+    pub _min:   Option<UserMinResult>,
+    pub _max:   Option<UserMaxResult>,
+    pub _count: Option<UserCountSelectResult>,
+}
+```
+
+`UserGroupByResult` is emitted **once per model** with a stable
+superset shape: every scalar column of the model appears as an
+`Option<T>` field, plus the five aggregate substructs. Only the
+columns named in the call's `by:` list are populated; the rest stay
+`None`. Codegen can't synthesize a per-call type without an extra
+macro-emitted module, and a stable per-model type keeps user code
+type-friendly (no fresh result struct per call site). Users who want
+a tighter type can `Into::into` their own struct.
+
+### 4.3 Args structs
+
+```rust
+#[derive(Debug, Default, Clone)]
+pub struct UserAggregateArgs {
+    pub where_input: Option<UserWhereInput>,
+    pub _sum:   Option<UserSumSelect>,
+    pub _avg:   Option<UserAvgSelect>,
+    pub _min:   Option<UserMinSelect>,
+    pub _max:   Option<UserMaxSelect>,
+    pub _count: Option<UserCountSelect>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct UserGroupByArgs {
+    pub by:           Vec<UserGroupByColumn>,  // strongly-typed column enum
+    pub where_input:  Option<UserWhereInput>,
+    pub _sum:         Option<UserSumSelect>,
+    pub _avg:         Option<UserAvgSelect>,
+    pub _min:         Option<UserMinSelect>,
+    pub _max:         Option<UserMaxSelect>,
+    pub _count:       Option<UserCountSelect>,
+    pub having:       Option<UserGroupByHaving>,
+    pub order_by:     Option<UserGroupByOrderBy>,
+}
+```
+
+`UserGroupByColumn` is a per-model enum naming the model's scalar
+columns (lets `by:` resolve column references at compile time without
+string-typing).
+
+## 5. Macro entry points (`prax-codegen/src/macros/ops/`)
+
+New files:
+- `aggregate.rs` — entry point for `aggregate!`, parses the brace-block
+  DSL and lowers to `AggregateOperation` builder calls via a generated
+  `with_aggregate_args(args: <Model>AggregateArgs)` extension on
+  `ModelAccessor`.
+- `group_by.rs` — entry point for `group_by!`, parses DSL with the
+  additional `by:`, `having:`, `order_by:` keys; lowers to
+  `GroupByOperation`.
+
+Extended file:
+- `count.rs` — replace the existing
+  `"select: on count! is a phase-6 feature"` rejection with the
+  Prisma-compatible `select:` parser. When `select:` is present, build
+  a `<Model>CountSelect` value, switch the operation to
+  `AggregateOperation::count_columns(...)`, and return the new
+  `<Model>CountSelectResult`.
+
+## 6. Lowering helpers (`prax-codegen/src/macros/lower/`)
+
+New helpers:
+- `aggregate_select.rs` — parses each `_<agg>: { col: true, ... }`
+  brace block into the corresponding `<Model><Agg>Select` struct
+  initialization. Shared between `count!`, `aggregate!`, and
+  `group_by!`.
+- `having.rs` — parses `having: { _count: { _all: { gt: 5 } } }` into
+  a sequence of `HavingCondition` calls. Operator set: `equals`,
+  `not_equals`, `lt`, `lte`, `gt`, `gte`, `in`, `not_in` (same as
+  phase 5.5 aggregate filters).
+
+## 7. Runtime wiring
+
+No new runtime types needed. Use the existing
+`AggregateOperation` / `GroupByOperation` (in
+`prax-query/src/operations/aggregate.rs`) plus two new extension
+methods generated by codegen:
+
+```rust
+impl<E: QueryEngine> ModelAccessor<E, User> {
+    pub fn aggregate(&self) -> AggregateOperation<User, E> { ... }
+    pub fn group_by(&self, by: Vec<UserGroupByColumn>) -> GroupByOperation<User, E> { ... }
+}
+
+impl<E: QueryEngine> AggregateOperation<User, E> {
+    pub fn with_aggregate_args(mut self, args: UserAggregateArgs) -> Self {
+        if let Some(w) = args.where_input { self = self.with_where_input(w); }
+        if let Some(s) = args._sum {
+            for col in s.fields_set() { self = self.sum(col); }
+        }
+        // ... etc for _avg / _min / _max / _count ...
+        self
+    }
+}
+
+impl<E: QueryEngine> GroupByOperation<User, E> {
+    pub fn with_group_by_args(mut self, args: UserGroupByArgs) -> Self {
+        // Similar: apply where_input, agg blocks, having, order_by.
+        self
+    }
+}
+```
+
+The `fields_set()` helper on each `<Model><Agg>Select` struct walks
+its fields and returns the list of column names whose `Option<bool>`
+is `Some(true)`.
+
+## 8. Capability gating
+
+No new marker trait. The macros emit `AggregateOperation`/`GroupByOperation`
+calls, which already require `QueryEngine` and which engines vary in
+support for natively. The existing engine impls cover PG, MySQL, SQLite,
+MSSQL, DuckDB. MongoDB and CQL engines that don't impl these operations
+fail to compile via the existing trait-bound diagnostics, same way phase
+5 nested writes are gated.
+
+If we want a clearer error message, add `SupportsAggregateMacros` (impl'd
+by the same five SQL engines) and gate `aggregate()` / `group_by()` on
+it. **Decision**: skip the new marker — the existing missing-`exec()`
+error is acceptable and we don't want capability-trait proliferation
+(risk listed at phase-1 spec §12).
+
+## 9. Diagnostics
+
+All emitted via `syn::Error::new(span, msg)` at macro expansion. Use
+the existing `strsim::jaro_winkler` did-you-mean machinery where
+applicable.
+
+| Trigger | Message |
+|---------|---------|
+| `_sum` / `_avg` on non-numeric column | `field \`email\` is not numeric; \`_sum\` requires a numeric column` |
+| Aggregate on relation field | `field \`posts\` is a relation; aggregates require a scalar column` |
+| Aggregate on `@generated` column | OK (treated like normal scalar — they're real columns) |
+| Aggregate on aggregate field (e.g. `_sum` of `post_count`) | `field \`post_count\` is itself an aggregate; cannot aggregate an aggregate` |
+| `by: [unknown_col]` | `unknown column \`foo\`; did you mean \`team_id\`?` |
+| `by: []` | `group_by! requires at least one column in \`by:\`` |
+| `having: { _count: { _all: { unknown_op: ... } } }` | `unsupported operator \`like\`; use one of equals/not_equals/lt/lte/gt/gte/in/not_in` |
+| `having:` referencing field not in any agg block | `field \`views\` is not in any aggregate block; cannot \`having\` on it` |
+| Empty all `_<agg>` blocks in `aggregate!` | `aggregate! requires at least one of _count, _sum, _avg, _min, _max` |
+| Empty `_<agg>: {}` block | `\`_sum\` block is empty; specify at least one column or remove the block` |
+| Unknown column in any `_<agg>: { col: true }` | `unknown column \`foo\` on model \`User\`; did you mean \`fop\`?` |
+| `select:` on `count!` with non-`bool` value | `select on count! must be \`{ col: true }\`; got \`{ col: 5 }\`` |
+
+## 10. Testing strategy
+
+| Layer | Location | What it catches |
+|-------|----------|----------------|
+| Lowering unit tests | `prax-codegen/src/macros/lower/aggregate_select.rs::tests`, `having.rs::tests` | DSL → token-stream correctness; helper output stability |
+| Macro UI tests | `prax-codegen/tests/ui/aggregate_*.rs`, `group_by_*.rs`, `count_select_*.rs` | trybuild fixtures for the 11 diagnostics in §9 |
+| Runtime SQL emit | `prax-query/src/operations/aggregate.rs::tests` | `with_aggregate_args` / `with_group_by_args` build the right SQL |
+| e2e | `tests/aggregate_macros_e2e.rs` (new) | RecordingEngine assertions on full macro call sites |
+| Live PG | `prax-postgres/tests/aggregate_macros.rs` (new, `#[ignore]`-gated) | round-trip against real Postgres |
+
+The e2e file uses the same `RecordingEngine` + `DialectKind` pattern
+established in `tests/nested_writes_e2e.rs` and
+`tests/computed_fields_e2e.rs`.
+
+## 11. Compatibility
+
+- `count!` `select:` is additive — existing `count!` calls without
+  `select:` continue to return `i64`.
+- `aggregate!` and `group_by!` are new macros; no existing call sites.
+- New per-model types live in the model's `inputs` module; additive.
+- `AggregateOperation` / `GroupByOperation` runtime types unchanged
+  (we only add extension methods).
+
+## 12. Open follow-ups (deferred)
+
+- MongoDB `$group` pipeline lowering.
+- CQL `GROUP BY` (partition-key prefix only).
+- `count_distinct` variant on `_count` shape (runtime already
+  supports it).
+- `_min`/`_max` against multiple columns at once.
+- Window-function aggregates, percentiles.
+- `having:` support for arbitrary scalar fields (not just aggregates).
+- `include:` form for aggregates (analogous to `include: { _count }`
+  which we already deferred from phase 5.5).

--- a/prax-codegen/src/generators/aggregate.rs
+++ b/prax-codegen/src/generators/aggregate.rs
@@ -337,6 +337,243 @@ pub fn emit_args_and_columns_enum(
     }
 }
 
+/// Emit `fields_set()` / `all_set()` helpers on the select-shape inputs,
+/// a typed `group_by_columns(Vec<ModelGroupByColumn>)` method on `Client<E>`,
+/// and the `with_aggregate_args` / `with_group_by_args` extension impls on
+/// `AggregateOperation` / `GroupByOperation`.
+///
+/// These are spliced into the per-model `pub mod` (same scope as the structs
+/// emitted by `emit_select_inputs` / `emit_args_and_columns_enum`), so
+/// references to the model use `super::#model_ident`.
+///
+/// `where_input_impl_exists` must be true only when a `WhereInput` impl was
+/// actually emitted for this model (i.e. the model struct is `pub`). When
+/// false, the `where_input` branch is compiled out of the extension impls.
+#[allow(dead_code)]
+pub fn emit_accessors_and_extensions(
+    model_ident: &syn::Ident,
+    scalars: &[ScalarFieldMeta<'_>],
+    where_input_impl_exists: bool,
+) -> TokenStream {
+    let agg_args = format_ident!("{}AggregateArgs", model_ident);
+    let gb_args = format_ident!("{}GroupByArgs", model_ident);
+    let count_select = format_ident!("{}CountSelect", model_ident);
+    let sum_select = format_ident!("{}SumSelect", model_ident);
+    let avg_select = format_ident!("{}AvgSelect", model_ident);
+    let min_select = format_ident!("{}MinSelect", model_ident);
+    let max_select = format_ident!("{}MaxSelect", model_ident);
+    let columns_enum = format_ident!("{}GroupByColumn", model_ident);
+
+    let count_set_arms: Vec<TokenStream> = scalars
+        .iter()
+        .map(|f| {
+            let ident = f.ident;
+            let col = f.column_name;
+            quote! {
+                if matches!(self.#ident, ::core::option::Option::Some(true)) {
+                    out.push(#col);
+                }
+            }
+        })
+        .collect();
+
+    let numeric_set_arms: Vec<TokenStream> = scalars
+        .iter()
+        .filter(|f| f.is_numeric)
+        .map(|f| {
+            let ident = f.ident;
+            let col = f.column_name;
+            quote! {
+                if matches!(self.#ident, ::core::option::Option::Some(true)) {
+                    out.push(#col);
+                }
+            }
+        })
+        .collect();
+
+    let sortable_set_arms: Vec<TokenStream> = scalars
+        .iter()
+        .filter(|f| f.is_sortable)
+        .map(|f| {
+            let ident = f.ident;
+            let col = f.column_name;
+            quote! {
+                if matches!(self.#ident, ::core::option::Option::Some(true)) {
+                    out.push(#col);
+                }
+            }
+        })
+        .collect();
+
+    let numeric_set_arms2 = numeric_set_arms.clone();
+    let sortable_set_arms2 = sortable_set_arms.clone();
+
+    let agg_where_branch = if where_input_impl_exists {
+        quote! {
+            if let ::core::option::Option::Some(w) = args.where_input {
+                self = self.r#where(<_ as ::prax_query::inputs::WhereInput>::into_ir(w));
+            }
+        }
+    } else {
+        quote! { let _ = args.where_input; }
+    };
+
+    let gb_where_branch = if where_input_impl_exists {
+        quote! {
+            if let ::core::option::Option::Some(w) = args.where_input {
+                self = self.r#where(
+                    <_ as ::prax_query::inputs::WhereInput>::into_ir(w),
+                );
+            }
+        }
+    } else {
+        quote! { let _ = args.where_input; }
+    };
+
+    quote! {
+        impl #count_select {
+            pub fn fields_set(&self) -> ::std::vec::Vec<&'static str> {
+                let mut out = ::std::vec::Vec::new();
+                #(#count_set_arms)*
+                out
+            }
+            pub fn all_set(&self) -> bool {
+                matches!(self._all, ::core::option::Option::Some(true))
+            }
+        }
+
+        impl #sum_select {
+            pub fn fields_set(&self) -> ::std::vec::Vec<&'static str> {
+                let mut out = ::std::vec::Vec::new();
+                #(#numeric_set_arms)*
+                out
+            }
+        }
+
+        impl #avg_select {
+            pub fn fields_set(&self) -> ::std::vec::Vec<&'static str> {
+                let mut out = ::std::vec::Vec::new();
+                #(#numeric_set_arms2)*
+                out
+            }
+        }
+
+        impl #min_select {
+            pub fn fields_set(&self) -> ::std::vec::Vec<&'static str> {
+                let mut out = ::std::vec::Vec::new();
+                #(#sortable_set_arms)*
+                out
+            }
+        }
+
+        impl #max_select {
+            pub fn fields_set(&self) -> ::std::vec::Vec<&'static str> {
+                let mut out = ::std::vec::Vec::new();
+                #(#sortable_set_arms2)*
+                out
+            }
+        }
+
+        impl<E: ::prax_query::traits::QueryEngine + ::core::clone::Clone> Client<E> {
+            pub fn group_by_columns(
+                &self,
+                by: ::std::vec::Vec<#columns_enum>,
+            ) -> ::prax_query::operations::GroupByOperation<super::#model_ident, E> {
+                let cols: ::std::vec::Vec<::std::string::String> =
+                    by.iter().map(|c| c.column_name().to_string()).collect();
+                ::prax_query::operations::GroupByOperation::with_engine(self.engine.clone(), cols)
+            }
+        }
+
+        pub trait AggregateOperationExt<E> {
+            fn with_aggregate_args(self, args: #agg_args) -> Self;
+        }
+
+        impl<E: ::prax_query::traits::QueryEngine + ::core::clone::Clone>
+            AggregateOperationExt<E>
+            for ::prax_query::operations::AggregateOperation<super::#model_ident, E>
+        {
+            fn with_aggregate_args(mut self, args: #agg_args) -> Self {
+                #agg_where_branch
+                if let ::core::option::Option::Some(c) = args._count {
+                    if c.all_set() {
+                        self = self.count();
+                    }
+                    for col in c.fields_set() {
+                        self = self.count_column(col);
+                    }
+                }
+                if let ::core::option::Option::Some(s) = args._sum {
+                    for col in s.fields_set() {
+                        self = self.sum(col);
+                    }
+                }
+                if let ::core::option::Option::Some(a) = args._avg {
+                    for col in a.fields_set() {
+                        self = self.avg(col);
+                    }
+                }
+                if let ::core::option::Option::Some(m) = args._min {
+                    for col in m.fields_set() {
+                        self = self.min(col);
+                    }
+                }
+                if let ::core::option::Option::Some(m) = args._max {
+                    for col in m.fields_set() {
+                        self = self.max(col);
+                    }
+                }
+                self
+            }
+        }
+
+        pub trait GroupByOperationExt<E> {
+            fn with_group_by_args(self, args: #gb_args) -> Self;
+        }
+
+        impl<E: ::prax_query::traits::QueryEngine + ::core::clone::Clone>
+            GroupByOperationExt<E>
+            for ::prax_query::operations::GroupByOperation<super::#model_ident, E>
+        {
+            fn with_group_by_args(mut self, args: #gb_args) -> Self {
+                #gb_where_branch
+                if let ::core::option::Option::Some(c) = args._count {
+                    if c.all_set() || !c.fields_set().is_empty() {
+                        self = self.count();
+                    }
+                }
+                if let ::core::option::Option::Some(s) = args._sum {
+                    for col in s.fields_set() {
+                        self = self.sum(col);
+                    }
+                }
+                if let ::core::option::Option::Some(a) = args._avg {
+                    for col in a.fields_set() {
+                        self = self.avg(col);
+                    }
+                }
+                if let ::core::option::Option::Some(m) = args._min {
+                    for col in m.fields_set() {
+                        self = self.min(col);
+                    }
+                }
+                if let ::core::option::Option::Some(m) = args._max {
+                    for col in m.fields_set() {
+                        self = self.max(col);
+                    }
+                }
+                if let ::core::option::Option::Some(h) = args.having {
+                    for cond in h.conditions {
+                        self = self.having(cond);
+                    }
+                }
+                let _ = args.order_by;
+                self
+            }
+        }
+    }
+}
+
 fn to_pascal_case(snake: &str) -> String {
     let mut out = String::with_capacity(snake.len());
     let mut upper = true;

--- a/prax-codegen/src/generators/aggregate.rs
+++ b/prax-codegen/src/generators/aggregate.rs
@@ -261,6 +261,98 @@ pub fn emit_result_structs(
     }
 }
 
+pub fn emit_args_and_columns_enum(
+    model_ident: &syn::Ident,
+    scalars: &[ScalarFieldMeta<'_>],
+) -> TokenStream {
+    let columns_enum = format_ident!("{}GroupByColumn", model_ident);
+    let args_agg = format_ident!("{}AggregateArgs", model_ident);
+    let args_gb = format_ident!("{}GroupByArgs", model_ident);
+    let where_input = format_ident!("{}WhereInput", model_ident);
+    let count_select = format_ident!("{}CountSelect", model_ident);
+    let sum_select = format_ident!("{}SumSelect", model_ident);
+    let avg_select = format_ident!("{}AvgSelect", model_ident);
+    let min_select = format_ident!("{}MinSelect", model_ident);
+    let max_select = format_ident!("{}MaxSelect", model_ident);
+    let having_ty = format_ident!("{}GroupByHaving", model_ident);
+    let order_by_ty = format_ident!("{}GroupByOrderBy", model_ident);
+
+    let variants = scalars.iter().map(|f| {
+        let v = format_ident!("{}", to_pascal_case(&f.ident.to_string()));
+        quote! { #v }
+    });
+    let column_arms = scalars.iter().map(|f| {
+        let v = format_ident!("{}", to_pascal_case(&f.ident.to_string()));
+        let col = f.column_name;
+        quote! { Self::#v => #col }
+    });
+
+    quote! {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub enum #columns_enum {
+            #(#variants,)*
+        }
+
+        impl #columns_enum {
+            pub fn column_name(&self) -> &'static str {
+                match self {
+                    #(#column_arms,)*
+                }
+            }
+        }
+
+        #[derive(Debug, Default, Clone)]
+        pub struct #args_agg {
+            pub where_input: ::core::option::Option<#where_input>,
+            pub _sum:   ::core::option::Option<#sum_select>,
+            pub _avg:   ::core::option::Option<#avg_select>,
+            pub _min:   ::core::option::Option<#min_select>,
+            pub _max:   ::core::option::Option<#max_select>,
+            pub _count: ::core::option::Option<#count_select>,
+        }
+
+        #[derive(Debug, Default, Clone)]
+        pub struct #args_gb {
+            pub by:           ::std::vec::Vec<#columns_enum>,
+            pub where_input:  ::core::option::Option<#where_input>,
+            pub _sum:         ::core::option::Option<#sum_select>,
+            pub _avg:         ::core::option::Option<#avg_select>,
+            pub _min:         ::core::option::Option<#min_select>,
+            pub _max:         ::core::option::Option<#max_select>,
+            pub _count:       ::core::option::Option<#count_select>,
+            pub having:       ::core::option::Option<#having_ty>,
+            pub order_by:     ::core::option::Option<#order_by_ty>,
+        }
+
+        #[derive(Debug, Default, Clone)]
+        pub struct #having_ty {
+            pub conditions: ::std::vec::Vec<::prax_query::operations::HavingCondition>,
+        }
+
+        #[derive(Debug, Default, Clone)]
+        #[allow(dead_code)]
+        pub struct #order_by_ty {
+            pub items: ::std::vec::Vec<::std::string::String>,
+        }
+    }
+}
+
+fn to_pascal_case(snake: &str) -> String {
+    let mut out = String::with_capacity(snake.len());
+    let mut upper = true;
+    for c in snake.chars() {
+        if c == '_' {
+            upper = true;
+        } else if upper {
+            out.push(c.to_ascii_uppercase());
+            upper = false;
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -374,6 +466,51 @@ mod tests {
             "must not double-wrap: {min_body}"
         );
         assert!(min_body.contains("Option < DateTime < Utc > >"));
+    }
+
+    #[test]
+    fn emit_args_and_columns_enum_has_variant_per_scalar_and_column_name_impl() {
+        let model_ident: syn::Ident = parse_quote!(User);
+        let team_id_ident: syn::Ident = parse_quote!(team_id);
+        let region_ident: syn::Ident = parse_quote!(region);
+        let i32_ty: syn::Type = parse_quote!(i32);
+        let str_ty: syn::Type = parse_quote!(String);
+        let scalars = vec![
+            ScalarFieldMeta {
+                ident: &team_id_ident,
+                ty: &i32_ty,
+                column_name: "team_id",
+                is_numeric: true,
+                is_sortable: true,
+            },
+            ScalarFieldMeta {
+                ident: &region_ident,
+                ty: &str_ty,
+                column_name: "region",
+                is_numeric: false,
+                is_sortable: true,
+            },
+        ];
+        let s = emit_args_and_columns_enum(&model_ident, &scalars).to_string();
+        assert!(s.contains("enum UserGroupByColumn"));
+        assert!(s.contains("TeamId"));
+        assert!(s.contains("Region"));
+        assert!(s.contains("Self :: TeamId => \"team_id\""));
+        assert!(s.contains("Self :: Region => \"region\""));
+        assert!(s.contains("struct UserAggregateArgs"));
+        assert!(s.contains("struct UserGroupByArgs"));
+        assert!(s.contains("struct UserGroupByHaving"));
+        assert!(s.contains("struct UserGroupByOrderBy"));
+        assert!(s.contains("pub by :"));
+        assert!(s.contains("Vec < UserGroupByColumn >"));
+    }
+
+    #[test]
+    fn to_pascal_case_handles_snake_input() {
+        assert_eq!(to_pascal_case("team_id"), "TeamId");
+        assert_eq!(to_pascal_case("region"), "Region");
+        assert_eq!(to_pascal_case("user_account_id"), "UserAccountId");
+        assert_eq!(to_pascal_case("a"), "A");
     }
 
     #[test]

--- a/prax-codegen/src/generators/aggregate.rs
+++ b/prax-codegen/src/generators/aggregate.rs
@@ -140,6 +140,127 @@ pub fn emit_select_inputs(
     }
 }
 
+fn is_option_type(ty: &syn::Type) -> bool {
+    if let syn::Type::Path(tp) = ty
+        && let Some(seg) = tp.path.segments.last()
+    {
+        return seg.ident == "Option";
+    }
+    false
+}
+
+fn ensure_optional(ty: &syn::Type) -> TokenStream {
+    if is_option_type(ty) {
+        quote! { #ty }
+    } else {
+        quote! { ::core::option::Option<#ty> }
+    }
+}
+
+/// Emit the seven per-model result-shape output structs:
+///
+/// - `<Model>CountSelectResult` — `i64` per scalar + `_all`.
+/// - `<Model>SumResult` / `<Model>AvgResult` — `Option<f64>` per
+///   numeric column (Sum widens to f64 for cross-dialect consistency;
+///   AggregateResult downcasts via the runtime AggregateResult helpers).
+/// - `<Model>MinResult` / `<Model>MaxResult` — `Option<T>` per sortable
+///   column.
+/// - `<Model>AggregateResult` — five aggregate substructs as
+///   `Option<...>`.
+/// - `<Model>GroupByResult` — same five substructs plus every scalar
+///   column as `Option<T>` (for `by:` columns).
+pub fn emit_result_structs(
+    model_ident: &syn::Ident,
+    scalars: &[ScalarFieldMeta<'_>],
+) -> TokenStream {
+    let count_result = format_ident!("{}CountSelectResult", model_ident);
+    let sum_result = format_ident!("{}SumResult", model_ident);
+    let avg_result = format_ident!("{}AvgResult", model_ident);
+    let min_result = format_ident!("{}MinResult", model_ident);
+    let max_result = format_ident!("{}MaxResult", model_ident);
+    let agg_result = format_ident!("{}AggregateResult", model_ident);
+    let gb_result = format_ident!("{}GroupByResult", model_ident);
+
+    let count_fields = scalars.iter().map(|f| {
+        let ident = f.ident;
+        quote! { pub #ident: i64 }
+    });
+
+    let sum_fields: Vec<TokenStream> = scalars
+        .iter()
+        .filter(|f| f.is_numeric)
+        .map(|f| {
+            let ident = f.ident;
+            quote! { pub #ident: ::core::option::Option<f64> }
+        })
+        .collect();
+    let avg_fields = sum_fields.clone();
+
+    let min_fields: Vec<TokenStream> = scalars
+        .iter()
+        .filter(|f| f.is_sortable)
+        .map(|f| {
+            let ident = f.ident;
+            let outer = ensure_optional(f.ty);
+            quote! { pub #ident: #outer }
+        })
+        .collect();
+    let max_fields = min_fields.clone();
+
+    let gb_scalar_fields = scalars.iter().map(|f| {
+        let ident = f.ident;
+        let outer = ensure_optional(f.ty);
+        quote! { pub #ident: #outer }
+    });
+
+    quote! {
+        #[derive(Debug, Default, Clone)]
+        pub struct #count_result {
+            pub _all: i64,
+            #(#count_fields,)*
+        }
+
+        #[derive(Debug, Default, Clone)]
+        pub struct #sum_result {
+            #(#sum_fields,)*
+        }
+
+        #[derive(Debug, Default, Clone)]
+        pub struct #avg_result {
+            #(#avg_fields,)*
+        }
+
+        #[derive(Debug, Default, Clone)]
+        pub struct #min_result {
+            #(#min_fields,)*
+        }
+
+        #[derive(Debug, Default, Clone)]
+        pub struct #max_result {
+            #(#max_fields,)*
+        }
+
+        #[derive(Debug, Default, Clone)]
+        pub struct #agg_result {
+            pub _sum:   ::core::option::Option<#sum_result>,
+            pub _avg:   ::core::option::Option<#avg_result>,
+            pub _min:   ::core::option::Option<#min_result>,
+            pub _max:   ::core::option::Option<#max_result>,
+            pub _count: ::core::option::Option<#count_result>,
+        }
+
+        #[derive(Debug, Default, Clone)]
+        pub struct #gb_result {
+            #(#gb_scalar_fields,)*
+            pub _sum:   ::core::option::Option<#sum_result>,
+            pub _avg:   ::core::option::Option<#avg_result>,
+            pub _min:   ::core::option::Option<#min_result>,
+            pub _max:   ::core::option::Option<#max_result>,
+            pub _count: ::core::option::Option<#count_result>,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -167,6 +288,92 @@ mod tests {
         assert!(rust_type_is_sortable(&ty));
         let ty: syn::Type = parse_quote!(serde_json::Value);
         assert!(!rust_type_is_sortable(&ty));
+    }
+
+    #[test]
+    fn emit_result_structs_count_has_i64_for_all_and_each_scalar() {
+        let model_ident: syn::Ident = parse_quote!(User);
+        let id_ident: syn::Ident = parse_quote!(id);
+        let email_ident: syn::Ident = parse_quote!(email);
+        let id_ty: syn::Type = parse_quote!(i32);
+        let email_ty: syn::Type = parse_quote!(String);
+        let scalars = vec![
+            ScalarFieldMeta {
+                ident: &id_ident,
+                ty: &id_ty,
+                column_name: "id",
+                is_numeric: true,
+                is_sortable: true,
+            },
+            ScalarFieldMeta {
+                ident: &email_ident,
+                ty: &email_ty,
+                column_name: "email",
+                is_numeric: false,
+                is_sortable: true,
+            },
+        ];
+        let s = emit_result_structs(&model_ident, &scalars).to_string();
+        assert!(s.contains("struct UserCountSelectResult"));
+        assert!(s.contains("_all : i64"));
+        assert!(s.contains("id : i64"));
+        assert!(s.contains("email : i64"));
+        let sum_idx = s.find("struct UserSumResult").unwrap();
+        let close = s[sum_idx..].find('}').unwrap();
+        let sum_body = &s[sum_idx..sum_idx + close];
+        assert!(sum_body.contains("id :"));
+        assert!(
+            !sum_body.contains("email :"),
+            "Sum body should not include non-numeric `email`: {sum_body}"
+        );
+    }
+
+    #[test]
+    fn emit_result_structs_group_by_includes_every_scalar_as_optional() {
+        let model_ident: syn::Ident = parse_quote!(User);
+        let team_id_ident: syn::Ident = parse_quote!(team_id);
+        let i32_ty: syn::Type = parse_quote!(i32);
+        let scalars = vec![ScalarFieldMeta {
+            ident: &team_id_ident,
+            ty: &i32_ty,
+            column_name: "team_id",
+            is_numeric: true,
+            is_sortable: true,
+        }];
+        let s = emit_result_structs(&model_ident, &scalars).to_string();
+        assert!(s.contains("struct UserGroupByResult"));
+        let gb_idx = s.find("struct UserGroupByResult").unwrap();
+        let close = s[gb_idx..].find('}').unwrap();
+        let gb_body = &s[gb_idx..gb_idx + close];
+        assert!(gb_body.contains("team_id :"));
+        assert!(
+            gb_body.contains("Option < i32 >")
+                || gb_body.contains(":: core :: option :: Option < i32 >"),
+            "expected Option<i32> in GroupByResult.team_id: {gb_body}"
+        );
+    }
+
+    #[test]
+    fn emit_result_structs_min_max_preserves_existing_option() {
+        let model_ident: syn::Ident = parse_quote!(Post);
+        let deleted_at_ident: syn::Ident = parse_quote!(deleted_at);
+        let opt_ty: syn::Type = parse_quote!(Option<DateTime<Utc>>);
+        let scalars = vec![ScalarFieldMeta {
+            ident: &deleted_at_ident,
+            ty: &opt_ty,
+            column_name: "deleted_at",
+            is_numeric: false,
+            is_sortable: true,
+        }];
+        let s = emit_result_structs(&model_ident, &scalars).to_string();
+        let min_idx = s.find("struct PostMinResult").unwrap();
+        let close = s[min_idx..].find('}').unwrap();
+        let min_body = &s[min_idx..min_idx + close];
+        assert!(
+            !min_body.contains("Option < Option <"),
+            "must not double-wrap: {min_body}"
+        );
+        assert!(min_body.contains("Option < DateTime < Utc > >"));
     }
 
     #[test]

--- a/prax-codegen/src/generators/aggregate.rs
+++ b/prax-codegen/src/generators/aggregate.rs
@@ -1,0 +1,204 @@
+//! Aggregate-macro support: per-model select-shape input structs,
+//! result structs, args structs, GroupByColumn enum, and the
+//! `aggregate()` / `group_by()` accessor + `with_aggregate_args` /
+//! `with_group_by_args` extension methods on AggregateOperation /
+//! GroupByOperation. Used by `count!` (extended in phase 6),
+//! `aggregate!`, and `group_by!`.
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+
+/// Information about one scalar (non-relation, non-aggregate) field
+/// on a model. Built by the caller from the existing FieldInfo loop.
+#[allow(dead_code)]
+pub struct ScalarFieldMeta<'a> {
+    pub ident: &'a syn::Ident,
+    pub ty: &'a syn::Type,
+    pub column_name: &'a str,
+    pub is_numeric: bool,
+    pub is_sortable: bool,
+}
+
+pub fn rust_type_is_numeric(ty: &syn::Type) -> bool {
+    let name = type_leaf_ident(ty);
+    matches!(
+        name.as_deref(),
+        Some(
+            "i8" | "i16"
+                | "i32"
+                | "i64"
+                | "i128"
+                | "u8"
+                | "u16"
+                | "u32"
+                | "u64"
+                | "u128"
+                | "f32"
+                | "f64"
+                | "isize"
+                | "usize"
+                | "Decimal"
+                | "BigDecimal"
+        )
+    )
+}
+
+pub fn rust_type_is_sortable(ty: &syn::Type) -> bool {
+    if rust_type_is_numeric(ty) {
+        return true;
+    }
+    let name = type_leaf_ident(ty);
+    matches!(
+        name.as_deref(),
+        Some(
+            "String"
+                | "str"
+                | "DateTime"
+                | "NaiveDateTime"
+                | "NaiveDate"
+                | "NaiveTime"
+                | "Date"
+                | "Time"
+                | "Uuid"
+        )
+    )
+}
+
+fn type_leaf_ident(ty: &syn::Type) -> Option<String> {
+    if let syn::Type::Path(tp) = ty
+        && let Some(seg) = tp.path.segments.last()
+    {
+        if seg.ident == "Option"
+            && let syn::PathArguments::AngleBracketed(args) = &seg.arguments
+            && let Some(syn::GenericArgument::Type(inner)) = args.args.first()
+        {
+            return type_leaf_ident(inner);
+        }
+        return Some(seg.ident.to_string());
+    }
+    None
+}
+
+/// Emit the five per-model select-shape input structs.
+#[allow(dead_code)]
+pub fn emit_select_inputs(
+    model_ident: &syn::Ident,
+    scalars: &[ScalarFieldMeta<'_>],
+) -> TokenStream {
+    let count_name = format_ident!("{}CountSelect", model_ident);
+    let sum_name = format_ident!("{}SumSelect", model_ident);
+    let avg_name = format_ident!("{}AvgSelect", model_ident);
+    let min_name = format_ident!("{}MinSelect", model_ident);
+    let max_name = format_ident!("{}MaxSelect", model_ident);
+
+    let count_fields = scalars.iter().map(|f| {
+        let ident = f.ident;
+        quote! { pub #ident: ::core::option::Option<bool> }
+    });
+    let numeric_fields: Vec<_> = scalars
+        .iter()
+        .filter(|f| f.is_numeric)
+        .map(|f| {
+            let ident = f.ident;
+            quote! { pub #ident: ::core::option::Option<bool> }
+        })
+        .collect();
+    let sortable_for_min_max: Vec<_> = scalars
+        .iter()
+        .filter(|f| f.is_sortable)
+        .map(|f| {
+            let ident = f.ident;
+            quote! { pub #ident: ::core::option::Option<bool> }
+        })
+        .collect();
+
+    let numeric_fields_2 = numeric_fields.to_vec();
+    let sortable_2 = sortable_for_min_max.to_vec();
+
+    quote! {
+        #[derive(Debug, Default, Clone)]
+        pub struct #count_name {
+            pub _all: ::core::option::Option<bool>,
+            #(#count_fields,)*
+        }
+        #[derive(Debug, Default, Clone)]
+        pub struct #sum_name {
+            #(#numeric_fields,)*
+        }
+        #[derive(Debug, Default, Clone)]
+        pub struct #avg_name {
+            #(#numeric_fields_2,)*
+        }
+        #[derive(Debug, Default, Clone)]
+        pub struct #min_name {
+            #(#sortable_for_min_max,)*
+        }
+        #[derive(Debug, Default, Clone)]
+        pub struct #max_name {
+            #(#sortable_2,)*
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_quote;
+
+    #[test]
+    fn numeric_detects_basic_ints_and_floats() {
+        let ty: syn::Type = parse_quote!(i32);
+        assert!(rust_type_is_numeric(&ty));
+        let ty: syn::Type = parse_quote!(Option<f64>);
+        assert!(rust_type_is_numeric(&ty));
+        let ty: syn::Type = parse_quote!(u128);
+        assert!(rust_type_is_numeric(&ty));
+        let ty: syn::Type = parse_quote!(String);
+        assert!(!rust_type_is_numeric(&ty));
+    }
+
+    #[test]
+    fn sortable_includes_string_and_datetime() {
+        let ty: syn::Type = parse_quote!(String);
+        assert!(rust_type_is_sortable(&ty));
+        let ty: syn::Type = parse_quote!(DateTime<Utc>);
+        assert!(rust_type_is_sortable(&ty));
+        let ty: syn::Type = parse_quote!(Option<NaiveDateTime>);
+        assert!(rust_type_is_sortable(&ty));
+        let ty: syn::Type = parse_quote!(serde_json::Value);
+        assert!(!rust_type_is_sortable(&ty));
+    }
+
+    #[test]
+    fn emit_select_inputs_count_includes_all_scalars() {
+        let model_ident: syn::Ident = parse_quote!(User);
+        let id_ident: syn::Ident = parse_quote!(id);
+        let email_ident: syn::Ident = parse_quote!(email);
+        let id_ty: syn::Type = parse_quote!(i32);
+        let email_ty: syn::Type = parse_quote!(String);
+        let scalars = vec![
+            ScalarFieldMeta {
+                ident: &id_ident,
+                ty: &id_ty,
+                column_name: "id",
+                is_numeric: true,
+                is_sortable: true,
+            },
+            ScalarFieldMeta {
+                ident: &email_ident,
+                ty: &email_ty,
+                column_name: "email",
+                is_numeric: false,
+                is_sortable: true,
+            },
+        ];
+        let s = emit_select_inputs(&model_ident, &scalars).to_string();
+        assert!(s.contains("struct UserCountSelect"));
+        assert!(s.contains("pub _all"));
+        let sum_idx = s.find("struct UserSumSelect").unwrap();
+        let close = s[sum_idx..].find('}').unwrap();
+        let sum_body = &s[sum_idx..sum_idx + close];
+        assert!(sum_body.contains("pub id :"));
+        assert!(!sum_body.contains("pub email :"));
+    }
+}

--- a/prax-codegen/src/generators/derive.rs
+++ b/prax-codegen/src/generators/derive.rs
@@ -268,6 +268,7 @@ pub fn derive_model_impl(input: &DeriveInput) -> Result<TokenStream, syn::Error>
         .collect();
     let aggregate_select_inputs = super::aggregate::emit_select_inputs(name, &scalar_meta);
     let aggregate_result_structs = super::aggregate::emit_result_structs(name, &scalar_meta);
+    let aggregate_args = super::aggregate::emit_args_and_columns_enum(name, &scalar_meta);
 
     // Per-model `impl ModelRelationLoader<E>` dispatcher. Models with
     // no relations still get an impl — it errors on any unknown name,
@@ -585,6 +586,10 @@ pub fn derive_model_impl(input: &DeriveInput) -> Result<TokenStream, syn::Error>
             // <Model>{CountSelectResult,SumResult,AvgResult,MinResult,MaxResult,
             // AggregateResult,GroupByResult}.
             #aggregate_result_structs
+
+            // Per-model GroupByColumn enum, AggregateArgs, GroupByArgs,
+            // GroupByHaving, GroupByOrderBy (phase 6 T4).
+            #aggregate_args
 
             // Per-relation `<Model><Relation>FilterMeta` marker structs (Task 8).
             // The corresponding `impl RelationFilterMeta` blocks are emitted

--- a/prax-codegen/src/generators/derive.rs
+++ b/prax-codegen/src/generators/derive.rs
@@ -255,6 +255,19 @@ pub fn derive_model_impl(input: &DeriveInput) -> Result<TokenStream, syn::Error>
             .collect();
     let count_struct_tokens = super::count_struct::emit_count_struct(name, &count_struct_outgoing);
 
+    let scalar_meta: Vec<super::aggregate::ScalarFieldMeta<'_>> = field_infos
+        .iter()
+        .filter(|f| f.relation.is_none() && f.aggregate.is_none())
+        .map(|f| super::aggregate::ScalarFieldMeta {
+            ident: &f.name,
+            ty: &f.ty,
+            column_name: f.column_name.as_str(),
+            is_numeric: super::aggregate::rust_type_is_numeric(&f.ty),
+            is_sortable: super::aggregate::rust_type_is_sortable(&f.ty),
+        })
+        .collect();
+    let aggregate_select_inputs = super::aggregate::emit_select_inputs(name, &scalar_meta);
+
     // Per-model `impl ModelRelationLoader<E>` dispatcher. Models with
     // no relations still get an impl — it errors on any unknown name,
     // preserving the uniform `ModelRelationLoader` bound on find
@@ -562,6 +575,10 @@ pub fn derive_model_impl(input: &DeriveInput) -> Result<TokenStream, syn::Error>
             #order_by_struct
             #create_struct
             #update_struct
+
+            // Per-model aggregate select-shape input structs (phase 6):
+            // <Model>{Count,Sum,Avg,Min,Max}Select.
+            #aggregate_select_inputs
 
             // Per-relation `<Model><Relation>FilterMeta` marker structs (Task 8).
             // The corresponding `impl RelationFilterMeta` blocks are emitted

--- a/prax-codegen/src/generators/derive.rs
+++ b/prax-codegen/src/generators/derive.rs
@@ -1692,13 +1692,14 @@ mod tests {
         );
         let code = result.unwrap().to_string();
 
-        // `PostCount` must NOT appear in the generated code.
-        // Models with zero outgoing relations are not count-able at the
-        // type level — attempting `_count` on them will be a compile-time
-        // error enforced in Task 14 macro lowering / Task 15 trybuild.
+        // The phase-5.5 relation-count substruct `struct PostCount { ... }`
+        // must NOT be emitted for a relation-free model. Note the trailing
+        // space discriminates it from the phase-6 aggregate types
+        // `PostCountSelect` / `PostCountSelectResult`, which ARE emitted for
+        // every model (count! / aggregate! work regardless of relations).
         assert!(
-            !code.contains("PostCount"),
-            "unexpected PostCount in generated code for a relation-free model"
+            !code.contains("struct PostCount "),
+            "unexpected relation-count `struct PostCount` for a relation-free model"
         );
     }
 

--- a/prax-codegen/src/generators/derive.rs
+++ b/prax-codegen/src/generators/derive.rs
@@ -267,6 +267,7 @@ pub fn derive_model_impl(input: &DeriveInput) -> Result<TokenStream, syn::Error>
         })
         .collect();
     let aggregate_select_inputs = super::aggregate::emit_select_inputs(name, &scalar_meta);
+    let aggregate_result_structs = super::aggregate::emit_result_structs(name, &scalar_meta);
 
     // Per-model `impl ModelRelationLoader<E>` dispatcher. Models with
     // no relations still get an impl — it errors on any unknown name,
@@ -579,6 +580,11 @@ pub fn derive_model_impl(input: &DeriveInput) -> Result<TokenStream, syn::Error>
             // Per-model aggregate select-shape input structs (phase 6):
             // <Model>{Count,Sum,Avg,Min,Max}Select.
             #aggregate_select_inputs
+
+            // Per-model aggregate result output structs (phase 6):
+            // <Model>{CountSelectResult,SumResult,AvgResult,MinResult,MaxResult,
+            // AggregateResult,GroupByResult}.
+            #aggregate_result_structs
 
             // Per-relation `<Model><Relation>FilterMeta` marker structs (Task 8).
             // The corresponding `impl RelationFilterMeta` blocks are emitted

--- a/prax-codegen/src/generators/derive.rs
+++ b/prax-codegen/src/generators/derive.rs
@@ -495,6 +495,8 @@ pub fn derive_model_impl(input: &DeriveInput) -> Result<TokenStream, syn::Error>
     // definition is always emitted; the trait impl is gated on visibility.
     let is_pub = matches!(input.vis, Visibility::Public(_));
     let gate_impl = |tokens: TokenStream| if is_pub { tokens } else { TokenStream::new() };
+    let aggregate_accessors =
+        super::aggregate::emit_accessors_and_extensions(name, &scalar_meta, is_pub);
     let maybe_where_input_impl = gate_impl(where_input_impl);
     let maybe_where_unique_impl = gate_impl(where_unique_impl);
     let maybe_include_impl = gate_impl(include_impl);
@@ -590,6 +592,11 @@ pub fn derive_model_impl(input: &DeriveInput) -> Result<TokenStream, syn::Error>
             // Per-model GroupByColumn enum, AggregateArgs, GroupByArgs,
             // GroupByHaving, GroupByOrderBy (phase 6 T4).
             #aggregate_args
+
+            // fields_set() / all_set() helpers, typed group_by_columns() on
+            // Client<E>, and with_aggregate_args / with_group_by_args extensions
+            // on AggregateOperation / GroupByOperation (phase 6 T5).
+            #aggregate_accessors
 
             // Per-relation `<Model><Relation>FilterMeta` marker structs (Task 8).
             // The corresponding `impl RelationFilterMeta` blocks are emitted

--- a/prax-codegen/src/generators/mod.rs
+++ b/prax-codegen/src/generators/mod.rs
@@ -1,5 +1,6 @@
 //! Code generators for Prax models, enums, types, and views.
 
+pub(crate) mod aggregate;
 pub(crate) mod count_struct;
 mod derive;
 mod derive_client;

--- a/prax-codegen/src/lib.rs
+++ b/prax-codegen/src/lib.rs
@@ -225,6 +225,27 @@ pub fn aggregate(input: TokenStream) -> TokenStream {
     }
 }
 
+/// `prax::group_by!` — schema-aware DSL targeting `group_by_columns`.
+/// Accepts `by:` (required), `where:`, `_count:`, `_sum:`, `_avg:`, `_min:`,
+/// `_max:`, and `having:` keys.
+///
+/// ```rust,ignore
+/// prax::group_by!(client.user, {
+///     by: [team_id, region],
+///     where: { active: true },
+///     _count: { _all: true },
+///     _sum: { views: true },
+///     having: { _count: { _all: { gt: 5 } } },
+/// });
+/// ```
+#[proc_macro]
+pub fn group_by(input: TokenStream) -> TokenStream {
+    match macros::ops::group_by::expand_group_by(input.into()) {
+        Ok(t) => t.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
 /// `prax::delete!` — schema-aware DSL targeting `delete`. The
 /// `where:` block must match a unique column.
 #[proc_macro]

--- a/prax-codegen/src/lib.rs
+++ b/prax-codegen/src/lib.rs
@@ -205,6 +205,26 @@ pub fn count(input: TokenStream) -> TokenStream {
     }
 }
 
+/// `prax::aggregate!` — schema-aware DSL targeting `aggregate`. Accepts
+/// `where:`, `_count:`, `_sum:`, `_avg:`, `_min:`, `_max:` keys. At least one
+/// aggregate key is required.
+///
+/// ```rust,ignore
+/// prax::aggregate!(client.user, {
+///     where: { active: true },
+///     _sum: { views: true, score: true },
+///     _avg: { score: true },
+///     _count: { _all: true },
+/// });
+/// ```
+#[proc_macro]
+pub fn aggregate(input: TokenStream) -> TokenStream {
+    match macros::ops::aggregate::expand_aggregate(input.into()) {
+        Ok(t) => t.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
 /// `prax::delete!` — schema-aware DSL targeting `delete`. The
 /// `where:` block must match a unique column.
 #[proc_macro]

--- a/prax-codegen/src/macros/lower/aggregate_select.rs
+++ b/prax-codegen/src/macros/lower/aggregate_select.rs
@@ -1,0 +1,310 @@
+// AggKind methods and lower_agg_select are consumed by Tasks 8-10; until
+// then the compiler sees them as unused.
+#![allow(dead_code)]
+
+use convert_case::{Case, Casing};
+use proc_macro2::{Span, TokenStream};
+use quote::{format_ident, quote};
+
+use super::LowerCtx;
+use crate::macros::dsl::ast::{DslBlock, DslField, DslValue};
+
+/// Which aggregate operation the caller is lowering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AggKind {
+    Count,
+    Sum,
+    Avg,
+    Min,
+    Max,
+}
+
+impl AggKind {
+    pub fn select_struct_suffix(self) -> &'static str {
+        match self {
+            Self::Count => "CountSelect",
+            Self::Sum => "SumSelect",
+            Self::Avg => "AvgSelect",
+            Self::Min => "MinSelect",
+            Self::Max => "MaxSelect",
+        }
+    }
+
+    pub fn key(self) -> &'static str {
+        match self {
+            Self::Count => "_count",
+            Self::Sum => "_sum",
+            Self::Avg => "_avg",
+            Self::Min => "_min",
+            Self::Max => "_max",
+        }
+    }
+}
+
+/// Lower one `_<agg>: { col: true, ... }` block to an expression that
+/// constructs `<Model><Agg>Select { <col>: Some(true), ... }`.
+///
+/// Validation enforced:
+/// - all values must be `true` literals (opt-in only)
+/// - `_all` is valid only inside `_count`
+/// - every column name must exist on the model (did-you-mean diagnostic)
+/// - relation and aggregate fields are rejected
+/// - `Sum`/`Avg` require numeric scalar columns (Int / BigInt / Float / Decimal)
+/// - empty blocks are rejected
+pub fn lower_agg_select(
+    kind: AggKind,
+    block: &DslBlock,
+    ctx: &LowerCtx<'_>,
+) -> syn::Result<TokenStream> {
+    let module_ident = format_ident!("{}", ctx.model.name().to_case(Case::Snake));
+    let struct_ident = format_ident!("{}{}", ctx.model.name(), kind.select_struct_suffix());
+
+    let mut setters: Vec<TokenStream> = Vec::new();
+
+    for entry in &block.fields {
+        let DslField::Pair { key, value, .. } = entry else {
+            return Err(syn::Error::new(
+                Span::call_site(),
+                format!(
+                    "`{}` block does not support spread or conditional fields",
+                    kind.key()
+                ),
+            ));
+        };
+        let key_str = key.to_string();
+
+        if !matches!(value, DslValue::Bool(true)) {
+            return Err(syn::Error::new(
+                key.span(),
+                format!(
+                    "value for `{}.{}` must be `true` (only opt-in is supported)",
+                    kind.key(),
+                    key_str
+                ),
+            ));
+        }
+
+        if key_str == "_all" {
+            if kind != AggKind::Count {
+                return Err(syn::Error::new(
+                    key.span(),
+                    format!("`_all` is only valid inside `_count`, not `{}`", kind.key()),
+                ));
+            }
+            setters.push(quote! { __s._all = ::core::option::Option::Some(true); });
+            continue;
+        }
+
+        let field = ctx.model.get_field(&key_str).ok_or_else(|| {
+            let candidates: Vec<String> = ctx.model.fields.keys().map(|k| k.to_string()).collect();
+            let suggestion = crate::macros::validate::suggest(&key_str, &candidates);
+            let msg = match suggestion {
+                Some(s) => format!(
+                    "unknown column `{}` on model `{}`; did you mean `{}`?",
+                    key_str,
+                    ctx.model.name(),
+                    s
+                ),
+                None => format!(
+                    "unknown column `{}` on model `{}`",
+                    key_str,
+                    ctx.model.name()
+                ),
+            };
+            syn::Error::new(key.span(), msg)
+        })?;
+
+        if field.is_relation() {
+            return Err(syn::Error::new(
+                key.span(),
+                format!(
+                    "field `{}` is a relation; aggregates require a scalar column",
+                    key_str
+                ),
+            ));
+        }
+        if field.aggregate().is_some() {
+            return Err(syn::Error::new(
+                key.span(),
+                format!(
+                    "field `{}` is itself an aggregate; cannot aggregate an aggregate",
+                    key_str
+                ),
+            ));
+        }
+
+        if matches!(kind, AggKind::Sum | AggKind::Avg) && !field_is_numeric(field) {
+            return Err(syn::Error::new(
+                key.span(),
+                format!(
+                    "field `{}` is not numeric; `{}` requires a numeric column (Int, BigInt, Float, or Decimal)",
+                    key_str,
+                    kind.key()
+                ),
+            ));
+        }
+
+        let col_ident = format_ident!("{}", key_str);
+        setters.push(quote! {
+            __s.#col_ident = ::core::option::Option::Some(true);
+        });
+    }
+
+    if setters.is_empty() {
+        return Err(syn::Error::new(
+            Span::call_site(),
+            format!(
+                "`{}` block is empty; specify at least one column or remove the block",
+                kind.key()
+            ),
+        ));
+    }
+
+    Ok(quote! {
+        {
+            let mut __s: #module_ident::#struct_ident =
+                <#module_ident::#struct_ident as ::core::default::Default>::default();
+            #(#setters)*
+            __s
+        }
+    })
+}
+
+#[allow(dead_code)]
+fn field_is_numeric(field: &prax_schema::Field) -> bool {
+    use prax_schema::ast::{FieldType, ScalarType};
+    matches!(
+        field.field_type,
+        FieldType::Scalar(ScalarType::Int)
+            | FieldType::Scalar(ScalarType::BigInt)
+            | FieldType::Scalar(ScalarType::Float)
+            | FieldType::Scalar(ScalarType::Decimal)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prax_schema::parse_schema;
+    use quote::quote;
+
+    const SCHEMA: &str = include_str!("../../../tests/fixtures/schema.prax");
+
+    fn make_ctx(schema: &prax_schema::Schema, model_name: &str) -> prax_schema::Model {
+        schema.get_model(model_name).unwrap().clone()
+    }
+
+    fn lower_ok(model_name: &str, kind: AggKind, tokens: TokenStream) -> TokenStream {
+        let schema = parse_schema(SCHEMA).unwrap();
+        let model = make_ctx(&schema, model_name);
+        let ctx = LowerCtx::new(&schema, &model);
+        let block = syn::parse2::<DslBlock>(tokens).unwrap();
+        lower_agg_select(kind, &block, &ctx).unwrap()
+    }
+
+    fn lower_err(model_name: &str, kind: AggKind, tokens: TokenStream) -> String {
+        let schema = parse_schema(SCHEMA).unwrap();
+        let model = make_ctx(&schema, model_name);
+        let ctx = LowerCtx::new(&schema, &model);
+        let block = syn::parse2::<DslBlock>(tokens).unwrap();
+        lower_agg_select(kind, &block, &ctx)
+            .unwrap_err()
+            .to_string()
+    }
+
+    #[test]
+    fn agg_kind_select_struct_suffix() {
+        assert_eq!(AggKind::Count.select_struct_suffix(), "CountSelect");
+        assert_eq!(AggKind::Sum.select_struct_suffix(), "SumSelect");
+        assert_eq!(AggKind::Avg.select_struct_suffix(), "AvgSelect");
+        assert_eq!(AggKind::Min.select_struct_suffix(), "MinSelect");
+        assert_eq!(AggKind::Max.select_struct_suffix(), "MaxSelect");
+    }
+
+    #[test]
+    fn agg_kind_key() {
+        assert_eq!(AggKind::Count.key(), "_count");
+        assert_eq!(AggKind::Sum.key(), "_sum");
+        assert_eq!(AggKind::Avg.key(), "_avg");
+        assert_eq!(AggKind::Min.key(), "_min");
+        assert_eq!(AggKind::Max.key(), "_max");
+    }
+
+    #[test]
+    fn lower_count_scalar_field() {
+        let ts = lower_ok("User", AggKind::Count, quote!({ id: true }));
+        let s = ts.to_string();
+        assert!(s.contains("UserCountSelect"), "got: {s}");
+        assert!(s.contains("id"), "got: {s}");
+    }
+
+    #[test]
+    fn lower_count_all() {
+        let ts = lower_ok("User", AggKind::Count, quote!({ _all: true }));
+        let s = ts.to_string();
+        assert!(s.contains("_all"), "got: {s}");
+    }
+
+    #[test]
+    fn lower_sum_numeric_field() {
+        let ts = lower_ok("User", AggKind::Sum, quote!({ age: true }));
+        let s = ts.to_string();
+        assert!(s.contains("UserSumSelect"), "got: {s}");
+        assert!(s.contains("age"), "got: {s}");
+    }
+
+    #[test]
+    fn lower_all_in_non_count_errors() {
+        let msg = lower_err("User", AggKind::Sum, quote!({ _all: true }));
+        assert!(msg.contains("_all"), "got: {msg}");
+        assert!(msg.contains("_count"), "got: {msg}");
+    }
+
+    #[test]
+    fn lower_unknown_column_errors() {
+        let msg = lower_err("User", AggKind::Min, quote!({ nonexistent: true }));
+        assert!(msg.contains("unknown column"), "got: {msg}");
+    }
+
+    #[test]
+    fn lower_unknown_column_did_you_mean() {
+        let msg = lower_err("User", AggKind::Min, quote!({ emial: true }));
+        assert!(msg.contains("did you mean"), "got: {msg}");
+    }
+
+    #[test]
+    fn lower_non_true_value_errors() {
+        let msg = lower_err("User", AggKind::Count, quote!({ id: false }));
+        assert!(msg.contains("must be `true`"), "got: {msg}");
+    }
+
+    #[test]
+    fn lower_relation_field_errors() {
+        let msg = lower_err("User", AggKind::Count, quote!({ posts: true }));
+        assert!(msg.contains("relation"), "got: {msg}");
+    }
+
+    #[test]
+    fn lower_aggregate_field_errors() {
+        let msg = lower_err("User", AggKind::Count, quote!({ post_count: true }));
+        assert!(msg.contains("aggregate"), "got: {msg}");
+    }
+
+    #[test]
+    fn lower_sum_non_numeric_field_errors() {
+        let msg = lower_err("User", AggKind::Sum, quote!({ email: true }));
+        assert!(msg.contains("not numeric"), "got: {msg}");
+    }
+
+    #[test]
+    fn lower_avg_non_numeric_field_errors() {
+        let msg = lower_err("User", AggKind::Avg, quote!({ email: true }));
+        assert!(msg.contains("not numeric"), "got: {msg}");
+    }
+
+    #[test]
+    fn lower_empty_block_errors() {
+        let msg = lower_err("User", AggKind::Count, quote!({}));
+        assert!(msg.contains("empty"), "got: {msg}");
+    }
+}

--- a/prax-codegen/src/macros/lower/having.rs
+++ b/prax-codegen/src/macros/lower/having.rs
@@ -1,0 +1,277 @@
+//! Lower a `having: { _count: { _all: { gt: 5 } }, _sum: { views: { gte: 100 } } }`
+//! block to a `Vec<HavingCondition>` token expression.
+//!
+//! Supported operators: equals, not_equals, lt, lte, gt, gte (matches
+//! the phase 5.5 aggregate-filter operator set, minus `in`/`not_in`
+//! which don't apply to scalar aggregates).
+//!
+//! Used by `group_by!` (Task 10). `count!` / `aggregate!` do not have
+//! HAVING clauses.
+
+#![allow(dead_code)]
+
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::Lit;
+
+use super::LowerCtx;
+use crate::macros::dsl::ast::{DslBlock, DslField, DslValue};
+use crate::macros::lower::aggregate_select::AggKind;
+
+/// Lower the `having:` block to a `Vec<HavingCondition>` expression.
+pub fn lower_having(block: &DslBlock, _ctx: &LowerCtx<'_>) -> syn::Result<TokenStream> {
+    let mut conditions: Vec<TokenStream> = Vec::new();
+
+    for entry in &block.fields {
+        let DslField::Pair { key, value, .. } = entry else {
+            return Err(syn::Error::new(
+                Span::call_site(),
+                "having block does not support spread or conditional fields",
+            ));
+        };
+        let agg_key = key.to_string();
+        let kind = match agg_key.as_str() {
+            "_count" => AggKind::Count,
+            "_sum" => AggKind::Sum,
+            "_avg" => AggKind::Avg,
+            "_min" => AggKind::Min,
+            "_max" => AggKind::Max,
+            other => {
+                return Err(syn::Error::new(
+                    key.span(),
+                    format!(
+                        "unknown having key `{}`; use one of _count, _sum, _avg, _min, _max",
+                        other
+                    ),
+                ));
+            }
+        };
+        let DslValue::Block(inner) = value else {
+            return Err(syn::Error::new(
+                key.span(),
+                format!(
+                    "having `{}` value must be a `{{ col: {{ op: value }} }}` block",
+                    agg_key
+                ),
+            ));
+        };
+
+        for col_entry in &inner.fields {
+            let DslField::Pair {
+                key: col_key,
+                value: col_val,
+                ..
+            } = col_entry
+            else {
+                return Err(syn::Error::new(
+                    Span::call_site(),
+                    "having column block does not support spread",
+                ));
+            };
+            let col = col_key.to_string();
+            let DslValue::Block(op_block) = col_val else {
+                return Err(syn::Error::new(
+                    col_key.span(),
+                    format!(
+                        "having `{}.{}` must be a `{{ op: value }}` block",
+                        agg_key, col
+                    ),
+                ));
+            };
+
+            for op_entry in &op_block.fields {
+                let DslField::Pair {
+                    key: op_key,
+                    value: op_val,
+                    ..
+                } = op_entry
+                else {
+                    continue;
+                };
+                let op = op_key.to_string();
+                let expr = dsl_value_to_f64_expr(op_val, op_key.span())?;
+                let ctor = build_having_ctor(kind, &col, &op, &expr, op_key.span())?;
+                conditions.push(ctor);
+            }
+        }
+    }
+
+    Ok(quote! {
+        {
+            let mut __conds: ::std::vec::Vec<::prax_query::operations::HavingCondition>
+                = ::std::vec::Vec::new();
+            #( __conds.push(#conditions); )*
+            __conds
+        }
+    })
+}
+
+fn build_having_ctor(
+    kind: AggKind,
+    col: &str,
+    op: &str,
+    expr: &TokenStream,
+    span: Span,
+) -> syn::Result<TokenStream> {
+    if matches!(kind, AggKind::Count) {
+        if col != "_all" {
+            return Err(syn::Error::new(
+                span,
+                format!(
+                    "count on a specific column (`{}`) in having is not supported; use `_count: {{ _all: {{ {}: value }} }}`",
+                    col, op
+                ),
+            ));
+        }
+        let path = match op {
+            "gt" => quote! { ::prax_query::operations::having::count_gt(#expr) },
+            "gte" => quote! { ::prax_query::operations::having::count_gte(#expr) },
+            "lt" => quote! { ::prax_query::operations::having::count_lt(#expr) },
+            "lte" => quote! { ::prax_query::operations::having::count_lte(#expr) },
+            "equals" => quote! { ::prax_query::operations::having::count_eq(#expr) },
+            "not_equals" => quote! { ::prax_query::operations::having::count_ne(#expr) },
+            _ => {
+                return Err(syn::Error::new(
+                    span,
+                    format!(
+                        "unsupported having operator `{}` on `_count`; use one of equals/not_equals/lt/lte/gt/gte",
+                        op
+                    ),
+                ));
+            }
+        };
+        return Ok(path);
+    }
+
+    let path = match (kind, op) {
+        (AggKind::Sum, "gt") => {
+            quote! { ::prax_query::operations::having::sum_gt(#col, #expr) }
+        }
+        (AggKind::Sum, "gte") => {
+            quote! { ::prax_query::operations::having::sum_gte(#col, #expr) }
+        }
+        (AggKind::Sum, "lt") => {
+            quote! { ::prax_query::operations::having::sum_lt(#col, #expr) }
+        }
+        (AggKind::Sum, "lte") => {
+            quote! { ::prax_query::operations::having::sum_lte(#col, #expr) }
+        }
+        (AggKind::Sum, "equals") => {
+            quote! { ::prax_query::operations::having::sum_eq(#col, #expr) }
+        }
+        (AggKind::Sum, "not_equals") => {
+            quote! { ::prax_query::operations::having::sum_ne(#col, #expr) }
+        }
+
+        (AggKind::Avg, "gt") => {
+            quote! { ::prax_query::operations::having::avg_gt(#col, #expr) }
+        }
+        (AggKind::Avg, "gte") => {
+            quote! { ::prax_query::operations::having::avg_gte(#col, #expr) }
+        }
+        (AggKind::Avg, "lt") => {
+            quote! { ::prax_query::operations::having::avg_lt(#col, #expr) }
+        }
+        (AggKind::Avg, "lte") => {
+            quote! { ::prax_query::operations::having::avg_lte(#col, #expr) }
+        }
+        (AggKind::Avg, "equals") => {
+            quote! { ::prax_query::operations::having::avg_eq(#col, #expr) }
+        }
+        (AggKind::Avg, "not_equals") => {
+            quote! { ::prax_query::operations::having::avg_ne(#col, #expr) }
+        }
+
+        (AggKind::Min, "gt") => {
+            quote! { ::prax_query::operations::having::min_gt(#col, #expr) }
+        }
+        (AggKind::Min, "gte") => {
+            quote! { ::prax_query::operations::having::min_gte(#col, #expr) }
+        }
+        (AggKind::Min, "lt") => {
+            quote! { ::prax_query::operations::having::min_lt(#col, #expr) }
+        }
+        (AggKind::Min, "lte") => {
+            quote! { ::prax_query::operations::having::min_lte(#col, #expr) }
+        }
+        (AggKind::Min, "equals") => {
+            quote! { ::prax_query::operations::having::min_eq(#col, #expr) }
+        }
+        (AggKind::Min, "not_equals") => {
+            quote! { ::prax_query::operations::having::min_ne(#col, #expr) }
+        }
+
+        (AggKind::Max, "gt") => {
+            quote! { ::prax_query::operations::having::max_gt(#col, #expr) }
+        }
+        (AggKind::Max, "gte") => {
+            quote! { ::prax_query::operations::having::max_gte(#col, #expr) }
+        }
+        (AggKind::Max, "lt") => {
+            quote! { ::prax_query::operations::having::max_lt(#col, #expr) }
+        }
+        (AggKind::Max, "lte") => {
+            quote! { ::prax_query::operations::having::max_lte(#col, #expr) }
+        }
+        (AggKind::Max, "equals") => {
+            quote! { ::prax_query::operations::having::max_eq(#col, #expr) }
+        }
+        (AggKind::Max, "not_equals") => {
+            quote! { ::prax_query::operations::having::max_ne(#col, #expr) }
+        }
+
+        (_, _) => {
+            return Err(syn::Error::new(
+                span,
+                format!(
+                    "unsupported having operator `{}` on `{}`; use one of equals/not_equals/lt/lte/gt/gte",
+                    op,
+                    kind.key()
+                ),
+            ));
+        }
+    };
+
+    Ok(path)
+}
+
+fn dsl_value_to_f64_expr(v: &DslValue, span: Span) -> syn::Result<TokenStream> {
+    match v {
+        DslValue::Lit(Lit::Int(i)) => Ok(quote! { (#i as f64) }),
+        DslValue::Lit(Lit::Float(f)) => Ok(quote! { (#f as f64) }),
+        DslValue::Expr(e) => Ok(quote! { ((#e) as f64) }),
+        _ => Err(syn::Error::new(
+            span,
+            "having operator value must be a numeric literal",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dsl_value_int_lit_emits_f64_cast() {
+        let lit_int: syn::LitInt = syn::parse_str("5").unwrap();
+        let v = DslValue::Lit(Lit::Int(lit_int));
+        let ts = dsl_value_to_f64_expr(&v, Span::call_site()).unwrap();
+        assert_eq!(ts.to_string(), "(5 as f64)");
+    }
+
+    #[test]
+    fn dsl_value_float_lit_emits_f64_cast() {
+        let lit_float: syn::LitFloat = syn::parse_str("3.14").unwrap();
+        let v = DslValue::Lit(Lit::Float(lit_float));
+        let ts = dsl_value_to_f64_expr(&v, Span::call_site()).unwrap();
+        assert_eq!(ts.to_string(), "(3.14 as f64)");
+    }
+
+    #[test]
+    fn dsl_value_string_errors() {
+        let lit_str: syn::LitStr = syn::parse_str("\"hello\"").unwrap();
+        let v = DslValue::Lit(Lit::Str(lit_str));
+        let err = dsl_value_to_f64_expr(&v, Span::call_site()).unwrap_err();
+        assert!(err.to_string().contains("numeric literal"));
+    }
+}

--- a/prax-codegen/src/macros/lower/mod.rs
+++ b/prax-codegen/src/macros/lower/mod.rs
@@ -3,6 +3,7 @@
 //! Each submodule lowers one piece of the per-model input shape.
 //! Filled in by tasks 7-10.
 
+pub(crate) mod aggregate_select;
 pub(crate) mod data_input;
 pub(crate) mod data_relation;
 pub(crate) mod include_input;

--- a/prax-codegen/src/macros/lower/mod.rs
+++ b/prax-codegen/src/macros/lower/mod.rs
@@ -6,6 +6,7 @@
 pub(crate) mod aggregate_select;
 pub(crate) mod data_input;
 pub(crate) mod data_relation;
+pub(crate) mod having;
 pub(crate) mod include_input;
 pub(crate) mod order_by_input;
 pub(crate) mod scalar_filter;

--- a/prax-codegen/src/macros/ops/aggregate.rs
+++ b/prax-codegen/src/macros/ops/aggregate.rs
@@ -1,0 +1,168 @@
+//! `aggregate!` proc-macro entry point.
+//!
+//! Lowers a `{ where: ..., _count: ..., _sum: ..., _avg: ..., _min: ...,
+//! _max: ... }` brace block into an
+//! `<accessor>.aggregate().with_aggregate_args(<Model>AggregateArgs { ... })`
+//! token stream.
+
+use convert_case::{Case, Casing};
+use proc_macro2::{Span, TokenStream};
+use quote::{format_ident, quote};
+use syn::Token;
+use syn::parse::Parser;
+
+use crate::macros::accessor::parse_accessor;
+use crate::macros::dsl::ast::{DslBlock, DslField, DslValue};
+use crate::macros::lower::LowerCtx;
+use crate::macros::lower::aggregate_select::{AggKind, lower_agg_select};
+use crate::macros::lower::where_input::lower_where_input_only;
+use crate::macros::schema_resolve::{resolve_schema, resolve_schema_path, track_schema_dep};
+use crate::macros::validate::unknown_top_key_error;
+
+const AGGREGATE_KEYS: &[&str] = &["where", "_count", "_sum", "_avg", "_min", "_max"];
+
+pub fn expand_aggregate(input: TokenStream) -> syn::Result<TokenStream> {
+    let schema = resolve_schema()?;
+    let schema_path = resolve_schema_path()?;
+    let dep = track_schema_dep(&schema_path);
+
+    let parser = move |s: syn::parse::ParseStream<'_>| -> syn::Result<TokenStream> {
+        let (accessor, model) = parse_accessor(s, &schema)?;
+        if s.peek(Token![,]) {
+            let _: Token![,] = s.parse()?;
+        }
+        let block: DslBlock = s.parse()?;
+        let ctx = LowerCtx::new(&schema, model);
+        lower_aggregate(&accessor, &block, &ctx)
+    };
+    let body = Parser::parse2(parser, input)?;
+    Ok(quote! {
+        {
+            #dep
+            #body
+        }
+    })
+}
+
+fn lower_aggregate(
+    accessor: &crate::macros::accessor::AccessorSpec,
+    block: &DslBlock,
+    ctx: &LowerCtx<'_>,
+) -> syn::Result<TokenStream> {
+    let mut where_block: Option<&DslBlock> = None;
+    let mut count_block: Option<&DslBlock> = None;
+    let mut sum_block: Option<&DslBlock> = None;
+    let mut avg_block: Option<&DslBlock> = None;
+    let mut min_block: Option<&DslBlock> = None;
+    let mut max_block: Option<&DslBlock> = None;
+
+    for field in &block.fields {
+        let DslField::Pair { key, value, .. } = field else {
+            return Err(syn::Error::new(
+                Span::call_site(),
+                "`aggregate!` does not accept spread or conditional fields at the top level",
+            ));
+        };
+        let key_str = key.to_string();
+        match key_str.as_str() {
+            "where" => {
+                let DslValue::Block(b) = value else {
+                    return Err(syn::Error::new(key.span(), "`where:` expects `{ ... }`"));
+                };
+                where_block = Some(b);
+            }
+            "_count" => {
+                let DslValue::Block(b) = value else {
+                    return Err(syn::Error::new(key.span(), "`_count:` expects `{ ... }`"));
+                };
+                count_block = Some(b);
+            }
+            "_sum" => {
+                let DslValue::Block(b) = value else {
+                    return Err(syn::Error::new(key.span(), "`_sum:` expects `{ ... }`"));
+                };
+                sum_block = Some(b);
+            }
+            "_avg" => {
+                let DslValue::Block(b) = value else {
+                    return Err(syn::Error::new(key.span(), "`_avg:` expects `{ ... }`"));
+                };
+                avg_block = Some(b);
+            }
+            "_min" => {
+                let DslValue::Block(b) = value else {
+                    return Err(syn::Error::new(key.span(), "`_min:` expects `{ ... }`"));
+                };
+                min_block = Some(b);
+            }
+            "_max" => {
+                let DslValue::Block(b) = value else {
+                    return Err(syn::Error::new(key.span(), "`_max:` expects `{ ... }`"));
+                };
+                max_block = Some(b);
+            }
+            _ => {
+                return Err(unknown_top_key_error(
+                    &key_str,
+                    key.span(),
+                    AGGREGATE_KEYS,
+                    "aggregate",
+                ));
+            }
+        }
+    }
+
+    if count_block.is_none()
+        && sum_block.is_none()
+        && avg_block.is_none()
+        && min_block.is_none()
+        && max_block.is_none()
+    {
+        return Err(syn::Error::new(
+            Span::call_site(),
+            "aggregate! requires at least one of _count, _sum, _avg, _min, _max",
+        ));
+    }
+
+    let lower_opt = |k: AggKind, b: Option<&DslBlock>| -> syn::Result<TokenStream> {
+        match b {
+            Some(blk) => {
+                let ts = lower_agg_select(k, blk, ctx)?;
+                Ok(quote! { ::core::option::Option::Some(#ts) })
+            }
+            None => Ok(quote! { ::core::option::Option::None }),
+        }
+    };
+
+    let count_ts = lower_opt(AggKind::Count, count_block)?;
+    let sum_ts = lower_opt(AggKind::Sum, sum_block)?;
+    let avg_ts = lower_opt(AggKind::Avg, avg_block)?;
+    let min_ts = lower_opt(AggKind::Min, min_block)?;
+    let max_ts = lower_opt(AggKind::Max, max_block)?;
+
+    let where_ts = match where_block {
+        Some(wb) => {
+            let w = lower_where_input_only(wb, ctx)?;
+            quote! { ::core::option::Option::Some(#w) }
+        }
+        None => quote! { ::core::option::Option::None },
+    };
+
+    let module_ident = format_ident!("{}", ctx.model.name().to_case(Case::Snake));
+    let args_ident = format_ident!("{}AggregateArgs", ctx.model.name());
+    let accessor_expr = &accessor.accessor_expr;
+
+    Ok(quote! {
+        {
+            let __args: #module_ident::#args_ident = #module_ident::#args_ident {
+                where_input: #where_ts,
+                _count: #count_ts,
+                _sum: #sum_ts,
+                _avg: #avg_ts,
+                _min: #min_ts,
+                _max: #max_ts,
+            };
+            (#accessor_expr).aggregate().with_aggregate_args(__args)
+        }
+    })
+}

--- a/prax-codegen/src/macros/ops/count.rs
+++ b/prax-codegen/src/macros/ops/count.rs
@@ -1,23 +1,20 @@
 //! `count!` proc-macro entry point.
-//!
-//! The runtime `CountOperation` only supports `where:` (plus an
-//! internal `distinct` column for future use). The DSL accepts
-//! `where:` only. `select:` (for the Prisma-style `_count`
-//! aggregate-spec) is rejected with a phase-6 marker, per the plan.
 
+use convert_case::{Case, Casing};
 use proc_macro2::{Span, TokenStream};
-use quote::quote;
+use quote::{format_ident, quote};
 use syn::Token;
 use syn::parse::Parser;
 
 use crate::macros::accessor::parse_accessor;
 use crate::macros::dsl::ast::{DslBlock, DslField, DslValue};
 use crate::macros::lower::LowerCtx;
+use crate::macros::lower::aggregate_select::{AggKind, lower_agg_select};
 use crate::macros::lower::where_input::lower_where_input_only;
 use crate::macros::schema_resolve::{resolve_schema, resolve_schema_path, track_schema_dep};
 use crate::macros::validate::unknown_top_key_error;
 
-const COUNT_KEYS: &[&str] = &["where"];
+const COUNT_KEYS: &[&str] = &["where", "select"];
 
 pub fn expand_count(input: TokenStream) -> syn::Result<TokenStream> {
     let schema = resolve_schema()?;
@@ -47,7 +44,8 @@ fn lower_count(
     block: &DslBlock,
     ctx: &LowerCtx<'_>,
 ) -> syn::Result<TokenStream> {
-    let mut where_tokens: Option<TokenStream> = None;
+    let mut where_block: Option<&DslBlock> = None;
+    let mut select_block: Option<&DslBlock> = None;
 
     for field in &block.fields {
         let DslField::Pair { key, value, .. } = field else {
@@ -62,14 +60,13 @@ fn lower_count(
                 let DslValue::Block(b) = value else {
                     return Err(syn::Error::new(key.span(), "`where:` expects `{ ... }`"));
                 };
-                where_tokens = Some(lower_where_input_only(b, ctx)?);
+                where_block = Some(b);
             }
             "select" => {
-                return Err(syn::Error::new(
-                    key.span(),
-                    "`select:` on `count!` (Prisma-style `_count` aggregate) is a phase-6 feature \
-                     not yet implemented. Track progress in the typed-query-traits design.",
-                ));
+                let DslValue::Block(b) = value else {
+                    return Err(syn::Error::new(key.span(), "`select:` expects `{ ... }`"));
+                };
+                select_block = Some(b);
             }
             _ => {
                 return Err(unknown_top_key_error(
@@ -83,8 +80,36 @@ fn lower_count(
     }
 
     let accessor_expr = &accessor.accessor_expr;
+
+    if let Some(sel_block) = select_block {
+        let count_select_ts = lower_agg_select(AggKind::Count, sel_block, ctx)?;
+
+        let where_ts = match where_block {
+            Some(wb) => {
+                let w = lower_where_input_only(wb, ctx)?;
+                quote! { ::core::option::Option::Some(#w) }
+            }
+            None => quote! { ::core::option::Option::None },
+        };
+
+        let module_ident = format_ident!("{}", ctx.model.name().to_case(Case::Snake));
+        let args_ident = format_ident!("{}AggregateArgs", ctx.model.name());
+
+        return Ok(quote! {
+            {
+                let __args: #module_ident::#args_ident = #module_ident::#args_ident {
+                    where_input: #where_ts,
+                    _count: ::core::option::Option::Some(#count_select_ts),
+                    .. ::core::default::Default::default()
+                };
+                (#accessor_expr).aggregate().with_aggregate_args(__args)
+            }
+        });
+    }
+
     let mut chain: Vec<TokenStream> = Vec::new();
-    if let Some(w) = where_tokens {
+    if let Some(wb) = where_block {
+        let w = lower_where_input_only(wb, ctx)?;
         chain.push(quote! { .with_where_input(#w) });
     }
     Ok(quote! {

--- a/prax-codegen/src/macros/ops/group_by.rs
+++ b/prax-codegen/src/macros/ops/group_by.rs
@@ -1,0 +1,273 @@
+//! `group_by!` proc-macro entry point.
+//!
+//! Lowers a `{ by: [...], where: ..., _count: ..., _sum: ..., _avg: ...,
+//! _min: ..., _max: ..., having: ... }` brace block into a
+//! `<accessor>.group_by_columns(by).with_group_by_args(<Model>GroupByArgs { ... })`
+//! token stream.
+
+use convert_case::{Case, Casing};
+use proc_macro2::{Span, TokenStream};
+use quote::{format_ident, quote};
+use syn::Token;
+use syn::parse::Parser;
+
+use crate::macros::accessor::parse_accessor;
+use crate::macros::dsl::ast::{DslBlock, DslField, DslValue};
+use crate::macros::lower::LowerCtx;
+use crate::macros::lower::aggregate_select::{AggKind, lower_agg_select};
+use crate::macros::lower::having::lower_having;
+use crate::macros::lower::where_input::lower_where_input_only;
+use crate::macros::schema_resolve::{resolve_schema, resolve_schema_path, track_schema_dep};
+use crate::macros::validate::unknown_top_key_error;
+
+const GROUP_BY_KEYS: &[&str] = &[
+    "by", "where", "_count", "_sum", "_avg", "_min", "_max", "having", "order_by",
+];
+
+pub fn expand_group_by(input: TokenStream) -> syn::Result<TokenStream> {
+    let schema = resolve_schema()?;
+    let schema_path = resolve_schema_path()?;
+    let dep = track_schema_dep(&schema_path);
+
+    let parser = move |s: syn::parse::ParseStream<'_>| -> syn::Result<TokenStream> {
+        let (accessor, model) = parse_accessor(s, &schema)?;
+        if s.peek(Token![,]) {
+            let _: Token![,] = s.parse()?;
+        }
+        let block: DslBlock = s.parse()?;
+        let ctx = LowerCtx::new(&schema, model);
+        lower_group_by(&accessor, &block, &ctx)
+    };
+    let body = Parser::parse2(parser, input)?;
+    Ok(quote! {
+        {
+            #dep
+            #body
+        }
+    })
+}
+
+fn lower_group_by(
+    accessor: &crate::macros::accessor::AccessorSpec,
+    block: &DslBlock,
+    ctx: &LowerCtx<'_>,
+) -> syn::Result<TokenStream> {
+    let mut by_value: Option<(&DslValue, proc_macro2::Span)> = None;
+    let mut where_block: Option<&DslBlock> = None;
+    let mut count_block: Option<&DslBlock> = None;
+    let mut sum_block: Option<&DslBlock> = None;
+    let mut avg_block: Option<&DslBlock> = None;
+    let mut min_block: Option<&DslBlock> = None;
+    let mut max_block: Option<&DslBlock> = None;
+    let mut having_block: Option<&DslBlock> = None;
+
+    for field in &block.fields {
+        let DslField::Pair { key, value, .. } = field else {
+            return Err(syn::Error::new(
+                Span::call_site(),
+                "`group_by!` does not accept spread or conditional fields at the top level",
+            ));
+        };
+        let key_str = key.to_string();
+        match key_str.as_str() {
+            "by" => {
+                by_value = Some((value, key.span()));
+            }
+            "where" => {
+                let DslValue::Block(b) = value else {
+                    return Err(syn::Error::new(key.span(), "`where:` expects `{ ... }`"));
+                };
+                where_block = Some(b);
+            }
+            "_count" => {
+                let DslValue::Block(b) = value else {
+                    return Err(syn::Error::new(key.span(), "`_count:` expects `{ ... }`"));
+                };
+                count_block = Some(b);
+            }
+            "_sum" => {
+                let DslValue::Block(b) = value else {
+                    return Err(syn::Error::new(key.span(), "`_sum:` expects `{ ... }`"));
+                };
+                sum_block = Some(b);
+            }
+            "_avg" => {
+                let DslValue::Block(b) = value else {
+                    return Err(syn::Error::new(key.span(), "`_avg:` expects `{ ... }`"));
+                };
+                avg_block = Some(b);
+            }
+            "_min" => {
+                let DslValue::Block(b) = value else {
+                    return Err(syn::Error::new(key.span(), "`_min:` expects `{ ... }`"));
+                };
+                min_block = Some(b);
+            }
+            "_max" => {
+                let DslValue::Block(b) = value else {
+                    return Err(syn::Error::new(key.span(), "`_max:` expects `{ ... }`"));
+                };
+                max_block = Some(b);
+            }
+            "having" => {
+                let DslValue::Block(b) = value else {
+                    return Err(syn::Error::new(key.span(), "`having:` expects `{ ... }`"));
+                };
+                having_block = Some(b);
+            }
+            "order_by" => {
+                return Err(syn::Error::new(
+                    key.span(),
+                    "`order_by:` on group_by! is not yet implemented in phase 6 — tracked as a follow-up",
+                ));
+            }
+            _ => {
+                return Err(unknown_top_key_error(
+                    &key_str,
+                    key.span(),
+                    GROUP_BY_KEYS,
+                    "group_by",
+                ));
+            }
+        }
+    }
+
+    let (by_val, by_span) = by_value.ok_or_else(|| {
+        syn::Error::new(
+            Span::call_site(),
+            "group_by! requires a `by: [...]` list of columns",
+        )
+    })?;
+
+    let items = match by_val {
+        DslValue::List(items) => items.as_slice(),
+        _ => {
+            return Err(syn::Error::new(
+                by_span,
+                "`by:` value must be a `[col1, col2]` list",
+            ));
+        }
+    };
+
+    if items.is_empty() {
+        return Err(syn::Error::new(
+            by_span,
+            "group_by! requires at least one column in `by:`",
+        ));
+    }
+
+    let model_name = ctx.model.name();
+    let columns_enum = format_ident!("{}GroupByColumn", model_name);
+    let module_ident = format_ident!("{}", model_name.to_case(Case::Snake));
+
+    let mut by_variants: Vec<TokenStream> = Vec::new();
+    for item in items {
+        let col_str = match item {
+            DslValue::BareIdent(i) => i.to_string(),
+            _ => {
+                return Err(syn::Error::new(
+                    by_span,
+                    "`by:` items must be bare column identifiers",
+                ));
+            }
+        };
+
+        let field = ctx.model.get_field(&col_str).ok_or_else(|| {
+            let candidates: Vec<String> = ctx.model.fields.keys().map(|k| k.to_string()).collect();
+            let suggestion = crate::macros::validate::suggest(&col_str, &candidates);
+            let msg = match suggestion {
+                Some(s) => format!("unknown column `{}`; did you mean `{}`?", col_str, s),
+                None => format!("unknown column `{}`", col_str),
+            };
+            syn::Error::new(by_span, msg)
+        })?;
+
+        if field.is_relation() {
+            return Err(syn::Error::new(
+                by_span,
+                format!(
+                    "by-column `{}` is a relation; group_by! requires scalar columns",
+                    col_str
+                ),
+            ));
+        }
+
+        let variant = format_ident!("{}", to_pascal_case(&col_str));
+        by_variants.push(quote! { #module_ident::#columns_enum::#variant });
+    }
+
+    let lower_opt = |k: AggKind, b: Option<&DslBlock>| -> syn::Result<TokenStream> {
+        match b {
+            Some(blk) => {
+                let ts = lower_agg_select(k, blk, ctx)?;
+                Ok(quote! { ::core::option::Option::Some(#ts) })
+            }
+            None => Ok(quote! { ::core::option::Option::None }),
+        }
+    };
+
+    let count_ts = lower_opt(AggKind::Count, count_block)?;
+    let sum_ts = lower_opt(AggKind::Sum, sum_block)?;
+    let avg_ts = lower_opt(AggKind::Avg, avg_block)?;
+    let min_ts = lower_opt(AggKind::Min, min_block)?;
+    let max_ts = lower_opt(AggKind::Max, max_block)?;
+
+    let where_ts = match where_block {
+        Some(wb) => {
+            let w = lower_where_input_only(wb, ctx)?;
+            quote! { ::core::option::Option::Some(#w) }
+        }
+        None => quote! { ::core::option::Option::None },
+    };
+
+    let having_ts = match having_block {
+        Some(hb) => {
+            let conds = lower_having(hb, ctx)?;
+            let having_ty = format_ident!("{}GroupByHaving", model_name);
+            quote! {
+                ::core::option::Option::Some(#module_ident::#having_ty {
+                    conditions: #conds,
+                })
+            }
+        }
+        None => quote! { ::core::option::Option::None },
+    };
+
+    let args_ident = format_ident!("{}GroupByArgs", model_name);
+    let accessor_expr = &accessor.accessor_expr;
+
+    Ok(quote! {
+        {
+            let __by: ::std::vec::Vec<#module_ident::#columns_enum> =
+                ::std::vec![#(#by_variants),*];
+            let __args: #module_ident::#args_ident = #module_ident::#args_ident {
+                by: __by.clone(),
+                where_input: #where_ts,
+                _count: #count_ts,
+                _sum: #sum_ts,
+                _avg: #avg_ts,
+                _min: #min_ts,
+                _max: #max_ts,
+                having: #having_ts,
+                order_by: ::core::option::Option::None,
+            };
+            (#accessor_expr).group_by_columns(__by).with_group_by_args(__args)
+        }
+    })
+}
+
+fn to_pascal_case(snake: &str) -> String {
+    let mut out = String::with_capacity(snake.len());
+    let mut upper = true;
+    for c in snake.chars() {
+        if c == '_' {
+            upper = true;
+        } else if upper {
+            out.push(c.to_ascii_uppercase());
+            upper = false;
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}

--- a/prax-codegen/src/macros/ops/mod.rs
+++ b/prax-codegen/src/macros/ops/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod delete_many;
 pub(crate) mod find_first;
 pub(crate) mod find_many;
 pub(crate) mod find_unique;
+pub(crate) mod group_by;
 pub(crate) mod shape;
 pub(crate) mod update;
 pub(crate) mod update_many;

--- a/prax-codegen/src/macros/ops/mod.rs
+++ b/prax-codegen/src/macros/ops/mod.rs
@@ -4,6 +4,7 @@
 //! top-level `#[proc_macro] fn <op>` wrapper in `lib.rs` calls.
 //! Filled in by tasks 13-15.
 
+pub(crate) mod aggregate;
 pub(crate) mod count;
 pub(crate) mod create;
 pub(crate) mod create_many;

--- a/prax-codegen/tests/ui/aggregate_no_blocks_fail.rs
+++ b/prax-codegen/tests/ui/aggregate_no_blocks_fail.rs
@@ -1,0 +1,9 @@
+// Fixture: aggregate! with no aggregate block (_count/_sum/_avg/_min/_max)
+// Expected diagnostic: "aggregate! requires at least one of _count, _sum, _avg, _min, _max"
+
+fn main() {
+    let client = ();
+    let _ = prax_codegen::aggregate!(client.user, {
+        where: { id: 1 },
+    });
+}

--- a/prax-codegen/tests/ui/aggregate_no_blocks_fail.stderr
+++ b/prax-codegen/tests/ui/aggregate_no_blocks_fail.stderr
@@ -1,0 +1,10 @@
+error: aggregate! requires at least one of _count, _sum, _avg, _min, _max
+ --> tests/ui/aggregate_no_blocks_fail.rs:6:13
+  |
+6 |       let _ = prax_codegen::aggregate!(client.user, {
+  |  _____________^
+7 | |         where: { id: 1 },
+8 | |     });
+  | |______^
+  |
+  = note: this error originates in the macro `prax_codegen::aggregate` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/prax-codegen/tests/ui/aggregate_sum_on_string_fail.rs
+++ b/prax-codegen/tests/ui/aggregate_sum_on_string_fail.rs
@@ -1,0 +1,9 @@
+// Fixture: aggregate! with _sum applied to a String column (email)
+// Expected diagnostic: "is not numeric; `_sum` requires a numeric column"
+
+fn main() {
+    let client = ();
+    let _ = prax_codegen::aggregate!(client.user, {
+        _sum: { email: true },
+    });
+}

--- a/prax-codegen/tests/ui/aggregate_sum_on_string_fail.stderr
+++ b/prax-codegen/tests/ui/aggregate_sum_on_string_fail.stderr
@@ -1,0 +1,5 @@
+error: field `email` is not numeric; `_sum` requires a numeric column (Int, BigInt, Float, or Decimal)
+ --> tests/ui/aggregate_sum_on_string_fail.rs:7:17
+  |
+7 |         _sum: { email: true },
+  |                 ^^^^^

--- a/prax-codegen/tests/ui/aggregate_unknown_column_fail.rs
+++ b/prax-codegen/tests/ui/aggregate_unknown_column_fail.rs
@@ -1,0 +1,9 @@
+// Fixture: aggregate! with an unknown column inside a _count block
+// Expected diagnostic: "unknown column `notacol`"
+
+fn main() {
+    let client = ();
+    let _ = prax_codegen::aggregate!(client.user, {
+        _count: { notacol: true },
+    });
+}

--- a/prax-codegen/tests/ui/aggregate_unknown_column_fail.stderr
+++ b/prax-codegen/tests/ui/aggregate_unknown_column_fail.stderr
@@ -1,0 +1,5 @@
+error: unknown column `notacol` on model `User`
+ --> tests/ui/aggregate_unknown_column_fail.rs:7:19
+  |
+7 |         _count: { notacol: true },
+  |                   ^^^^^^^

--- a/prax-codegen/tests/ui/aggregate_unknown_key_fail.rs
+++ b/prax-codegen/tests/ui/aggregate_unknown_key_fail.rs
@@ -1,0 +1,9 @@
+// Fixture: aggregate! with an unknown top-level key
+// Expected diagnostic: "unknown key `_foo`"
+
+fn main() {
+    let client = ();
+    let _ = prax_codegen::aggregate!(client.user, {
+        _foo: { id: true },
+    });
+}

--- a/prax-codegen/tests/ui/aggregate_unknown_key_fail.stderr
+++ b/prax-codegen/tests/ui/aggregate_unknown_key_fail.stderr
@@ -1,0 +1,5 @@
+error: unknown top-level key `_foo` for `aggregate!`. Allowed keys: ["where", "_count", "_sum", "_avg", "_min", "_max"]
+ --> tests/ui/aggregate_unknown_key_fail.rs:7:9
+  |
+7 |         _foo: { id: true },
+  |         ^^^^

--- a/prax-codegen/tests/ui/aggregate_value_not_true_fail.rs
+++ b/prax-codegen/tests/ui/aggregate_value_not_true_fail.rs
@@ -1,0 +1,9 @@
+// Fixture: aggregate! with a non-true value inside a _count block
+// Expected diagnostic: "must be `true`"
+
+fn main() {
+    let client = ();
+    let _ = prax_codegen::aggregate!(client.user, {
+        _count: { email: false },
+    });
+}

--- a/prax-codegen/tests/ui/aggregate_value_not_true_fail.stderr
+++ b/prax-codegen/tests/ui/aggregate_value_not_true_fail.stderr
@@ -1,0 +1,5 @@
+error: value for `_count.email` must be `true` (only opt-in is supported)
+ --> tests/ui/aggregate_value_not_true_fail.rs:7:19
+  |
+7 |         _count: { email: false },
+  |                   ^^^^^

--- a/prax-codegen/tests/ui/count_select_value_not_true_fail.rs
+++ b/prax-codegen/tests/ui/count_select_value_not_true_fail.rs
@@ -1,0 +1,9 @@
+// Fixture: count! with a non-true value inside a select: block
+// Expected diagnostic: "must be `true`"
+
+fn main() {
+    let client = ();
+    let _ = prax_codegen::count!(client.user, {
+        select: { email: 5 },
+    });
+}

--- a/prax-codegen/tests/ui/count_select_value_not_true_fail.stderr
+++ b/prax-codegen/tests/ui/count_select_value_not_true_fail.stderr
@@ -1,0 +1,5 @@
+error: value for `_count.email` must be `true` (only opt-in is supported)
+ --> tests/ui/count_select_value_not_true_fail.rs:7:19
+  |
+7 |         select: { email: 5 },
+  |                   ^^^^^

--- a/prax-codegen/tests/ui/group_by_empty_by_fail.rs
+++ b/prax-codegen/tests/ui/group_by_empty_by_fail.rs
@@ -1,0 +1,10 @@
+// Fixture: group_by! with an empty by: list
+// Expected diagnostic: "group_by! requires at least one column in `by:`"
+
+fn main() {
+    let client = ();
+    let _ = prax_codegen::group_by!(client.user, {
+        by: [],
+        _count: { _all: true },
+    });
+}

--- a/prax-codegen/tests/ui/group_by_empty_by_fail.stderr
+++ b/prax-codegen/tests/ui/group_by_empty_by_fail.stderr
@@ -1,0 +1,5 @@
+error: group_by! requires at least one column in `by:`
+ --> tests/ui/group_by_empty_by_fail.rs:7:9
+  |
+7 |         by: [],
+  |         ^^

--- a/prax-codegen/tests/ui/group_by_missing_by_fail.rs
+++ b/prax-codegen/tests/ui/group_by_missing_by_fail.rs
@@ -1,0 +1,9 @@
+// Fixture: group_by! with no by: key at all
+// Expected diagnostic: "group_by! requires a `by: [...]` list"
+
+fn main() {
+    let client = ();
+    let _ = prax_codegen::group_by!(client.user, {
+        _count: { _all: true },
+    });
+}

--- a/prax-codegen/tests/ui/group_by_missing_by_fail.stderr
+++ b/prax-codegen/tests/ui/group_by_missing_by_fail.stderr
@@ -1,0 +1,10 @@
+error: group_by! requires a `by: [...]` list of columns
+ --> tests/ui/group_by_missing_by_fail.rs:6:13
+  |
+6 |       let _ = prax_codegen::group_by!(client.user, {
+  |  _____________^
+7 | |         _count: { _all: true },
+8 | |     });
+  | |______^
+  |
+  = note: this error originates in the macro `prax_codegen::group_by` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/prax-codegen/tests/ui/group_by_order_by_deferred_fail.rs
+++ b/prax-codegen/tests/ui/group_by_order_by_deferred_fail.rs
@@ -1,0 +1,11 @@
+// Fixture: group_by! with order_by: which is not yet implemented
+// Expected diagnostic: "`order_by:` on group_by! is not yet implemented in phase 6"
+
+fn main() {
+    let client = ();
+    let _ = prax_codegen::group_by!(client.user, {
+        by: [id],
+        _count: { _all: true },
+        order_by: { _sum: { age: desc } },
+    });
+}

--- a/prax-codegen/tests/ui/group_by_order_by_deferred_fail.stderr
+++ b/prax-codegen/tests/ui/group_by_order_by_deferred_fail.stderr
@@ -1,0 +1,5 @@
+error: `order_by:` on group_by! is not yet implemented in phase 6 — tracked as a follow-up
+ --> tests/ui/group_by_order_by_deferred_fail.rs:9:9
+  |
+9 |         order_by: { _sum: { age: desc } },
+  |         ^^^^^^^^

--- a/prax-codegen/tests/ui/group_by_unknown_by_column_fail.rs
+++ b/prax-codegen/tests/ui/group_by_unknown_by_column_fail.rs
@@ -1,0 +1,10 @@
+// Fixture: group_by! with an unknown column in the by: list
+// Expected diagnostic: "unknown column `notacol`"
+
+fn main() {
+    let client = ();
+    let _ = prax_codegen::group_by!(client.user, {
+        by: [notacol],
+        _count: { _all: true },
+    });
+}

--- a/prax-codegen/tests/ui/group_by_unknown_by_column_fail.stderr
+++ b/prax-codegen/tests/ui/group_by_unknown_by_column_fail.stderr
@@ -1,0 +1,5 @@
+error: unknown column `notacol`
+ --> tests/ui/group_by_unknown_by_column_fail.rs:7:9
+  |
+7 |         by: [notacol],
+  |         ^^

--- a/prax-postgres/tests/aggregate_macros.rs
+++ b/prax-postgres/tests/aggregate_macros.rs
@@ -1,0 +1,323 @@
+//! Live Postgres integration for phase-6 aggregate operations.
+//! Gated #[ignore] — requires PRAX_E2E=1 and POSTGRES_URL.
+//! Run: PRAX_E2E=1 POSTGRES_URL=... cargo test -p prax-postgres --test aggregate_macros -- --ignored
+//!
+//! Exercises the runtime AggregateOperation / GroupByOperation (what the
+//! aggregate!/group_by!/count! macros lower to) against real Postgres.
+//! The macro front-end is covered by trybuild fixtures (compile-level)
+//! and the codegen unit tests; the schema-path relation_helpers bug
+//! prevents end-to-end macro use in a test crate (see
+//! tests/aggregate_macros_e2e.rs).
+//!
+//! Because Model::TABLE_NAME is a `&'static str` const we cannot set it to a
+//! runtime-generated unique table name.  Tests therefore call
+//! `AggregateOperation::build_sql` / `GroupByOperation::build_sql` for the
+//! SQL shape and then execute via the raw `QueryEngine::aggregate_query` path,
+//! swapping the static TABLE_NAME for the dynamic table name in the SQL
+//! string.  This is the same execution path that `exec()` takes internally.
+
+#![cfg(test)]
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Duration;
+
+use prax_postgres::{PgEngine, PgPool, PgPoolBuilder};
+use prax_query::filter::FilterValue;
+use prax_query::operations::having;
+use prax_query::operations::{
+    AggregateOperation, AggregateResult, GroupByOperation, GroupByResult,
+};
+use prax_query::traits::{Model, QueryEngine};
+
+// =============================================================================
+// Harness (mirrors computed_fields.rs)
+// =============================================================================
+
+static TABLE_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn unique_table(prefix: &str) -> String {
+    let n = TABLE_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let pid = std::process::id();
+    format!("agg_{prefix}_{pid}_{n}")
+}
+
+fn skip_unless_e2e() -> Option<String> {
+    if std::env::var("PRAX_E2E").ok().as_deref() != Some("1") {
+        return None;
+    }
+    std::env::var("POSTGRES_URL").ok()
+}
+
+async fn pool() -> PgPool {
+    let url = skip_unless_e2e().expect("PRAX_E2E=1 and POSTGRES_URL required");
+    PgPoolBuilder::new()
+        .url(url)
+        .max_connections(4)
+        .connection_timeout(Duration::from_secs(10))
+        .build()
+        .await
+        .expect("connect to postgres")
+}
+
+async fn drop_table(pool: &PgPool, table: &str) {
+    let conn = pool.get().await.expect("acquire conn for cleanup");
+    let _ = conn
+        .batch_execute(&format!("DROP TABLE IF EXISTS {table}"))
+        .await;
+}
+
+// =============================================================================
+// Minimal Model stubs required by the typed operation builders.
+// =============================================================================
+
+struct CountModel;
+impl Model for CountModel {
+    const MODEL_NAME: &'static str = "CountModel";
+    const TABLE_NAME: &'static str = "count_model_placeholder";
+    const PRIMARY_KEY: &'static [&'static str] = &["id"];
+    const COLUMNS: &'static [&'static str] = &["id", "email"];
+}
+
+struct ScoreModel;
+impl Model for ScoreModel {
+    const MODEL_NAME: &'static str = "ScoreModel";
+    const TABLE_NAME: &'static str = "score_model_placeholder";
+    const PRIMARY_KEY: &'static [&'static str] = &["id"];
+    const COLUMNS: &'static [&'static str] = &["id", "score"];
+}
+
+struct TeamModel;
+impl Model for TeamModel {
+    const MODEL_NAME: &'static str = "TeamModel";
+    const TABLE_NAME: &'static str = "team_model_placeholder";
+    const PRIMARY_KEY: &'static [&'static str] = &["id"];
+    const COLUMNS: &'static [&'static str] = &["id", "team_id", "score"];
+}
+
+// =============================================================================
+// Test 1 — COUNT(*) round-trip
+//
+// Creates a table with 5 rows and verifies COUNT(*) returns 5.
+// =============================================================================
+
+#[tokio::test]
+#[ignore = "requires running PostgreSQL via docker-compose (PRAX_E2E=1 + POSTGRES_URL)"]
+async fn count_select_round_trip() {
+    if skip_unless_e2e().is_none() {
+        eprintln!("skipping: PRAX_E2E not set");
+        return;
+    }
+    let pool = pool().await;
+    let table = unique_table("count");
+    drop_table(&pool, &table).await;
+
+    {
+        let conn = pool.get().await.expect("conn");
+        conn.batch_execute(&format!(
+            "CREATE TABLE {table} (id SERIAL PRIMARY KEY, email TEXT)"
+        ))
+        .await
+        .expect("create table");
+
+        // 3 rows with email, 2 with NULL
+        conn.batch_execute(&format!(
+            "INSERT INTO {table} (email) VALUES \
+             ('a@example.com'), ('b@example.com'), ('c@example.com'), (NULL), (NULL)"
+        ))
+        .await
+        .expect("insert rows");
+    }
+
+    let engine = PgEngine::new(pool.clone());
+    let dialect = engine.dialect();
+
+    // Build SQL via the operation builder, then swap in the real table name.
+    let op: AggregateOperation<CountModel, PgEngine> = AggregateOperation::new().count();
+    let (sql, params) = op.build_sql(dialect);
+    let sql = sql.replace(CountModel::TABLE_NAME, &table);
+
+    let mut rows = engine
+        .aggregate_query(&sql, params)
+        .await
+        .expect("aggregate_query");
+
+    let result = AggregateResult::from_row(rows.pop().unwrap_or_default());
+
+    assert_eq!(
+        result.count,
+        Some(5),
+        "COUNT(*) should be 5 (includes NULLs)"
+    );
+
+    drop_table(&pool, &table).await;
+}
+
+// =============================================================================
+// Test 2 — SUM / AVG / COUNT(*) round-trip
+//
+// Inserts scores 10, 20, 30 and validates aggregate results.
+// =============================================================================
+
+#[tokio::test]
+#[ignore = "requires running PostgreSQL via docker-compose (PRAX_E2E=1 + POSTGRES_URL)"]
+async fn aggregate_sum_avg_count_round_trip() {
+    if skip_unless_e2e().is_none() {
+        eprintln!("skipping: PRAX_E2E not set");
+        return;
+    }
+    let pool = pool().await;
+    let table = unique_table("score");
+    drop_table(&pool, &table).await;
+
+    {
+        let conn = pool.get().await.expect("conn");
+        conn.batch_execute(&format!(
+            "CREATE TABLE {table} (id SERIAL PRIMARY KEY, score INT NOT NULL)"
+        ))
+        .await
+        .expect("create table");
+
+        conn.batch_execute(&format!(
+            "INSERT INTO {table} (score) VALUES (10), (20), (30)"
+        ))
+        .await
+        .expect("insert rows");
+    }
+
+    let engine = PgEngine::new(pool.clone());
+    let dialect = engine.dialect();
+
+    let op: AggregateOperation<ScoreModel, PgEngine> =
+        AggregateOperation::new().count().sum("score").avg("score");
+    let (sql, params) = op.build_sql(dialect);
+    let sql = sql.replace(ScoreModel::TABLE_NAME, &table);
+
+    let mut rows = engine
+        .aggregate_query(&sql, params)
+        .await
+        .expect("aggregate_query");
+
+    let result = AggregateResult::from_row(rows.pop().unwrap_or_default());
+
+    assert_eq!(result.count, Some(3), "COUNT(*) should be 3");
+
+    let sum = result
+        .sum_as_f64("score")
+        .expect("sum(score) should be present");
+    assert!(
+        (sum - 60.0).abs() < 0.001,
+        "SUM(score) should be 60, got {sum}"
+    );
+
+    let avg = result
+        .avg_as_f64("score")
+        .expect("avg(score) should be present");
+    assert!(
+        (avg - 20.0).abs() < 0.001,
+        "AVG(score) should be 20.0, got {avg}"
+    );
+
+    drop_table(&pool, &table).await;
+}
+
+// =============================================================================
+// Test 3 — GROUP BY + HAVING round-trip
+//
+// team 1 → 2 rows, team 2 → 4 rows.
+// HAVING COUNT(*) > 3 should return only team 2 with count == 4.
+// =============================================================================
+
+#[tokio::test]
+#[ignore = "requires running PostgreSQL via docker-compose (PRAX_E2E=1 + POSTGRES_URL)"]
+async fn group_by_with_having_round_trip() {
+    if skip_unless_e2e().is_none() {
+        eprintln!("skipping: PRAX_E2E not set");
+        return;
+    }
+    let pool = pool().await;
+    let table = unique_table("team");
+    drop_table(&pool, &table).await;
+
+    {
+        let conn = pool.get().await.expect("conn");
+        conn.batch_execute(&format!(
+            "CREATE TABLE {table} (id SERIAL PRIMARY KEY, team_id INT NOT NULL, score INT NOT NULL)"
+        ))
+        .await
+        .expect("create table");
+
+        // team 1 → 2 rows, team 2 → 4 rows
+        conn.batch_execute(&format!(
+            "INSERT INTO {table} (team_id, score) VALUES \
+             (1, 10), (1, 20), \
+             (2, 30), (2, 40), (2, 50), (2, 60)"
+        ))
+        .await
+        .expect("insert rows");
+    }
+
+    let engine = PgEngine::new(pool.clone());
+    let dialect = engine.dialect();
+
+    let op: GroupByOperation<TeamModel, PgEngine> =
+        GroupByOperation::new(vec!["team_id".to_string()])
+            .count()
+            .having(having::count_gt(3.0));
+    let (sql, params) = op.build_sql(dialect);
+    let sql = sql.replace(TeamModel::TABLE_NAME, &table);
+
+    let raw_rows = engine
+        .aggregate_query(&sql, params)
+        .await
+        .expect("aggregate_query for group_by");
+
+    // Split raw rows into GroupByResult (same logic as GroupByOperation::exec).
+    let group_columns = ["team_id"];
+    let results: Vec<GroupByResult> = raw_rows
+        .into_iter()
+        .map(|row| {
+            let mut group_values: HashMap<String, serde_json::Value> = HashMap::new();
+            let mut agg_map: HashMap<String, FilterValue> = HashMap::new();
+            for (k, v) in row {
+                if group_columns.contains(&k.as_str()) {
+                    let json_val = match &v {
+                        FilterValue::Int(n) => serde_json::Value::from(*n),
+                        FilterValue::Float(f) => serde_json::json!(*f),
+                        FilterValue::String(s) => serde_json::Value::String(s.clone()),
+                        FilterValue::Bool(b) => serde_json::Value::Bool(*b),
+                        _ => serde_json::Value::Null,
+                    };
+                    group_values.insert(k, json_val);
+                } else {
+                    agg_map.insert(k, v);
+                }
+            }
+            GroupByResult {
+                group_values,
+                aggregates: AggregateResult::from_row(agg_map),
+            }
+        })
+        .collect();
+
+    assert_eq!(
+        results.len(),
+        1,
+        "HAVING COUNT(*) > 3 should return exactly one group"
+    );
+
+    let team_id = results[0]
+        .group_values
+        .get("team_id")
+        .and_then(serde_json::Value::as_i64)
+        .expect("team_id should be present as integer");
+    assert_eq!(team_id, 2, "the surviving group should be team 2");
+
+    let count = results[0]
+        .aggregates
+        .count
+        .expect("COUNT(*) should be present in aggregates");
+    assert_eq!(count, 4, "team 2 has 4 rows");
+
+    drop_table(&pool, &table).await;
+}

--- a/prax-query/src/operations/aggregate.rs
+++ b/prax-query/src/operations/aggregate.rs
@@ -712,7 +712,30 @@ pub mod having {
         }
     }
 
-    /// Create a having condition for sum > value.
+    pub fn count_lte(value: f64) -> HavingCondition {
+        HavingCondition {
+            field: AggregateField::CountAll,
+            op: HavingOp::Lte,
+            value,
+        }
+    }
+
+    pub fn count_eq(value: f64) -> HavingCondition {
+        HavingCondition {
+            field: AggregateField::CountAll,
+            op: HavingOp::Eq,
+            value,
+        }
+    }
+
+    pub fn count_ne(value: f64) -> HavingCondition {
+        HavingCondition {
+            field: AggregateField::CountAll,
+            op: HavingOp::Ne,
+            value,
+        }
+    }
+
     pub fn sum_gt(column: impl Into<String>, value: f64) -> HavingCondition {
         HavingCondition {
             field: AggregateField::Sum(column.into()),
@@ -721,11 +744,186 @@ pub mod having {
         }
     }
 
-    /// Create a having condition for avg > value.
+    pub fn sum_gte(column: impl Into<String>, value: f64) -> HavingCondition {
+        HavingCondition {
+            field: AggregateField::Sum(column.into()),
+            op: HavingOp::Gte,
+            value,
+        }
+    }
+
+    pub fn sum_lt(column: impl Into<String>, value: f64) -> HavingCondition {
+        HavingCondition {
+            field: AggregateField::Sum(column.into()),
+            op: HavingOp::Lt,
+            value,
+        }
+    }
+
+    pub fn sum_lte(column: impl Into<String>, value: f64) -> HavingCondition {
+        HavingCondition {
+            field: AggregateField::Sum(column.into()),
+            op: HavingOp::Lte,
+            value,
+        }
+    }
+
+    pub fn sum_eq(column: impl Into<String>, value: f64) -> HavingCondition {
+        HavingCondition {
+            field: AggregateField::Sum(column.into()),
+            op: HavingOp::Eq,
+            value,
+        }
+    }
+
+    pub fn sum_ne(column: impl Into<String>, value: f64) -> HavingCondition {
+        HavingCondition {
+            field: AggregateField::Sum(column.into()),
+            op: HavingOp::Ne,
+            value,
+        }
+    }
+
     pub fn avg_gt(column: impl Into<String>, value: f64) -> HavingCondition {
         HavingCondition {
             field: AggregateField::Avg(column.into()),
             op: HavingOp::Gt,
+            value,
+        }
+    }
+
+    pub fn avg_gte(column: impl Into<String>, value: f64) -> HavingCondition {
+        HavingCondition {
+            field: AggregateField::Avg(column.into()),
+            op: HavingOp::Gte,
+            value,
+        }
+    }
+
+    pub fn avg_lt(column: impl Into<String>, value: f64) -> HavingCondition {
+        HavingCondition {
+            field: AggregateField::Avg(column.into()),
+            op: HavingOp::Lt,
+            value,
+        }
+    }
+
+    pub fn avg_lte(column: impl Into<String>, value: f64) -> HavingCondition {
+        HavingCondition {
+            field: AggregateField::Avg(column.into()),
+            op: HavingOp::Lte,
+            value,
+        }
+    }
+
+    pub fn avg_eq(column: impl Into<String>, value: f64) -> HavingCondition {
+        HavingCondition {
+            field: AggregateField::Avg(column.into()),
+            op: HavingOp::Eq,
+            value,
+        }
+    }
+
+    pub fn avg_ne(column: impl Into<String>, value: f64) -> HavingCondition {
+        HavingCondition {
+            field: AggregateField::Avg(column.into()),
+            op: HavingOp::Ne,
+            value,
+        }
+    }
+
+    pub fn min_gt(column: impl Into<String>, value: f64) -> HavingCondition {
+        HavingCondition {
+            field: AggregateField::Min(column.into()),
+            op: HavingOp::Gt,
+            value,
+        }
+    }
+
+    pub fn min_gte(column: impl Into<String>, value: f64) -> HavingCondition {
+        HavingCondition {
+            field: AggregateField::Min(column.into()),
+            op: HavingOp::Gte,
+            value,
+        }
+    }
+
+    pub fn min_lt(column: impl Into<String>, value: f64) -> HavingCondition {
+        HavingCondition {
+            field: AggregateField::Min(column.into()),
+            op: HavingOp::Lt,
+            value,
+        }
+    }
+
+    pub fn min_lte(column: impl Into<String>, value: f64) -> HavingCondition {
+        HavingCondition {
+            field: AggregateField::Min(column.into()),
+            op: HavingOp::Lte,
+            value,
+        }
+    }
+
+    pub fn min_eq(column: impl Into<String>, value: f64) -> HavingCondition {
+        HavingCondition {
+            field: AggregateField::Min(column.into()),
+            op: HavingOp::Eq,
+            value,
+        }
+    }
+
+    pub fn min_ne(column: impl Into<String>, value: f64) -> HavingCondition {
+        HavingCondition {
+            field: AggregateField::Min(column.into()),
+            op: HavingOp::Ne,
+            value,
+        }
+    }
+
+    pub fn max_gt(column: impl Into<String>, value: f64) -> HavingCondition {
+        HavingCondition {
+            field: AggregateField::Max(column.into()),
+            op: HavingOp::Gt,
+            value,
+        }
+    }
+
+    pub fn max_gte(column: impl Into<String>, value: f64) -> HavingCondition {
+        HavingCondition {
+            field: AggregateField::Max(column.into()),
+            op: HavingOp::Gte,
+            value,
+        }
+    }
+
+    pub fn max_lt(column: impl Into<String>, value: f64) -> HavingCondition {
+        HavingCondition {
+            field: AggregateField::Max(column.into()),
+            op: HavingOp::Lt,
+            value,
+        }
+    }
+
+    pub fn max_lte(column: impl Into<String>, value: f64) -> HavingCondition {
+        HavingCondition {
+            field: AggregateField::Max(column.into()),
+            op: HavingOp::Lte,
+            value,
+        }
+    }
+
+    pub fn max_eq(column: impl Into<String>, value: f64) -> HavingCondition {
+        HavingCondition {
+            field: AggregateField::Max(column.into()),
+            op: HavingOp::Eq,
+            value,
+        }
+    }
+
+    pub fn max_ne(column: impl Into<String>, value: f64) -> HavingCondition {
+        HavingCondition {
+            field: AggregateField::Max(column.into()),
+            op: HavingOp::Ne,
             value,
         }
     }
@@ -1383,5 +1581,101 @@ mod tests {
 
         // Empty group columns should not produce GROUP BY
         assert!(!sql.contains("GROUP BY"));
+    }
+
+    #[test]
+    fn test_having_count_lte_eq_ne() {
+        let c = having::count_lte(10.0);
+        assert!(matches!(c.field, AggregateField::CountAll));
+        assert!(matches!(c.op, HavingOp::Lte));
+        assert_eq!(c.value, 10.0);
+
+        let c = having::count_eq(5.0);
+        assert!(matches!(c.op, HavingOp::Eq));
+
+        let c = having::count_ne(0.0);
+        assert!(matches!(c.op, HavingOp::Ne));
+    }
+
+    #[test]
+    fn test_having_sum_variants() {
+        let c = having::sum_gte("views", 100.0);
+        assert!(matches!(&c.field, AggregateField::Sum(col) if col == "views"));
+        assert!(matches!(c.op, HavingOp::Gte));
+
+        let c = having::sum_lt("views", 50.0);
+        assert!(matches!(c.op, HavingOp::Lt));
+
+        let c = having::sum_lte("views", 50.0);
+        assert!(matches!(c.op, HavingOp::Lte));
+
+        let c = having::sum_eq("views", 0.0);
+        assert!(matches!(c.op, HavingOp::Eq));
+
+        let c = having::sum_ne("views", 0.0);
+        assert!(matches!(c.op, HavingOp::Ne));
+    }
+
+    #[test]
+    fn test_having_avg_variants() {
+        let c = having::avg_gte("score", 3.5);
+        assert!(matches!(&c.field, AggregateField::Avg(col) if col == "score"));
+        assert!(matches!(c.op, HavingOp::Gte));
+
+        let c = having::avg_lt("score", 2.0);
+        assert!(matches!(c.op, HavingOp::Lt));
+
+        let c = having::avg_lte("score", 2.0);
+        assert!(matches!(c.op, HavingOp::Lte));
+
+        let c = having::avg_eq("score", 5.0);
+        assert!(matches!(c.op, HavingOp::Eq));
+
+        let c = having::avg_ne("score", 0.0);
+        assert!(matches!(c.op, HavingOp::Ne));
+    }
+
+    #[test]
+    fn test_having_min_variants() {
+        let c = having::min_gt("age", 18.0);
+        assert!(matches!(&c.field, AggregateField::Min(col) if col == "age"));
+        assert!(matches!(c.op, HavingOp::Gt));
+
+        let c = having::min_gte("age", 18.0);
+        assert!(matches!(c.op, HavingOp::Gte));
+
+        let c = having::min_lt("age", 65.0);
+        assert!(matches!(c.op, HavingOp::Lt));
+
+        let c = having::min_lte("age", 65.0);
+        assert!(matches!(c.op, HavingOp::Lte));
+
+        let c = having::min_eq("age", 21.0);
+        assert!(matches!(c.op, HavingOp::Eq));
+
+        let c = having::min_ne("age", 0.0);
+        assert!(matches!(c.op, HavingOp::Ne));
+    }
+
+    #[test]
+    fn test_having_max_variants() {
+        let c = having::max_gt("salary", 50000.0);
+        assert!(matches!(&c.field, AggregateField::Max(col) if col == "salary"));
+        assert!(matches!(c.op, HavingOp::Gt));
+
+        let c = having::max_gte("salary", 50000.0);
+        assert!(matches!(c.op, HavingOp::Gte));
+
+        let c = having::max_lt("salary", 200000.0);
+        assert!(matches!(c.op, HavingOp::Lt));
+
+        let c = having::max_lte("salary", 200000.0);
+        assert!(matches!(c.op, HavingOp::Lte));
+
+        let c = having::max_eq("salary", 100000.0);
+        assert!(matches!(c.op, HavingOp::Eq));
+
+        let c = having::max_ne("salary", 0.0);
+        assert!(matches!(c.op, HavingOp::Ne));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -633,6 +633,9 @@ pub use prax_codegen::prax_schema;
 // Read-operation macros (phase 3). See `prax-codegen/src/macros/`.
 pub use prax_codegen::{count, delete, delete_many, find_first, find_many, find_unique};
 
+// Aggregate macros (phase 6). See `prax-codegen/src/macros/ops/aggregate.rs`.
+pub use prax_codegen::aggregate;
+
 // Write-operation macros (phase 5a). See `prax-codegen/src/macros/ops/`.
 pub use prax_codegen::{create, create_many, update, update_many, upsert};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -635,6 +635,7 @@ pub use prax_codegen::{count, delete, delete_many, find_first, find_many, find_u
 
 // Aggregate macros (phase 6). See `prax-codegen/src/macros/ops/aggregate.rs`.
 pub use prax_codegen::aggregate;
+pub use prax_codegen::group_by;
 
 // Write-operation macros (phase 5a). See `prax-codegen/src/macros/ops/`.
 pub use prax_codegen::{create, create_many, update, update_many, upsert};

--- a/tests/aggregate_macros_e2e.rs
+++ b/tests/aggregate_macros_e2e.rs
@@ -1,0 +1,359 @@
+//! End-to-end coverage for phase-6 aggregate macros:
+//!
+//!   - `count!` select: per-column `COUNT(col)` / `COUNT(*)` emission.
+//!   - `aggregate!` all five aggregate functions (SUM/AVG/MIN/MAX/COUNT).
+//!   - `aggregate!` WHERE-clause filtering.
+//!   - `group_by!` GROUP BY clause emission.
+//!   - `group_by!` HAVING clause emission.
+//!   - `aggregate!` omits unspecified aggregate blocks.
+//!
+//! # Design — why we use the runtime API here
+//!
+//! The `aggregate!` / `group_by!` / `count!` macro lowering for aggregate
+//! fields is driven by schema metadata in a `LowerCtx` which requires the
+//! schema to be resolved via `prax_schema!("prax/schema.prax")`.  The
+//! schema-path codegen's `relation_helpers` emit `super::<Model>` paths that
+//! don't resolve in the workspace-root test crate context — a latent issue
+//! documented in `tests/nested_writes_e2e.rs` and `tests/computed_fields_e2e.rs`.
+//!
+//! Derive-style models (using `#[derive(Model)]`) avoid the relation-helper
+//! path issue when no cross-model relations are declared.  However the
+//! `aggregate!`, `group_by!`, and `count!` macros with select still require
+//! `AggregateArgs` / `GroupByArgs` structs that are only emitted by
+//! schema-path codegen, not by the derive macro.  Because of this we use the
+//! runtime builder API (`AggregateOperation` / `GroupByOperation`) directly,
+//! mirroring the approach taken in `computed_fields_e2e.rs`.
+//!
+//! All tests call `build_sql(&Postgres)` (synchronous) to materialise the
+//! operation into SQL — this is the right level for "DSL → SQL emission chain"
+//! tests.  No live engine is needed.
+//!
+//! # TODO (cleanup)
+//!
+//! When the schema-path `relation_helpers` path-resolution bug is fixed AND
+//! the derive macro emits `AggregateArgs` structs, the macro-DSL variants of
+//! these tests can be re-enabled.
+
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+use std::borrow::Cow;
+use std::sync::{Arc, Mutex};
+
+use prax_orm::{Model, client};
+use prax_query::capabilities::{SupportsNestedWrites, SupportsScalarSubqueryInSelect};
+use prax_query::dialect::SqlDialect;
+use prax_query::error::{QueryError, QueryResult};
+use prax_query::filter::{Filter, FilterValue};
+use prax_query::row::{FromRow, RowError, RowRef};
+use prax_query::traits::{BoxFuture, Model as ModelTrait, QueryEngine};
+use prax_query::types::{OrderBy, OrderByField, SortOrder};
+use prax_query::{
+    AggregateField, AggregateOperation, GroupByOperation, HavingCondition, HavingOp, having,
+};
+
+// ── RecordingEngine ───────────────────────────────────────────────────────────
+//
+// Verbatim copy from tests/nested_writes_e2e.rs.
+
+type StatementLog = Arc<Mutex<Vec<(String, Vec<FilterValue>)>>>;
+
+/// Recording mock engine for e2e tests.
+#[derive(Clone)]
+struct RecordingEngine {
+    recorded: StatementLog,
+}
+
+impl RecordingEngine {
+    fn new() -> Self {
+        Self {
+            recorded: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn statements(&self) -> Vec<(String, Vec<FilterValue>)> {
+        self.recorded.lock().unwrap().clone()
+    }
+}
+
+impl QueryEngine for RecordingEngine {
+    fn dialect(&self) -> &dyn SqlDialect {
+        &prax_query::dialect::Postgres
+    }
+    fn query_many<T: ModelTrait + FromRow + Send + 'static>(
+        &self,
+        sql: &str,
+        params: Vec<FilterValue>,
+    ) -> BoxFuture<'_, QueryResult<Vec<T>>> {
+        let recorded = self.recorded.clone();
+        let sql = sql.to_string();
+        Box::pin(async move {
+            recorded.lock().unwrap().push((sql, params));
+            Ok(Vec::new())
+        })
+    }
+    fn query_one<T: ModelTrait + FromRow + Send + 'static>(
+        &self,
+        sql: &str,
+        params: Vec<FilterValue>,
+    ) -> BoxFuture<'_, QueryResult<T>> {
+        let recorded = self.recorded.clone();
+        let sql = sql.to_string();
+        Box::pin(async move {
+            recorded.lock().unwrap().push((sql, params));
+            T::from_row(&CannedRow).map_err(|e| QueryError::internal(e.to_string()))
+        })
+    }
+    fn query_optional<T: ModelTrait + FromRow + Send + 'static>(
+        &self,
+        _sql: &str,
+        _params: Vec<FilterValue>,
+    ) -> BoxFuture<'_, QueryResult<Option<T>>> {
+        Box::pin(async { Ok(None) })
+    }
+    fn execute_insert<T: ModelTrait + FromRow + Send + 'static>(
+        &self,
+        sql: &str,
+        params: Vec<FilterValue>,
+    ) -> BoxFuture<'_, QueryResult<T>> {
+        let recorded = self.recorded.clone();
+        let sql = sql.to_string();
+        Box::pin(async move {
+            recorded.lock().unwrap().push((sql, params));
+            T::from_row(&CannedRow).map_err(|e| QueryError::internal(e.to_string()))
+        })
+    }
+    fn execute_update<T: ModelTrait + FromRow + Send + 'static>(
+        &self,
+        sql: &str,
+        params: Vec<FilterValue>,
+    ) -> BoxFuture<'_, QueryResult<Vec<T>>> {
+        let recorded = self.recorded.clone();
+        let sql = sql.to_string();
+        Box::pin(async move {
+            recorded.lock().unwrap().push((sql, params));
+            Ok(Vec::new())
+        })
+    }
+    fn execute_delete(
+        &self,
+        _sql: &str,
+        _params: Vec<FilterValue>,
+    ) -> BoxFuture<'_, QueryResult<u64>> {
+        Box::pin(async { Ok(0) })
+    }
+    fn execute_raw(&self, sql: &str, params: Vec<FilterValue>) -> BoxFuture<'_, QueryResult<u64>> {
+        let recorded = self.recorded.clone();
+        let sql = sql.to_string();
+        Box::pin(async move {
+            recorded.lock().unwrap().push((sql, params));
+            Ok(1)
+        })
+    }
+    fn count(&self, _sql: &str, _params: Vec<FilterValue>) -> BoxFuture<'_, QueryResult<u64>> {
+        Box::pin(async { Ok(0) })
+    }
+}
+
+impl SupportsNestedWrites for RecordingEngine {}
+impl SupportsScalarSubqueryInSelect for RecordingEngine {}
+
+// Canned row — returns plausible defaults for all scalar types so that
+// `T::from_row(&CannedRow)` succeeds in `execute_insert` / `query_one`.
+struct CannedRow;
+
+impl RowRef for CannedRow {
+    fn get_i32(&self, _column: &str) -> Result<i32, RowError> {
+        Ok(1)
+    }
+    fn get_i32_opt(&self, _column: &str) -> Result<Option<i32>, RowError> {
+        Ok(Some(1))
+    }
+    fn get_i64(&self, _column: &str) -> Result<i64, RowError> {
+        Ok(0)
+    }
+    fn get_i64_opt(&self, _column: &str) -> Result<Option<i64>, RowError> {
+        Ok(None)
+    }
+    fn get_f64(&self, _column: &str) -> Result<f64, RowError> {
+        Ok(0.0)
+    }
+    fn get_f64_opt(&self, _column: &str) -> Result<Option<f64>, RowError> {
+        Ok(None)
+    }
+    fn get_bool(&self, _column: &str) -> Result<bool, RowError> {
+        Ok(false)
+    }
+    fn get_bool_opt(&self, _column: &str) -> Result<Option<bool>, RowError> {
+        Ok(None)
+    }
+    fn get_str(&self, _column: &str) -> Result<&str, RowError> {
+        Ok("canned")
+    }
+    fn get_str_opt(&self, _column: &str) -> Result<Option<&str>, RowError> {
+        Ok(Some("canned"))
+    }
+    fn get_bytes(&self, _column: &str) -> Result<&[u8], RowError> {
+        Ok(b"")
+    }
+    fn get_bytes_opt(&self, _column: &str) -> Result<Option<&[u8]>, RowError> {
+        Ok(None)
+    }
+}
+
+// ── Models ────────────────────────────────────────────────────────────────────
+
+/// Derive-style model used by all aggregate e2e tests.
+///
+/// No cross-model relations are declared, so the `relation_helpers`
+/// schema-path bug does not fire.
+#[derive(Model, Debug, Clone, Default)]
+#[prax(table = "users")]
+pub struct User {
+    #[prax(id, auto)]
+    pub id: i32,
+    #[prax(unique)]
+    pub email: String,
+    pub team_id: i32,
+    pub region: String,
+    pub active: bool,
+    pub views: i32,
+    pub score: i32,
+}
+
+client!(User);
+
+// ── Test 1: count! select — per-column COUNT emission ─────────────────────────
+
+/// `count! select: { _all: true, email: true }` (runtime equiv):
+/// emits `COUNT(*)` and `COUNT(email)` in SELECT.
+///
+/// Uses the runtime `count_column` / `count` builder methods because the
+/// `count!` select macro requires codegen-emitted `UserCountSelect` structs.
+#[test]
+fn count_select_emits_per_column_counts() {
+    let op: AggregateOperation<User, RecordingEngine> = AggregateOperation::new()
+        .count() // _all: true  → COUNT(*)
+        .count_column("email"); // email: true → COUNT(email)
+
+    let (sql, params) = op.build_sql(&prax_query::dialect::Postgres);
+
+    assert!(sql.contains("COUNT(*)"), "missing COUNT(*); got: {sql}");
+    assert!(
+        sql.contains("COUNT(email)"),
+        "missing COUNT(email); got: {sql}"
+    );
+    assert!(params.is_empty(), "no params expected; got: {params:?}");
+}
+
+// ── Test 2: aggregate! — all five functions ───────────────────────────────────
+
+/// `aggregate! { _sum: { views }, _avg: { score }, _min: { views },
+///               _max: { views }, _count: { _all } }` (runtime equiv):
+/// emits SUM, AVG, MIN, MAX, COUNT(*) in a single SELECT.
+#[test]
+fn aggregate_emits_all_five_functions() {
+    let op: AggregateOperation<User, RecordingEngine> = AggregateOperation::new()
+        .sum("views")
+        .avg("score")
+        .min("views")
+        .max("views")
+        .count();
+
+    let (sql, params) = op.build_sql(&prax_query::dialect::Postgres);
+
+    assert!(sql.contains("SUM(views)"), "missing SUM(views); got: {sql}");
+    assert!(sql.contains("AVG(score)"), "missing AVG(score); got: {sql}");
+    assert!(sql.contains("MIN(views)"), "missing MIN(views); got: {sql}");
+    assert!(sql.contains("MAX(views)"), "missing MAX(views); got: {sql}");
+    assert!(sql.contains("COUNT(*)"), "missing COUNT(*); got: {sql}");
+    assert!(params.is_empty(), "no params expected; got: {params:?}");
+}
+
+// ── Test 3: aggregate! where — WHERE clause filtering ────────────────────────
+
+/// `aggregate! { where: { active: true }, _count: { _all } }` (runtime equiv):
+/// emits a WHERE clause containing the `active` column and records the param.
+#[test]
+fn aggregate_where_filters_underlying_select() {
+    let op: AggregateOperation<User, RecordingEngine> = AggregateOperation::new()
+        .count()
+        .r#where(Filter::Equals("active".into(), FilterValue::Bool(true)));
+
+    let (sql, params) = op.build_sql(&prax_query::dialect::Postgres);
+
+    assert!(sql.contains("WHERE"), "missing WHERE clause; got: {sql}");
+    assert!(
+        sql.contains("active"),
+        "missing `active` column in WHERE; got: {sql}"
+    );
+    assert_eq!(params.len(), 1, "expected exactly 1 param; got: {params:?}");
+    assert_eq!(
+        params[0],
+        FilterValue::Bool(true),
+        "param should be Bool(true); got: {:?}",
+        params[0]
+    );
+}
+
+// ── Test 4: group_by! — GROUP BY clause ──────────────────────────────────────
+
+/// `group_by!(c.user, { by: [team_id, region], _count: { _all } })` (runtime equiv):
+/// emits `GROUP BY team_id, region` and `COUNT(*)` in SELECT.
+#[test]
+fn group_by_emits_group_by_clause() {
+    let op: GroupByOperation<User, RecordingEngine> =
+        GroupByOperation::new(vec!["team_id".into(), "region".into()]).count();
+
+    let (sql, params) = op.build_sql(&prax_query::dialect::Postgres);
+
+    assert!(
+        sql.contains("GROUP BY team_id, region"),
+        "missing GROUP BY clause; got: {sql}"
+    );
+    assert!(sql.contains("COUNT(*)"), "missing COUNT(*); got: {sql}");
+    assert!(params.is_empty(), "no params expected; got: {params:?}");
+}
+
+// ── Test 5: group_by! having — HAVING clause ─────────────────────────────────
+
+/// `group_by!(c.user, { by: [team_id], _count: { _all },
+///             having: { _count: { _all: { gt: 5 } } } })` (runtime equiv):
+/// emits `HAVING COUNT(*) > 5`.
+///
+/// Note: HAVING thresholds are inlined as float literals, not parameterized.
+#[test]
+fn group_by_having_emits_having_clause() {
+    let op: GroupByOperation<User, RecordingEngine> = GroupByOperation::new(vec!["team_id".into()])
+        .count()
+        .having(having::count_gt(5.0));
+
+    let (sql, _params) = op.build_sql(&prax_query::dialect::Postgres);
+
+    assert!(sql.contains("HAVING"), "missing HAVING clause; got: {sql}");
+    assert!(
+        sql.contains("COUNT(*) > 5"),
+        "missing `COUNT(*) > 5` in HAVING; got: {sql}"
+    );
+}
+
+// ── Test 6: aggregate! — omits unspecified blocks ────────────────────────────
+
+/// `aggregate! { _sum: { views } }` (runtime equiv):
+/// emits `SUM(views)` but NOT `AVG`, `MIN`, `MAX`, or `COUNT`.
+#[test]
+fn aggregate_omits_unspecified_blocks() {
+    let op: AggregateOperation<User, RecordingEngine> = AggregateOperation::new().sum("views");
+
+    let (sql, params) = op.build_sql(&prax_query::dialect::Postgres);
+
+    assert!(sql.contains("SUM(views)"), "missing SUM(views); got: {sql}");
+    assert!(!sql.contains("AVG"), "unexpected AVG in SQL; got: {sql}");
+    assert!(!sql.contains("MIN"), "unexpected MIN in SQL; got: {sql}");
+    assert!(!sql.contains("MAX"), "unexpected MAX in SQL; got: {sql}");
+    assert!(
+        !sql.contains("COUNT"),
+        "unexpected COUNT in SQL; got: {sql}"
+    );
+    assert!(params.is_empty(), "no params expected; got: {params:?}");
+}


### PR DESCRIPTION
Closes phase 6 of the typed-query-traits initiative. Spec: `docs/superpowers/specs/2026-05-23-aggregate-macros-design.md`. Plan: `docs/superpowers/plans/2026-05-23-aggregate-macros.md`.

## What ships

Three Prisma-style macros over the existing `AggregateOperation` / `GroupByOperation` runtime:

- **`count!` `select:` block** — per-column non-null counts. `count!(c.user, { select: { _all: true, email: true } })` → `<Model>CountSelectResult`. Without `select:`, unchanged (`i64`).
- **`aggregate!`** — `_sum`/`_avg`/`_min`/`_max`/`_count` blocks → per-model `<Model>AggregateResult` with substructs populated only when supplied. Requires ≥1 aggregate block.
- **`group_by!`** — `by:`, `where:`, the five aggregate blocks, `having:` → `Vec<<Model>GroupByResult>`.

## Codegen surface (per model)

`<Model>{Count,Sum,Avg,Min,Max}Select` inputs, matching `*Result` outputs, `<Model>AggregateResult`, `<Model>GroupByResult`, `<Model>GroupByColumn` enum, `<Model>AggregateArgs`/`<Model>GroupByArgs`, `aggregate()`/`group_by_columns()` accessors, `with_aggregate_args`/`with_group_by_args` extensions. Also expanded `HavingCondition` with the full `{count,sum,avg,min,max}_{gt,gte,lt,lte,eq,ne}` constructor set.

## Diagnostics (trybuild-locked)

`_sum`/`_avg` on non-numeric column, aggregate on relation/aggregate field, unknown column (did-you-mean), empty `by:`, unknown by-column, empty aggregate block, `aggregate!` with no blocks, unsupported `having` operator, `group_by!` `order_by:` (deferred).

## Known limitations (see CHANGELOG)

- Macros lower into schema-path-emitted Args structs; the schema-path `relation_helpers` bug (since phase 5b) blocks end-to-end macro use in test crates, so e2e + live-PG tests drive the runtime API. Macro front-end is covered by trybuild + codegen unit tests.
- `AggregateResult::from_row` doesn't yet hydrate per-column `_count_<col>` aliases (SQL emitted, typed read-back pending). `COUNT(*)` works.
- `having:` thresholds inlined as numeric literals (SQL-safe `f64`).

## Deferred follow-ups

MongoDB `$group`, CQL `GROUP BY`, `count_distinct` macro shape, multi-column `_min`/`_max`, `group_by!` `order_by:`, per-column count typed hydration.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features --no-fail-fast` (local + pre-push hook)
- [x] trybuild diagnostic fixtures
- [x] `tests/aggregate_macros_e2e.rs`
- [x] `prax-postgres/tests/aggregate_macros.rs` (`--ignored`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)