### PR TITLE
fix(codegen): harden prax_schema! relation generation (PR #116 review)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   schema-defined models with relations (previously every macro-DSL
   e2e test had to fall back to derive-style models + `RecordingEngine`,
   and the workspace fixture schema was kept relation-free).
+- **`prax_schema!` relation follow-up hardening.** Code-review fixes
+  on top of the above: single relations now generate
+  `Option<Box<Target>>` (was `Option<Target>`) so required relations
+  default cleanly via `FromRow` and self-/mutually-recursive relations
+  stay finitely sized (previously E0072/E0391); each schema-path model
+  emits a `ModelRelationLoader<E>` impl so `.exec()` compiles (the bound
+  is required unconditionally — without it the macro DSL could not
+  execute at all), with includes erroring loudly until functional
+  relation loading lands; relation field modules expose `fetch()`
+  returning an `IncludeSpec` (aligning with the derive path) instead of
+  an `include()` returning the divergent `IncludeParam`, and no longer
+  emit misleading `COLUMN`/`IS_OPTIONAL`/`IS_LIST` consts; the
+  `IncludeParam` default sentinel was renamed `__None` to avoid
+  colliding with a relation field named `none`; and a self-relation
+  whose field name collides with the model's own module name is now
+  rejected with a clear diagnostic. New fixtures cover a multi-word
+  model name (`BlogPost`) and a self-relation (`Category`).
 
 ### Added
 

--- a/prax-codegen/src/generators/fields.rs
+++ b/prax-codegen/src/generators/fields.rs
@@ -93,23 +93,32 @@ pub fn generate_field_module(field: &Field, model: &Model) -> TokenStream {
         (select_fn, filters)
     };
 
-    // For relation fields, expose an `include()` helper returning the
-    // model's `IncludeParam` variant (a unit variant for both list and
-    // single relations — nested-include sub-queries are not yet wired).
-    let include_fn = if is_relation {
+    // For relation fields, expose a `fetch()` helper returning an
+    // `IncludeSpec` keyed by the relation's field name. This mirrors the
+    // derive path's `relation_accessors::emit` output so the two codegen
+    // paths share the same include API. The prior `include()` -> `IncludeParam`
+    // helper was divergent from the derive path and exposed a type that
+    // carries no relation metadata useful to the executor.
+    let fetch_fn = if is_relation {
+        let field_name_str = field.name();
         quote! {
-            /// Include this relation in the query.
-            pub fn include() -> super::IncludeParam {
-                super::IncludeParam::#field_name_pascal
+            /// Build an [`::prax_query::relations::IncludeSpec`] for this
+            /// relation. Used as `include(author::posts::fetch())`.
+            pub fn fetch() -> ::prax_query::relations::IncludeSpec {
+                ::prax_query::relations::IncludeSpec::new(#field_name_str)
             }
         }
     } else {
         TokenStream::new()
     };
 
-    quote! {
-        #doc
-        pub mod #field_name {
+    // COLUMN / IS_OPTIONAL / IS_LIST are meaningful only for scalar fields.
+    // Emitting them for relation fields is misleading: COLUMN would hold the
+    // field name (e.g. "posts"), which is not a real database column. Gate
+    // them behind `!is_relation` so relation field modules contain only the
+    // fetch() helper (and nothing that implies a backing column).
+    let scalar_consts = if !is_relation {
+        quote! {
             /// Database column name.
             pub const COLUMN: &str = #col_name;
 
@@ -118,9 +127,18 @@ pub fn generate_field_module(field: &Field, model: &Model) -> TokenStream {
 
             /// Whether this field is a list.
             pub const IS_LIST: bool = #is_list;
+        }
+    } else {
+        TokenStream::new()
+    };
+
+    quote! {
+        #doc
+        pub mod #field_name {
+            #scalar_consts
 
             #select_fn
-            #include_fn
+            #fetch_fn
             #order_by
             #set_ops
 

--- a/prax-codegen/src/generators/model.rs
+++ b/prax-codegen/src/generators/model.rs
@@ -372,7 +372,28 @@ pub fn generate_model_module_with_style(
                     let target_type = pascal_ident(target.as_str());
                     let target_mod = snake_ident(target.as_str());
                     let base = quote! { super::#target_mod::#target_type };
-                    crate::types::apply_modifier(base, &field.modifier)
+                    // Relation fields are never populated from the database
+                    // row — the relation executor fills them after the main
+                    // query via the ModelRelationLoader impl. At construction
+                    // time (FromRow::from_row) they are initialized to
+                    // Default::default(), so they must be Default-constructible.
+                    //
+                    // List relations are `Vec<Target>` (empty default). Single
+                    // relations are `Option<Box<Target>>`, not `Option<Target>`,
+                    // for two reasons:
+                    //   1. A Required modifier would otherwise produce a bare
+                    //      `Target`, which is not Default (E0277).
+                    //   2. A self- or mutually-recursive single relation (e.g.
+                    //      `model Category { parent Category? }`) embedded by
+                    //      value is an infinitely-sized type (E0072/E0391). The
+                    //      `Box` provides the indirection that breaks the cycle;
+                    //      `Vec` already does this for list relations.
+                    // `None` is still the default and a valid initializer.
+                    if field.modifier.is_list() {
+                        quote! { Vec<#base> }
+                    } else {
+                        quote! { Option<Box<#base>> }
+                    }
                 }
                 _ => field_type_to_rust(&field.field_type, &field.modifier),
             };
@@ -435,7 +456,27 @@ pub fn generate_model_module_with_style(
         })
         .collect();
 
-    // Generate field modules
+    // Generate field modules. Guard against self-relation name collisions
+    // before doing anything else: a relation field whose snake name equals
+    // the model's own module name (e.g. `model Node { node Node? }`) would
+    // emit `pub mod node` inside `pub mod node`, making `super::node::Node`
+    // resolve into the inner field module instead of the sibling model module
+    // (E0433). Reject such schemas with a clear diagnostic.
+    for field in model.fields.values() {
+        if matches!(field.field_type, FieldType::Model(_))
+            && snake_ident(field.name()) == module_name
+        {
+            return Err(syn::Error::new(
+                proc_macro2::Span::call_site(),
+                format!(
+                    "relation field `{}` collides with model `{}`'s own module name; \
+                     rename the field to resolve the ambiguity",
+                    field.name(),
+                    model.name()
+                ),
+            ));
+        }
+    }
     let field_modules: Vec<_> = model
         .fields
         .values()
@@ -620,6 +661,22 @@ pub fn generate_model_module_with_style(
     let count_struct_tokens =
         super::count_struct::emit_count_struct(&model_name, &count_struct_outgoing);
 
+    // Emit a `ModelRelationLoader<E>` impl so schema-path models satisfy the
+    // bound `FindManyOperation::exec` requires unconditionally — without it,
+    // calling `.exec()` on any schema-path model is a compile error (E0277),
+    // making the macro DSL unusable for actual query execution.
+    //
+    // We emit the empty-`rels` stub: it errors at runtime on any relation name.
+    // A functional loader would need per-relation `Relation` marker types
+    // (with FK metadata) emitted into each relation field module — mirroring
+    // the derive path's `relation_accessors::emit`. That is a larger feature
+    // (relation loading on the schema path) and is tracked as a follow-up;
+    // until then `include()` on a schema-path model fails loudly with
+    // "unknown relation" rather than silently or at compile time. The impl is
+    // emitted inside the model module so `for #model_name` binds the local
+    // struct (the schema path nests the struct in `pub mod #module_name`).
+    let relation_loader_impl = super::derive_relation_loader::emit(&model_name, &[]);
+
     Ok(quote! {
         #doc
         pub mod #module_name {
@@ -672,6 +729,10 @@ pub fn generate_model_module_with_style(
             #from_row_impl
             #model_with_pk_impl
             #client_impl
+
+            // Stub ModelRelationLoader<E> — see rationale above. Restores
+            // `.exec()` on schema-path models; errors on any relation include.
+            #relation_loader_impl
 
             // Query/Actions pre-compiled-SQL builders (legacy, being replaced by Client<E>).
             #query_builder
@@ -1199,10 +1260,14 @@ fn generate_relation_helpers(model: &Model, _schema: &Schema) -> TokenStream {
 
     quote! {
         /// Include related records in the query.
+        ///
+        /// The `__None` sentinel (not `None`) is used as the `#[default]`
+        /// variant so that a relation field named `none` does not produce a
+        /// duplicate `None` variant, which would be a compile error.
         #[derive(Debug, Clone, Default)]
         pub enum IncludeParam {
             #[default]
-            None,
+            __None,
             #(#include_variants,)*
         }
     }

--- a/tests/fixtures/relations.prax
+++ b/tests/fixtures/relations.prax
@@ -14,3 +14,24 @@ model Post {
     author_id Int
     author    Author? @relation(fields: [author_id], references: [id])
 }
+
+// Multi-word model name: exercises snake_case module naming (`blog_post`)
+// and PascalCase struct/path resolution (`super::author::Author`).
+model BlogPost {
+    id        Int     @id @auto
+    title     String
+    author_id Int
+    author    Author? @relation(fields: [author_id], references: [id])
+}
+
+// Self-relation: the relation target is the model itself. The field names
+// (`parent`, `children`) deliberately differ from the model's own module
+// name (`category`) so the self-relation collision guard does not fire —
+// `super::category::Category` must resolve back to this model.
+model Category {
+    id        Int        @id @auto
+    name      String
+    parent_id Int
+    parent    Category?  @relation(fields: [parent_id], references: [id])
+    children  Category[] @relation(fields: [id], references: [parent_id])
+}

--- a/tests/schema_macro_relations.rs
+++ b/tests/schema_macro_relations.rs
@@ -1,7 +1,7 @@
 //! Regression test for the schema-path relation_helpers bug: `prax_schema!`
 //! over a schema containing relations must emit cross-model module paths
 //! that resolve (`crate::<model>::<Model>`), populate relation fields via
-//! FromRow defaults, and expose Include/Select relation variants.
+//! FromRow defaults, and expose fetch()/select relation helpers.
 //!
 //! Before the fix this file failed to compile (E0433 "too many leading
 //! super", E0425 unresolved `Post`/`Author`, E0063 missing relation field
@@ -20,7 +20,10 @@ fn relation_models_compile_and_default_relation_fields() {
     };
     assert_eq!(a.posts.len(), 0);
 
-    // Optional single relation (`author: Option<Author>`) defaults to None.
+    // Single relation (`author: Option<Box<Author>>`) — always optional and
+    // boxed regardless of the schema modifier, so FromRow's Default (None)
+    // holds even when the schema declares the relation as required, and
+    // self-recursive relations stay finitely sized.
     let p = post::Post {
         id: 1,
         title: "t".into(),
@@ -31,18 +34,17 @@ fn relation_models_compile_and_default_relation_fields() {
 }
 
 #[test]
-fn relation_include_helper_resolves_to_include_param() {
-    // The relation field module exposes `include()` returning the model's
-    // IncludeParam variant (relations are included, not selected/filtered
-    // as scalar columns).
-    assert!(matches!(
-        author::posts::include(),
-        author::IncludeParam::Posts
-    ));
-    assert!(matches!(
-        post::author::include(),
-        post::IncludeParam::Author
-    ));
+fn relation_fetch_helper_returns_include_spec() {
+    // The schema path's relation field module exposes `fetch()` returning
+    // an `IncludeSpec` keyed by the field name — mirroring the derive
+    // path's `relation_accessors::emit` output so both codegen paths share
+    // the same include API (fetch() -> IncludeSpec, not include() ->
+    // IncludeParam).
+    let spec = author::posts::fetch();
+    assert_eq!(spec.relation_name, "posts");
+
+    let spec2 = post::author::fetch();
+    assert_eq!(spec2.relation_name, "author");
 }
 
 #[test]
@@ -52,4 +54,150 @@ fn scalar_filter_helpers_still_work_alongside_relations() {
     let w = author::name::equals("Ada".to_string());
     assert!(matches!(w, author::WhereParam::Name(_)));
     assert_eq!(author::name::COLUMN, "name");
+}
+
+#[test]
+fn multi_word_model_name_resolves_relation_paths() {
+    // `BlogPost` -> module `blog_post`, struct `BlogPost`. The single
+    // relation `author Author?` must resolve `super::author::Author` from
+    // inside the snake_cased module and default to None via FromRow.
+    let bp = blog_post::BlogPost {
+        id: 1,
+        title: "t".into(),
+        author_id: 1,
+        author: None,
+    };
+    assert!(bp.author.is_none());
+    let spec = blog_post::author::fetch();
+    assert_eq!(spec.relation_name, "author");
+}
+
+#[test]
+fn self_relation_resolves_to_own_module() {
+    // `Category { parent Category?, children Category[] }` — the relation
+    // target is the model itself. `super::category::Category` must resolve
+    // back to this model; the field names differ from the module name so the
+    // collision guard does not fire.
+    let c = category::Category {
+        id: 2,
+        name: "rust".into(),
+        parent_id: 1,
+        parent: None,
+        children: Vec::new(),
+    };
+    assert!(c.parent.is_none());
+    assert_eq!(c.children.len(), 0);
+    assert_eq!(category::parent::fetch().relation_name, "parent");
+    assert_eq!(category::children::fetch().relation_name, "children");
+}
+
+// --- ModelRelationLoader bound (relation execution) ------------------------
+//
+// `FindManyOperation::exec` requires `M: ModelRelationLoader<E>`
+// unconditionally. The schema path must emit this impl or `.exec()` on any
+// schema-path model is a compile error (E0277). This asserts the bound is
+// satisfied for a schema-path model; it does not exercise the (deferred)
+// functional relation loading — the stub impl errors at runtime on includes.
+
+use prax_query::error::QueryError;
+use prax_query::filter::FilterValue;
+use prax_query::row::FromRow;
+use prax_query::traits::{BoxFuture, Model as ModelTrait, ModelRelationLoader, QueryEngine};
+
+#[derive(Clone)]
+struct MockEngine;
+
+impl QueryEngine for MockEngine {
+    fn dialect(&self) -> &dyn prax_query::dialect::SqlDialect {
+        &prax_query::dialect::Postgres
+    }
+    fn query_many<T: ModelTrait + FromRow + Send + 'static>(
+        &self,
+        _sql: &str,
+        _params: Vec<FilterValue>,
+    ) -> BoxFuture<'_, prax_query::error::QueryResult<Vec<T>>> {
+        Box::pin(async { Ok(Vec::new()) })
+    }
+    fn query_one<T: ModelTrait + FromRow + Send + 'static>(
+        &self,
+        _sql: &str,
+        _params: Vec<FilterValue>,
+    ) -> BoxFuture<'_, prax_query::error::QueryResult<T>> {
+        Box::pin(async { Err(QueryError::not_found("test")) })
+    }
+    fn query_optional<T: ModelTrait + FromRow + Send + 'static>(
+        &self,
+        _sql: &str,
+        _params: Vec<FilterValue>,
+    ) -> BoxFuture<'_, prax_query::error::QueryResult<Option<T>>> {
+        Box::pin(async { Ok(None) })
+    }
+    fn execute_insert<T: ModelTrait + FromRow + Send + 'static>(
+        &self,
+        _sql: &str,
+        _params: Vec<FilterValue>,
+    ) -> BoxFuture<'_, prax_query::error::QueryResult<T>> {
+        Box::pin(async { Err(QueryError::not_found("test")) })
+    }
+    fn execute_update<T: ModelTrait + FromRow + Send + 'static>(
+        &self,
+        _sql: &str,
+        _params: Vec<FilterValue>,
+    ) -> BoxFuture<'_, prax_query::error::QueryResult<Vec<T>>> {
+        Box::pin(async { Ok(Vec::new()) })
+    }
+    fn execute_delete(
+        &self,
+        _sql: &str,
+        _params: Vec<FilterValue>,
+    ) -> BoxFuture<'_, prax_query::error::QueryResult<u64>> {
+        Box::pin(async { Ok(0) })
+    }
+    fn execute_raw(
+        &self,
+        _sql: &str,
+        _params: Vec<FilterValue>,
+    ) -> BoxFuture<'_, prax_query::error::QueryResult<u64>> {
+        Box::pin(async { Ok(0) })
+    }
+    fn count(
+        &self,
+        _sql: &str,
+        _params: Vec<FilterValue>,
+    ) -> BoxFuture<'_, prax_query::error::QueryResult<u64>> {
+        Box::pin(async { Ok(0) })
+    }
+}
+
+fn assert_loader<E: QueryEngine, M: ModelRelationLoader<E>>() {}
+
+#[test]
+fn schema_path_models_implement_relation_loader() {
+    // Compile-time proof the bound `exec` requires is satisfied for every
+    // schema-path model (including those with no relations resolvable yet).
+    assert_loader::<MockEngine, author::Author>();
+    assert_loader::<MockEngine, post::Post>();
+    assert_loader::<MockEngine, blog_post::BlogPost>();
+    assert_loader::<MockEngine, category::Category>();
+}
+
+#[tokio::test]
+async fn schema_path_include_errors_loudly_until_relation_loading_lands() {
+    // The stub loader errors on any relation name rather than silently
+    // no-op'ing. This pins the documented behavior: includes on schema-path
+    // models are rejected at runtime until functional relation loading lands.
+    let mut parents = vec![author::Author {
+        id: 1,
+        name: "Ada".into(),
+        posts: Vec::new(),
+    }];
+    let spec = author::posts::fetch();
+    let err = <author::Author as ModelRelationLoader<MockEngine>>::load_relation(
+        &MockEngine,
+        &mut parents,
+        &spec,
+    )
+    .await
+    .unwrap_err();
+    assert!(err.to_string().contains("unknown relation"));
 }


### PR DESCRIPTION
Follow-up to #116 applying the actionable findings from its code review (High + Medium).

## Fixes

**High**
- **Required single relations no longer fail to compile.** Single relations now generate `Option<Box<Target>>` (was `Option<Target>`). Required relations default cleanly via `FromRow` (`None`), and self-/mutually-recursive relations stay finitely sized — `model Category { parent Category? }` previously produced `E0072`/`E0391` infinite-layout errors. `Box` supplies the indirection that `Vec` already provides for list relations.
- **Schema-path models are now executable.** `FindManyOperation::exec` requires `M: ModelRelationLoader<E>` unconditionally; the schema path never emitted it, so `.exec()` on any schema-path model was a compile error (`E0277`) — the macro DSL could not execute at all. Each model now emits the impl. It is the empty-`rels` stub (errors loudly on any relation name); a functional loader needs per-relation marker types with FK metadata and is deferred to a follow-up.

**Medium**
- Relation field modules expose `fetch() -> IncludeSpec`, aligning the schema path with the derive path's include API (was `include() -> IncludeParam`).
- Relation field modules no longer emit `COLUMN`/`IS_OPTIONAL`/`IS_LIST` consts (a relation field has no backing column).
- `IncludeParam`'s default sentinel renamed `None` -> `__None` to avoid collision with a relation field named `none`.
- A self-relation whose field name collides with the model's own module name is rejected with a clear diagnostic.

## Tests
New fixtures cover a multi-word model name (`BlogPost`) and a self-relation (`Category`). Tests assert the `ModelRelationLoader` bound is satisfied for every schema-path model and that includes error loudly until functional relation loading lands. `schema_macro_relations` is 7/7 green; full pre-push suite passes.

## Deferred
Functional relation loading on the schema path (emit per-relation `Relation` marker types + FK metadata so `load_has_many` can run) — tracked as the next roadmap item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)