### PR TITLE
fix(codegen): resolve relation paths in prax_schema! model generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`prax_schema!` now compiles for schemas with relations.** The
+  schema-path model generator nests each model's struct inside
+  `pub mod <model>`, but its relation-referencing codegen emitted
+  paths calibrated for the flat `#[derive(Model)]` layout, producing
+  E0433 ("too many leading `super`") and a cascade (E0425/E0063/E0599/
+  E0277) on any relation. Fixed: relation field types are qualified
+  (`super::<target>::<Target>`), `FromRow` defaults relation fields,
+  `IncludeParam` variants are unit and module-correct, per-relation
+  field modules expose `include()` instead of invalid scalar
+  `select()`/filters, and relations are excluded from the legacy
+  `WhereParam`. This unblocks the macro DSL end-to-end against
+  schema-defined models with relations (previously every macro-DSL
+  e2e test had to fall back to derive-style models + `RecordingEngine`,
+  and the workspace fixture schema was kept relation-free).
+
 ### Added
 
 - **Aggregate macros (phase 6).** Three new macros over the existing

--- a/prax-codegen/src/generators/fields.rs
+++ b/prax-codegen/src/generators/fields.rs
@@ -94,9 +94,8 @@ pub fn generate_field_module(field: &Field, model: &Model) -> TokenStream {
     };
 
     // For relation fields, expose an `include()` helper returning the
-    // model's `IncludeParam` variant. List relations carry an optional
-    // boxed sub-query (`None` = include all); single relations are a unit
-    // variant.
+    // model's `IncludeParam` variant (a unit variant for both list and
+    // single relations — nested-include sub-queries are not yet wired).
     let include_fn = if is_relation {
         quote! {
             /// Include this relation in the query.

--- a/prax-codegen/src/generators/fields.rs
+++ b/prax-codegen/src/generators/fields.rs
@@ -73,8 +73,40 @@ pub fn generate_field_module(field: &Field, model: &Model) -> TokenStream {
     // `pub mod` never compiled when a numeric field was present. Re-add once
     // the Client exposes a proper `.increment()/.decrement()` update op.
 
-    // Generate filter operations
-    let filters = super::filters::generate_field_filters(field, model.name());
+    // Scalar-only members. Relation fields have no `SelectParam` variant
+    // and no scalar `WhereOp` filters — they are read via the model's
+    // `IncludeParam` (the `include()` helper below), not selected or
+    // filtered as columns. Emitting the scalar plumbing for a relation
+    // references `SelectParam::<Rel>` / `WhereParam::<Rel>` variants and a
+    // `WhereOp::Equals(<RelatedModel>)` value that don't (and shouldn't)
+    // exist.
+    let (select_fn, filters) = if is_relation {
+        (TokenStream::new(), TokenStream::new())
+    } else {
+        let select_fn = quote! {
+            /// Select this field.
+            pub fn select() -> super::SelectParam {
+                super::SelectParam::#field_name_pascal
+            }
+        };
+        let filters = super::filters::generate_field_filters(field, model.name());
+        (select_fn, filters)
+    };
+
+    // For relation fields, expose an `include()` helper returning the
+    // model's `IncludeParam` variant. List relations carry an optional
+    // boxed sub-query (`None` = include all); single relations are a unit
+    // variant.
+    let include_fn = if is_relation {
+        quote! {
+            /// Include this relation in the query.
+            pub fn include() -> super::IncludeParam {
+                super::IncludeParam::#field_name_pascal
+            }
+        }
+    } else {
+        TokenStream::new()
+    };
 
     quote! {
         #doc
@@ -88,11 +120,8 @@ pub fn generate_field_module(field: &Field, model: &Model) -> TokenStream {
             /// Whether this field is a list.
             pub const IS_LIST: bool = #is_list;
 
-            /// Select this field.
-            pub fn select() -> super::SelectParam {
-                super::SelectParam::#field_name_pascal
-            }
-
+            #select_fn
+            #include_fn
             #order_by
             #set_ops
 

--- a/prax-codegen/src/generators/model.rs
+++ b/prax-codegen/src/generators/model.rs
@@ -365,7 +365,11 @@ pub fn generate_model_module_with_style(
             // Scalar/enum fields use the plain rendering.
             let field_type = match &field.field_type {
                 FieldType::Model(target) => {
-                    let target_type = format_ident!("{}", target.to_string());
+                    // Must match how the target model's struct ident and module
+                    // are formed: `pascal_ident(model.name())` for the struct,
+                    // `snake_ident(...)` for the module. Using the raw target
+                    // string here would desync for non-PascalCase model names.
+                    let target_type = pascal_ident(target.as_str());
                     let target_mod = snake_ident(target.as_str());
                     let base = quote! { super::#target_mod::#target_type };
                     crate::types::apply_modifier(base, &field.modifier)

--- a/prax-codegen/src/generators/model.rs
+++ b/prax-codegen/src/generators/model.rs
@@ -359,7 +359,19 @@ pub fn generate_model_module_with_style(
         .values()
         .map(|field| {
             let field_name = snake_ident(field.name());
-            let field_type = field_type_to_rust(&field.field_type, &field.modifier);
+            // Relation fields reference a sibling model whose struct lives in
+            // its own `mod <target_snake>` at crate root. From inside this
+            // model's module the path is `super::<target_snake>::<Target>`.
+            // Scalar/enum fields use the plain rendering.
+            let field_type = match &field.field_type {
+                FieldType::Model(target) => {
+                    let target_type = format_ident!("{}", target.to_string());
+                    let target_mod = snake_ident(target.as_str());
+                    let base = quote! { super::#target_mod::#target_type };
+                    crate::types::apply_modifier(base, &field.modifier)
+                }
+                _ => field_type_to_rust(&field.field_type, &field.modifier),
+            };
             let field_doc =
                 generate_doc_comment(field.documentation.as_ref().map(|d| d.text.as_str()));
 
@@ -491,13 +503,23 @@ pub fn generate_model_module_with_style(
         &[],
         &[],
     );
-    // The prax_schema! path filters `FieldType::Model(_)` relation
-    // fields out of `from_row_fields` above; pass an empty slice for
-    // relation defaults to keep the `FromRow` shape unchanged.
+    // Relation fields (`FieldType::Model`) are filtered out of
+    // `from_row_fields` (no column to read), but they ARE fields on the
+    // generated struct, so `FromRow` must default them (empty Vec for
+    // list relations, None for optional single relations) — the relation
+    // executor fills them on the `.include()` path. Mirrors the derive
+    // path's `relation_fields` handling.
+    let relation_field_idents: Vec<syn::Ident> = model
+        .fields
+        .values()
+        .filter(|f| matches!(f.field_type, FieldType::Model(_)))
+        .map(|f| snake_ident(f.name()))
+        .collect();
     // The prax_schema! path does not yet interpret aggregate directives
-    // from the .prax AST (Task 11 wires the derive path; schema path follows).
+    // from the .prax AST (the derive path wires them; schema path follows).
     // Pass an empty slice so aggregate fields default to the zero-state.
-    let from_row_impl = super::derive_from_row::emit(&model_name, &from_row_fields, &[], &[]);
+    let from_row_impl =
+        super::derive_from_row::emit(&model_name, &from_row_fields, &relation_field_idents, &[]);
     let model_with_pk_impl = super::derive_model_with_pk::emit(&model_name, &model_with_pk_fields);
     let client_impl = super::derive_client::emit(quote! { #model_name });
 
@@ -715,9 +737,18 @@ fn get_primary_key_fields(model: &Model) -> Vec<String> {
 
 /// Generate the WhereParam enum for a model.
 fn generate_where_param(model: &Model) -> TokenStream {
-    let variants: Vec<_> = model
-        .fields
-        .values()
+    // Relation fields have no scalar `WhereOp` / `COLUMN` in their field
+    // module (they are filtered, not column-compared), so exclude them from
+    // the legacy `WhereParam` enum — same decision as `collect_where_fields`
+    // and the derive path.
+    let scalar_fields = || {
+        model
+            .fields
+            .values()
+            .filter(|f| !matches!(f.field_type, FieldType::Model(_)))
+    };
+
+    let variants: Vec<_> = scalar_fields()
         .map(|field| {
             let name = pascal_ident(field.name());
             let field_mod = snake_ident(field.name());
@@ -725,9 +756,7 @@ fn generate_where_param(model: &Model) -> TokenStream {
         })
         .collect();
 
-    let to_sql_matches: Vec<_> = model
-        .fields
-        .values()
+    let to_sql_matches: Vec<_> = scalar_fields()
         .map(|field| {
             let name = pascal_ident(field.name());
             let field_mod = snake_ident(field.name());
@@ -735,9 +764,7 @@ fn generate_where_param(model: &Model) -> TokenStream {
         })
         .collect();
 
-    let from_filter_arms: Vec<_> = model
-        .fields
-        .values()
+    let from_filter_arms: Vec<_> = scalar_fields()
         .map(|field| {
             let name = pascal_ident(field.name());
             quote! { WhereParam::#name(op) => op.to_filter(), }
@@ -1153,16 +1180,16 @@ fn generate_relation_helpers(model: &Model, _schema: &Schema) -> TokenStream {
         return TokenStream::new();
     }
 
+    // Each relation is a unit variant. A nested-include sub-query payload
+    // (`Option<Box<Target::Query>>`) is intentionally omitted: it was never
+    // wired to the executor and forced `IncludeParam`'s derived `Clone`/`Debug`
+    // to require the legacy `Query` builder to be `Clone`/`Debug`. Re-add a
+    // typed payload when nested includes are actually implemented.
     let include_variants: Vec<_> = relation_fields
         .iter()
         .map(|f| {
             let name = pascal_ident(f.name());
-            let is_list = f.modifier.is_list();
-            if is_list {
-                quote! { #name(Option<Box<super::super::#name::Query>>) }
-            } else {
-                quote! { #name }
-            }
+            quote! { #name }
         })
         .collect();
 

--- a/tests/fixtures/relations.prax
+++ b/tests/fixtures/relations.prax
@@ -1,0 +1,16 @@
+// Regression fixture for the schema-path relation_helpers bug.
+// Two models with a bidirectional relation; prax_schema! must emit
+// resolvable cross-model module paths (crate::<model>::<Model>).
+
+model Author {
+    id    Int    @id @auto
+    name  String
+    posts Post[] @relation(fields: [id], references: [author_id])
+}
+
+model Post {
+    id        Int    @id @auto
+    title     String
+    author_id Int
+    author    Author? @relation(fields: [author_id], references: [id])
+}

--- a/tests/nested_writes_e2e.rs
+++ b/tests/nested_writes_e2e.rs
@@ -16,9 +16,11 @@
 //!
 //! `create!` macro coverage of nested writes is covered by the
 //! lowering unit tests in
-//! `prax-codegen/src/macros/lower/data_relation.rs`; the schema-aware
-//! macro path will be exercised end-to-end once the schema-path
-//! relation_helpers bug is fixed (deferred).
+//! `prax-codegen/src/macros/lower/data_relation.rs`. The schema-path
+//! `relation_helpers` bug that previously forced these derive-style
+//! mocks is now fixed (regression test: `tests/schema_macro_relations.rs`).
+//! Migrating these nested-write e2e tests onto the schema-path macro DSL
+//! is a separate follow-up.
 
 #![allow(dead_code)]
 

--- a/tests/schema_macro_relations.rs
+++ b/tests/schema_macro_relations.rs
@@ -1,0 +1,55 @@
+//! Regression test for the schema-path relation_helpers bug: `prax_schema!`
+//! over a schema containing relations must emit cross-model module paths
+//! that resolve (`crate::<model>::<Model>`), populate relation fields via
+//! FromRow defaults, and expose Include/Select relation variants.
+//!
+//! Before the fix this file failed to compile (E0433 "too many leading
+//! super", E0425 unresolved `Post`/`Author`, E0063 missing relation field
+//! in initializer, E0599 missing Select variant, E0277 FilterValue::From).
+
+prax_orm::prax_schema!("tests/fixtures/relations.prax");
+
+#[test]
+fn relation_models_compile_and_default_relation_fields() {
+    // List relation (`posts: Vec<Post>`) defaults empty; the cross-model
+    // type `Post` must resolve from inside `mod author`.
+    let a = author::Author {
+        id: 1,
+        name: "Ada".into(),
+        posts: Vec::new(),
+    };
+    assert_eq!(a.posts.len(), 0);
+
+    // Optional single relation (`author: Option<Author>`) defaults to None.
+    let p = post::Post {
+        id: 1,
+        title: "t".into(),
+        author_id: 1,
+        author: None,
+    };
+    assert!(p.author.is_none());
+}
+
+#[test]
+fn relation_include_helper_resolves_to_include_param() {
+    // The relation field module exposes `include()` returning the model's
+    // IncludeParam variant (relations are included, not selected/filtered
+    // as scalar columns).
+    assert!(matches!(
+        author::posts::include(),
+        author::IncludeParam::Posts
+    ));
+    assert!(matches!(
+        post::author::include(),
+        post::IncludeParam::Author
+    ));
+}
+
+#[test]
+fn scalar_filter_helpers_still_work_alongside_relations() {
+    // A model that has relation fields must still generate working scalar
+    // WhereParam filters for its columns.
+    let w = author::name::equals("Ada".to_string());
+    assert!(matches!(w, author::WhereParam::Name(_)));
+    assert_eq!(author::name::COLUMN, "name");
+}


### PR DESCRIPTION
## Root cause

The `prax_schema!` macro generates a module tree where each model's struct lives **inside** its own module — `crate::author::Author`, `crate::post::Post` — with relation fields getting a nested submodule (`mod author::posts`). But the relation-referencing codegen emitted paths calibrated for the flat `#[derive(Model)]` layout (structs at crate root, modules as flat siblings). On **any** schema with a relation this produced `E0433` ("too many leading `super`") plus a cascade of `E0425` / `E0063` / `E0599` / `E0277`.

This is why the workspace fixture schema was deliberately kept relation-free and every macro-DSL e2e test fell back to derive-style models + `RecordingEngine`.

## Fixes (all in the `prax_schema!` generator)

- **Relation struct field types** are now qualified: `super::<target_mod>::<Target>` (via `pascal_ident`, matching how the target struct ident is formed) instead of a bare, unresolvable `<Target>`.
- **FromRow** now defaults relation fields (empty `Vec` / `None`) by threading the relation idents into `derive_from_row::emit` — mirrors the derive path; fixes the "missing field in initializer" `E0063`.
- **`IncludeParam`** relation variants are unit variants pointing at the correct module; dropped the never-wired `Option<Box<Target::Query>>` payload that overflowed `super` and forced `Query: Clone`/`Debug`.
- **Per-relation field module** no longer emits scalar `select()` / `WhereOp` filters (which referenced nonexistent `SelectParam`/`WhereParam` relation variants and treated a whole related struct as a `FilterValue`); it now exposes an `include()` helper returning the model's `IncludeParam`.
- **Legacy `WhereParam`** enum excludes relation fields (no scalar `WhereOp`/`COLUMN` exists for them), matching `collect_where_fields` and the derive path.

## Verification

- New regression test `tests/schema_macro_relations.rs` + fixture `tests/fixtures/relations.prax`: `prax_schema!`s a bidirectional relation and asserts compilation, FromRow relation defaults, the `include()` helper resolving to `IncludeParam`, and that scalar filters on a relation-bearing model still work.
- No change to the relation-free path: `prax-codegen` lib (289) + `schema_macro` / read / write / shape e2e suites stay green.
- `/simplify` review of the diff caught one real bug (raw target string vs `pascal_ident`) — fixed in this branch.

## Follow-up (out of scope)

- Migrating the existing nested-write e2e tests onto the schema-path macro DSL (now unblocked).
- Typed `<Model>CountSelectResult` hydration from `AggregateResult` (was gated on this fix).
- Relation field modules still emit an unreferenced `COLUMN` const; required single-relation fields rely on `Default` (shared with the derive path — declare such relations as `T?`/`T[]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)